### PR TITLE
RootTools AutoHandle: Allow a handle to be marked as possibly failing.

### DIFF
--- a/CMGTools/RootTools/python/fwlite/AutoHandle.py
+++ b/CMGTools/RootTools/python/fwlite/AutoHandle.py
@@ -7,10 +7,11 @@ class AutoHandle( Handle, object ):
 
     handles = {}
     
-    def __init__(self, label, type):
+    def __init__(self, label, type, mayFail=False):
         '''Note: label can be a tuple : (module_label, collection_label, process)'''
         self.label = label
         self.type = type
+        self.mayFail = mayFail
         Handle.__init__(self, self.type)
 
     def Load(self, event):
@@ -25,5 +26,6 @@ class AutoHandle( Handle, object ):
             type = {type}
             label = {label}
             '''.format(type = self.type, label = self.label)
-            raise ValueError(errstr)
+            if not self.mayFail:
+                raise ValueError(errstr)
             

--- a/CMGTools/TTHAnalysis/python/analyzers/susyParameterScanAnalyzer.py
+++ b/CMGTools/TTHAnalysis/python/analyzers/susyParameterScanAnalyzer.py
@@ -35,7 +35,7 @@ class susyParameterScanAnalyzer( Analyzer ):
         #mc information
         self.mchandles['genParticles'] = AutoHandle( 'genParticlesPruned',
                                                      'std::vector<reco::GenParticle>' )
-        self.mchandles['lhe'] = AutoHandle( 'source', 'LHEEventProduct' )
+        self.mchandles['lhe'] = AutoHandle( 'source', 'LHEEventProduct', mayFail = True )
         
     def beginLoop(self):
         super(susyParameterScanAnalyzer,self).beginLoop()
@@ -60,6 +60,11 @@ class susyParameterScanAnalyzer( Analyzer ):
             setattr(event, "genSusyM"+p, avgmass)
 
     def readLHE(self,event):
+        if not self.mchandles['lhe'].isValid():
+            if not hasattr(self,"warned_already"):
+                print "ERROR: Missing LHE header in file"
+                self.warned_already = True
+            return
         lheprod = self.mchandles['lhe'].product()
         scanline = re.compile(r"#\s*model\s+([A-Za-z0-9]+)_((\d+\.?\d*)(_\d+\.?\d*)*)\s+(\d+\.?\d*)\s*")
         for i in xrange(lheprod.comments_size()):


### PR DESCRIPTION
Allow a handle to be marked as possibly failing. In that case it will not throw if the product is not in the event. Used for LHEEventProduct in TTHAnalysis module for Susy scans
