### PR TITLE
Implement lepton IDs (at least the POG ones) in the C++

### DIFF
--- a/AnalysisDataFormats/CMGTools/BuildFile.xml
+++ b/AnalysisDataFormats/CMGTools/BuildFile.xml
@@ -4,6 +4,7 @@
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/FWLite"/>
 <use name="PhysicsTools/SelectorUtils"/>
+<use name="EgammaAnalysis/ElectronTools"/>
 
 <use name="rootrflx"/>
 

--- a/AnalysisDataFormats/CMGTools/interface/Electron.h
+++ b/AnalysisDataFormats/CMGTools/interface/Electron.h
@@ -110,7 +110,29 @@ class Electron : public cmg::Lepton<pat::ElectronPtr>{
     reco::isodeposit::AbsVetos neutralHadronVetos() const;
     /// photon vetoes
     reco::isodeposit::AbsVetos photonVetos() const;
-    
+
+    /// The POG_xx_ID_yy are only the ID part, not including isolation, impact parameter and conv veto
+    ///     POG_xx_Full_yy include also the isolation, impact parameter and conv. veto
+    ///     POG_ConvVeto_Loose = (missing hits <= 1)
+    ///     POG_ConvVeto_Tight = (missing hits == 1 && vertex-based conversion)
+    enum ElectronID { POG_Cuts_ID_Veto,   POG_Cuts_Full_Veto,
+                      POG_Cuts_ID_Loose,  POG_Cuts_Full_Loose,
+                      POG_Cuts_ID_Medium, POG_Cuts_Full_Medium, 
+                      POG_Cuts_ID_Tight,  POG_Cuts_Full_Tight, 
+                      POG_TriggerPreselection,
+                      POG_ConvVeto_Loose, POG_ConvVeto_Tight,
+                      POG_MVA_ID_NonTrig, POG_MVA_Full_NonTrig,
+                      POG_MVA_ID_Trig,    POG_MVA_Full_Trig,
+                      HZZ4L_ID// == POG_MVA_ID_NonTrig 
+                    };
+    bool electronID(ElectronID id, const reco::Vertex *vtx = 0, double rho=UnSet(double)) const ;
+    bool electronID(const std::string &id, const reco::Vertex *vtx = 0, double rho=UnSet(double)) const ;
+    bool electronID(const char        *id, const reco::Vertex *vtx = 0, double rho=UnSet(double)) const ;
+    /// provide a copy of it so that we can override electronID in python and still be able to call the C++
+    bool electronID_cpp_(const std::string &id, const reco::Vertex *vtx = 0, double rho=UnSet(double)) const { return electronID(id,vtx,rho); }
+
+    static void SetEffectiveAreaForRhoCorrections(int year=2012, bool data=1);
+
 private:
     
     // That's the PF mva
@@ -132,7 +154,6 @@ private:
     bool passConversionVeto_;
           
     friend class cmg::ElectronFactory;    
-
 };
 
 }

--- a/AnalysisDataFormats/CMGTools/interface/Muon.h
+++ b/AnalysisDataFormats/CMGTools/interface/Muon.h
@@ -138,6 +138,13 @@ class MuonFactory;
 
     AlgebraicSymMatrix66 covarianceMatrix() { return covarianceMatrix_; }
 
+
+    enum MuonID { POG_ID_Loose, POG_ID_Soft, POG_ID_Tight, POG_ID_HighPt, POG_PFIso_Loose, POG_PFIso_Tight };
+    bool muonID(MuonID id, const reco::Vertex *vtx = 0) const ;
+    bool muonID(const std::string &id, const reco::Vertex *vtx = 0) const ;
+    bool muonID(const char        *id, const reco::Vertex *vtx = 0) const ;
+    // this is needed to make sure we can redefine muonID in python but still be able to call back the C++ one
+    bool muonID_cpp_(const std::string &id, const reco::Vertex *vtx = 0) const { return muonID(id,vtx); }
 	
     friend class cmg::MuonFactory;
 	

