### PR TITLE
cmgPackedCandidates: round 16bit floats instead of truncating them

### DIFF
--- a/AnalysisDataFormats/CMGTools/interface/libminifloat.h
+++ b/AnalysisDataFormats/CMGTools/interface/libminifloat.h
@@ -12,9 +12,27 @@ class MiniFloatConverter {
             return conv.flt;
         }
         inline static uint16_t float32to16(float x) {
+            return float32to16round(x);
+        }
+        /// Fast implementation, but it crops the number so it biases low
+        inline static uint16_t float32to16crop(float x) {
             union { float flt; uint32_t i32; } conv;
             conv.flt = x;
             return basetable[(conv.i32>>23)&0x1ff]+((conv.i32&0x007fffff)>>shifttable[(conv.i32>>23)&0x1ff]);
+        }
+        /// Slower implementation, but it rounds to avoid biases
+        inline static uint16_t float32to16round(float x) {
+            union { float flt; uint32_t i32; } conv;
+            conv.flt = x;
+            uint8_t shift = shifttable[(conv.i32>>23)&0x1ff];
+            if (shift == 13) {
+                uint16_t base2 = (conv.i32&0x007fffff)>>12;
+                uint16_t base = base2 >> 1;
+                if (((base2 & 1) != 0) && (base < 1023)) base++;
+                return basetable[(conv.i32>>23)&0x1ff]+base; 
+            } else {
+                return basetable[(conv.i32>>23)&0x1ff]+((conv.i32&0x007fffff)>>shifttable[(conv.i32>>23)&0x1ff]);
+            }
         }
     private:
         static uint32_t mantissatable[2048];

--- a/AnalysisDataFormats/CMGTools/src/libminifloat.cc
+++ b/AnalysisDataFormats/CMGTools/src/libminifloat.cc
@@ -38,12 +38,12 @@ void MiniFloatConverter::filltables() {
     exponenttable[0] = 0;
     for (unsigned int i = 1; i <= 30; ++i) exponenttable[i] = i<<23;
     exponenttable[31] = 0x47800000;
-    exponenttable[32] = 0;
-    for (unsigned int i = 33; i <= 62; ++i) exponenttable[i] = 0x80000000u | (i-32)<<23;
+    exponenttable[32] = 0x80000000u;
+    for (unsigned int i = 33; i <= 62; ++i) exponenttable[i] = 0x80000000u | ((i-32)<<23);
     exponenttable[63] = 0xC7800000;
 
     // ==== offsettable ====
-    for (unsigned int i = 0; i <= 63; ++i) offsettable[i] = (i == 0 || i == 32 ? 0 : 1024);
+    for (unsigned int i = 0; i <= 63; ++i) offsettable[i] = ((i == 0 || i == 32) ? 0 : 1024);
 
     // ==== basetable, shifttable ===
     for (unsigned i=0; i<256; ++i){


### PR DESCRIPTION
cmgPackedCandidates with 16-bit floats: round quantities instead of truncating them, 
to avoid a systematic bias in aggregate quantities like jet pTs or masses.
(related to task #9)
