### PR TITLE
Modify RandomNumberGeneratorService to new style for CRAB jobs.

### DIFF
--- a/CMGTools/Common/python/PAT/PATCMG_cff.py
+++ b/CMGTools/Common/python/PAT/PATCMG_cff.py
@@ -11,12 +11,11 @@ from CMGTools.Common.analysis_cff import *
 
 
 # SERVICES         ---------------------------
-RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService",
-        sourceSeed = cms.untracked.uint32(414000),
-        moduleSeeds = cms.PSet(
-            patElectronsWithCalibrations = cms.untracked.uint32(1041963),
-            )
-        )
+process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService",
+    patElectronsWithCalibrations = cms.PSet(
+        initialSeed = cms.untracked.uint32( 1041963)
+    )
+)
 
 # GEN              ---------------------------
 

--- a/CMGTools/Common/python/PAT/PATCMG_cff.py
+++ b/CMGTools/Common/python/PAT/PATCMG_cff.py
@@ -11,7 +11,7 @@ from CMGTools.Common.analysis_cff import *
 
 
 # SERVICES         ---------------------------
-process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService",
+RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService",
     patElectronsWithCalibrations = cms.PSet(
         initialSeed = cms.untracked.uint32( 1041963)
     )


### PR DESCRIPTION
RNG serivce was changed from CMSSW_6_2_X.

Although we only use CMSSW_5_X, CRAB refuse this old style.