--- a/AnalysisDataFormats/CMGTools/src/Electron.cc
+++ b/AnalysisDataFormats/CMGTools/src/Electron.cc
@@ -1,6 +1,171 @@
-# include "AnalysisDataFormats/CMGTools/interface/Electron.h"
+#include "AnalysisDataFormats/CMGTools/interface/Electron.h"
+#include "EgammaAnalysis/ElectronTools/interface/EGammaCutBasedEleId.h"
+#include "EgammaAnalysis/ElectronTools/interface/ElectronEffectiveArea.h"
+#include <unordered_map>
 
 using namespace cmg;
+namespace {
+    ElectronEffectiveArea::ElectronEffectiveAreaTarget _electron_EA = ElectronEffectiveArea::kEleEAData2012;
+
+    std::unordered_map<std::string,cmg::Electron::ElectronID> _electron_id_map;
+    const std::unordered_map<std::string,cmg::Electron::ElectronID> & fill_electron_id_map() {
+        if (_electron_id_map.empty()) {
+            _electron_id_map["POG_Cuts_ID_Veto"] = cmg::Electron::POG_Cuts_ID_Veto;
+            _electron_id_map["POG_Cuts_ID_Loose"] = cmg::Electron::POG_Cuts_ID_Loose;
+            _electron_id_map["POG_Cuts_ID_Medium"] = cmg::Electron::POG_Cuts_ID_Medium;
+            _electron_id_map["POG_Cuts_ID_Tight"] = cmg::Electron::POG_Cuts_ID_Tight;
+            _electron_id_map["POG_Cuts_Full_Veto"] = cmg::Electron::POG_Cuts_Full_Veto;
+            _electron_id_map["POG_Cuts_Full_Loose"] = cmg::Electron::POG_Cuts_Full_Loose;
+            _electron_id_map["POG_Cuts_Full_Medium"] = cmg::Electron::POG_Cuts_Full_Medium;
+            _electron_id_map["POG_Cuts_Full_Tight"] = cmg::Electron::POG_Cuts_Full_Tight;
+            _electron_id_map["POG_TriggerPreselection"] = cmg::Electron::POG_TriggerPreselection;
+            _electron_id_map["POG_ConvVeto_Loose"] = cmg::Electron::POG_ConvVeto_Loose;
+            _electron_id_map["POG_ConvVeto_Tight"] = cmg::Electron::POG_ConvVeto_Tight;
+            _electron_id_map["POG_MVA_ID_NonTrig"] = cmg::Electron::POG_MVA_ID_NonTrig;
+            _electron_id_map["POG_MVA_ID_Trig"] = cmg::Electron::POG_MVA_ID_Trig;
+            _electron_id_map["POG_MVA_Full_NonTrig"] = cmg::Electron::POG_MVA_Full_NonTrig;
+            _electron_id_map["POG_MVA_Full_Trig"] = cmg::Electron::POG_MVA_Full_Trig;
+            _electron_id_map["HZZ4L_ID"] = cmg::Electron::HZZ4L_ID;
+        }
+        return _electron_id_map;
+    }
+}
+
+bool cmg::Electron::electronID(ElectronID id, const reco::Vertex *vtx, double rho) const 
+{
+    using std::abs;
+
+    const pat::Electron &ele = **sourcePtr();
+    bool isEB = ele.isEB() ? true : false;
+    float pt = ele.pt();
+    float eta = ele.superCluster()->eta();
+
+    // id variables
+    float dEtaIn = deltaEtaSuperClusterTrackAtVtx();
+    float dPhiIn = deltaPhiSuperClusterTrackAtVtx();
+    float sigmaIEtaIEta = sigmaIetaIeta();
+    float hoe = hadronicOverEm();
+    float ooemoop = (1.0/ele.ecalEnergy() - ele.eSuperClusterOverP()/ele.ecalEnergy());
+    bool vtxFitConversion = passConversionVeto();
+    float mHits = numberOfHits();
+    // impact parameter variables
+    float d0vtx = 0.0, dzvtx = 0.0;
+    if (id == POG_Cuts_Full_Veto || id == POG_Cuts_Full_Loose || id == POG_Cuts_Full_Medium || id == POG_Cuts_Full_Tight) {
+        if (vtx == 0)     throw cms::Exception("InvalidArgument", "POG_Cuts_Full_XXX ids require a vertex");
+        d0vtx = ele.gsfTrack()->dxy(vtx->position());
+        dzvtx = ele.gsfTrack()->dxy(vtx->position());
+    } 
+    // isolation
+    float iso_ch = 0.0, iso_em = 0.0, iso_nh = 0.0;
+    if (id == POG_Cuts_Full_Veto || id == POG_Cuts_Full_Loose || id == POG_Cuts_Full_Medium || id == POG_Cuts_Full_Tight || id == POG_MVA_Full_NonTrig || id == POG_MVA_Full_Trig)  {
+        if (isUnset(rho)) throw cms::Exception("InvalidArgument", "POG_Cuts_Full_XXX and POG_MVA_Full_XXX ids require a rho value");
+        float dr = (id == POG_MVA_Full_NonTrig || id == POG_MVA_Full_Trig) ? 0.4 : 0.3;
+        iso_ch = chargedHadronIso(dr);
+        iso_em = photonIso(dr);
+        iso_nh = neutralHadronIso(dr);
+    } else {
+        rho = 0;
+    }
+    switch(id) {
+        case POG_Cuts_ID_Veto:
+            return EgammaCutBasedEleId::PassWP(EgammaCutBasedEleId::VETO,   isEB, pt, eta, dEtaIn, dPhiIn, sigmaIEtaIEta, hoe, ooemoop, 0.0,   0.0,   0.0,    0.0,    0.0,    1,                0,     0.0);
+        case POG_Cuts_ID_Loose:
+            return EgammaCutBasedEleId::PassWP(EgammaCutBasedEleId::LOOSE,  isEB, pt, eta, dEtaIn, dPhiIn, sigmaIEtaIEta, hoe, ooemoop, 0.0,   0.0,   0.0,    0.0,    0.0,    1,                0,     0.0);
+        case POG_Cuts_ID_Medium:
+            return EgammaCutBasedEleId::PassWP(EgammaCutBasedEleId::MEDIUM, isEB, pt, eta, dEtaIn, dPhiIn, sigmaIEtaIEta, hoe, ooemoop, 0.0,   0.0,   0.0,    0.0,    0.0,    1,                0,     0.0);
+        case POG_Cuts_ID_Tight:
+            return EgammaCutBasedEleId::PassWP(EgammaCutBasedEleId::TIGHT,  isEB, pt, eta, dEtaIn, dPhiIn, sigmaIEtaIEta, hoe, ooemoop, 0.0,   0.0,   0.0,    0.0,    0.0,    1,                0,     0.0);
+        case POG_Cuts_Full_Veto:
+            return EgammaCutBasedEleId::PassWP(EgammaCutBasedEleId::VETO,   isEB, pt, eta, dEtaIn, dPhiIn, sigmaIEtaIEta, hoe, ooemoop, d0vtx, dzvtx, iso_ch, iso_em, iso_nh, vtxFitConversion, mHits, rho);
+        case POG_Cuts_Full_Loose:
+            return EgammaCutBasedEleId::PassWP(EgammaCutBasedEleId::LOOSE,  isEB, pt, eta, dEtaIn, dPhiIn, sigmaIEtaIEta, hoe, ooemoop, d0vtx, dzvtx, iso_ch, iso_em, iso_nh, vtxFitConversion, mHits, rho);
+        case POG_Cuts_Full_Medium:
+            return EgammaCutBasedEleId::PassWP(EgammaCutBasedEleId::MEDIUM, isEB, pt, eta, dEtaIn, dPhiIn, sigmaIEtaIEta, hoe, ooemoop, d0vtx, dzvtx, iso_ch, iso_em, iso_nh, vtxFitConversion, mHits, rho);
+        case POG_Cuts_Full_Tight:
+            return EgammaCutBasedEleId::PassWP(EgammaCutBasedEleId::TIGHT,  isEB, pt, eta, dEtaIn, dPhiIn, sigmaIEtaIEta, hoe, ooemoop, d0vtx, dzvtx, iso_ch, iso_em, iso_nh, vtxFitConversion, mHits, rho);
+        case POG_TriggerPreselection:
+            return EgammaCutBasedEleId::PassTriggerCuts(EgammaCutBasedEleId::TRIGGERTIGHT, ele);
+        case POG_ConvVeto_Loose:
+            return mHits <= 1;
+        case POG_ConvVeto_Tight:
+            return mHits == 1 && vtxFitConversion;
+        case POG_MVA_ID_NonTrig:
+        case HZZ4L_ID:
+            if (pt < 10) {
+                if      (abs(eta) < 0.8)   return mvaNonTrigV0() > +0.47f;
+                else if (abs(eta) < 1.479) return mvaNonTrigV0() > +0.004f;
+                else                       return mvaNonTrigV0() > +0.295f;
+            } else {
+                if      (abs(eta) < 0.8)   return mvaNonTrigV0() > -0.34;
+                else if (abs(eta) < 1.479) return mvaNonTrigV0() > -0.65;
+                else                       return mvaNonTrigV0() > +0.60;
+            }
+        case POG_MVA_Full_NonTrig:
+            {
+                float AEff = ElectronEffectiveArea::GetElectronEffectiveArea(ElectronEffectiveArea::kEleGammaAndNeutralHadronIso03, eta, _electron_EA);
+                if (chargedHadronIso(0.4) + std::max(0.0, neutralHadronIso(0.4)+photonIso(0.4) - rho*AEff) >= 0.4*pt) return false;
+                if (abs(dB3D()/edB3D()) >= 4) return false;
+                if (pt < 10) {
+                    if      (abs(eta) < 0.8)   return mvaNonTrigV0() > +0.47f;
+                    else if (abs(eta) < 1.479) return mvaNonTrigV0() > +0.004f;
+                    else                       return mvaNonTrigV0() > +0.295f;
+                } else {
+                    if      (abs(eta) < 0.8)   return mvaNonTrigV0() > -0.34;
+                    else if (abs(eta) < 1.479) return mvaNonTrigV0() > -0.65;
+                    else                       return mvaNonTrigV0() > +0.60;
+                }
+            }
+         case POG_MVA_ID_Trig:
+            if (pt < 20) {
+                if      (abs(eta) < 0.8)   return mvaTrigV0() > +0.00f;
+                else if (abs(eta) < 1.479) return mvaTrigV0() > +0.10f;
+                else                       return mvaTrigV0() > +0.62f;
+            } else {
+                if      (abs(eta) < 0.8)   return mvaTrigV0() > +0.94;
+                else if (abs(eta) < 1.479) return mvaTrigV0() > +0.85;
+                else                       return mvaTrigV0() > +0.92;
+            }
+        case POG_MVA_Full_Trig:
+            {
+                float AEff = ElectronEffectiveArea::GetElectronEffectiveArea(ElectronEffectiveArea::kEleGammaAndNeutralHadronIso03, eta, _electron_EA);
+                if (chargedHadronIso(0.4) + std::max(0.0, neutralHadronIso(0.4)+photonIso(0.4) - rho*AEff) >= 0.15*pt) return false;
+                if (mHits != 0 || !vtxFitConversion) return false;
+                if (pt < 20) {
+                    if      (abs(eta) < 0.8)   return mvaTrigV0() > +0.00f;
+                    else if (abs(eta) < 1.479) return mvaTrigV0() > +0.10f;
+                    else                       return mvaTrigV0() > +0.62f;
+                } else {
+                    if      (abs(eta) < 0.8)   return mvaTrigV0() > +0.94;
+                    else if (abs(eta) < 1.479) return mvaTrigV0() > +0.85;
+                    else                       return mvaTrigV0() > +0.92;
+                }
+            }
+    }
+    throw cms::Exception("InvalidArgument", "Unrecognized Electron ID choice");
+}
+bool cmg::Electron::electronID(const std::string &id, const reco::Vertex *vtx, double rho) const 
+{
+    static const std::unordered_map<std::string,ElectronID> & id_map = fill_electron_id_map();
+    auto match = id_map.find(id);
+    if (match == id_map.end()) throw cms::Exception("InvalidArgument", id+" electron ID not known");
+    return electronID(match->second, vtx, rho);
+}
+bool cmg::Electron::electronID(const char *id, const reco::Vertex *vtx, double rho) const 
+{
+    return electronID(std::string(id), vtx);
+}
+
+void cmg::Electron::SetEffectiveAreaForRhoCorrections(int year, bool data) {
+    if (year == 2011) {
+        if (data == 1) ::_electron_EA = ElectronEffectiveArea::kEleEAData2011;
+        else           ::_electron_EA = ElectronEffectiveArea::kEleEAFall11MC;
+    } else if (year == 2012) {
+        if (data == 1) ::_electron_EA = ElectronEffectiveArea::kEleEAData2011;
+        else throw cms::Exception("InvalidArgument", "2012 Electron effective areas are available only for data, use those for MC as well.\n");
+    } else {
+        throw cms::Exception("InvalidArgument", "Electron effective areas are available only for 2012 (data) and 2011 (data, mc)\n");
+    }
+}
 
 /// charged hadron vetoes    
 reco::isodeposit::AbsVetos Electron::chargedHadronVetos() const {

--- a/AnalysisDataFormats/CMGTools/src/Muon.cc
+++ b/AnalysisDataFormats/CMGTools/src/Muon.cc
@@ -1,6 +1,59 @@
-# include "AnalysisDataFormats/CMGTools/interface/Muon.h"
+#include "AnalysisDataFormats/CMGTools/interface/Muon.h"
+#include "DataFormats/MuonReco/interface/MuonSelectors.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include <unordered_map>
 
 using namespace cmg;
+
+namespace {
+    std::unordered_map<std::string,cmg::Muon::MuonID> _muon_id_map;
+    const std::unordered_map<std::string,cmg::Muon::MuonID> & fill_muon_id_map() {
+        if (_muon_id_map.empty()) {
+            _muon_id_map["POG_ID_Soft"] = cmg::Muon::POG_ID_Soft;
+            _muon_id_map["POG_ID_Loose"] = cmg::Muon::POG_ID_Loose;
+            _muon_id_map["POG_ID_Tight"] = cmg::Muon::POG_ID_Tight;
+            _muon_id_map["POG_ID_HighPt"] = cmg::Muon::POG_ID_HighPt;
+            _muon_id_map["POG_PFIso_Loose"] = cmg::Muon::POG_PFIso_Loose;
+            _muon_id_map["POG_PFIso_Tight"] = cmg::Muon::POG_PFIso_Tight;
+        }
+        return _muon_id_map;
+    }
+}
+
+bool cmg::Muon::muonID(MuonID id, const reco::Vertex *vtx) const 
+{
+    const pat::Muon &mu = **sourcePtr();
+    switch(id) {
+        case POG_ID_Loose:  
+                return muon::isLooseMuon(mu);
+        case POG_ID_Soft:   
+                if (vtx == 0) throw cms::Exception("InvalidArgument", "POG_ID_Soft requires a vertex");
+                return muon::isSoftMuon(mu, *vtx);
+        case POG_ID_Tight:  
+                if (vtx == 0) throw cms::Exception("InvalidArgument", "POG_ID_Tight requires a vertex");
+                return muon::isTightMuon(mu, *vtx);
+        case POG_ID_HighPt: 
+                if (vtx == 0) throw cms::Exception("InvalidArgument", "POG_ID_HighPt requires a vertex");
+                return muon::isHighPtMuon(mu, *vtx, reco::improvedTuneP);
+        case POG_PFIso_Loose:
+                return (mu.pfIsolationR04().sumChargedHadronPt + std::max(mu.pfIsolationR04().sumNeutralHadronEt + mu.pfIsolationR04().sumPhotonEt - 0.5*mu.pfIsolationR04().sumPUPt,0.0)) < 0.20 * mu.pt();
+        case POG_PFIso_Tight:
+                return (mu.pfIsolationR04().sumChargedHadronPt + std::max(mu.pfIsolationR04().sumNeutralHadronEt + mu.pfIsolationR04().sumPhotonEt - 0.5*mu.pfIsolationR04().sumPUPt,0.0)) < 0.12 * mu.pt();
+    }
+    throw cms::Exception("InvalidArgument", "Unrecognized Muon ID choice");
+}
+bool cmg::Muon::muonID(const std::string &id, const reco::Vertex *vtx) const 
+{
+    static const std::unordered_map<std::string,MuonID> & id_map = fill_muon_id_map();
+    auto match = id_map.find(id);
+    if (match == id_map.end()) throw cms::Exception("InvalidArgument", id+" muon ID not known");
+    return muonID(match->second, vtx);
+}
+bool cmg::Muon::muonID(const char *id, const reco::Vertex *vtx) const 
+{
+    return muonID(std::string(id), vtx);
+}
+
 
 /// charged hadron vetoes    
 reco::isodeposit::AbsVetos Muon::chargedHadronVetos() const {

--- a/CMGTools/RootTools/python/physicsobjects/Electron.py
+++ b/CMGTools/RootTools/python/physicsobjects/Electron.py
@@ -1,4 +1,4 @@
-from CMGTools.RootTools.physicsobjects.Lepton import *
+from CMGTools.RootTools.physicsobjects.Lepton import Lepton
 
 class Electron( Lepton ):
 
@@ -8,6 +8,11 @@ class Electron( Lepton ):
         function.'''
         super(Electron, self).__init__(*args, **kwargs)
         self.tightIdResult = None
+
+    def electronID( self, id, vertex=None, rho=None ):
+        if vertex == None and hasattr(self,'associatedVertex') and self.associatedVertex != None: vertex = self.associatedVertex
+        if rho == None and hasattr(self,'rho') and self.rho != None: rho = self.rho
+        return self.electronID_cpp_(id,vertex,rho) if rho != None else self.electronID_cpp_(id,vertex);
 
     def absEffAreaIso(self,rho,effectiveAreas):
         '''MIKE, missing doc.

--- a/CMGTools/RootTools/python/physicsobjects/Muon.py
+++ b/CMGTools/RootTools/python/physicsobjects/Muon.py
@@ -1,6 +1,10 @@
-from CMGTools.RootTools.physicsobjects.Lepton import *
+from CMGTools.RootTools.physicsobjects.Lepton import Lepton
 
 class Muon( Lepton ):
+
+    def muonID( self, id, vertex=None ):
+        if vertex == None and hasattr(self,'associatedVertex') and self.associatedVertex != None: vertex = self.associatedVertex
+        return self.muonID_cpp_(id,vertex)
 
     def looseId( self ):
         '''Loose ID as recommended by mu POG.'''

--- a/EgammaAnalysis/ElectronTools/src/EGammaCutBasedEleId.cc
+++ b/EgammaAnalysis/ElectronTools/src/EGammaCutBasedEleId.cc
@@ -302,7 +302,7 @@ unsigned int EgammaCutBasedEleId::TestWP(WorkingPoint workingPoint, const bool i
     unsigned int idx = isEB ? 0 : 1;
 
     // effective area for isolation
-    float AEff = ElectronEffectiveArea::GetElectronEffectiveArea(ElectronEffectiveArea::kEleGammaAndNeutralHadronIso03, eta, ElectronEffectiveArea::kEleEAData2011);
+    float AEff = ElectronEffectiveArea::GetElectronEffectiveArea(ElectronEffectiveArea::kEleGammaAndNeutralHadronIso03, eta, ElectronEffectiveArea::kEleEAData2012);
 
     // apply to neutrals
     double rhoPrime = std::max(rho, 0.0);


### PR DESCRIPTION
First part of task #13 
Implemented with enumerators (so that the list of possible values is clearly defined) and also by string and by const char pointer (useful in some cases in ROOT). 
The same metods are redefined in python so that they can take the attached values of the vertex and of rho.
