### PR TITLE
By default, make slim CMG Tuple

### DIFF
--- a/CMGTools/Common/prod/PATCMG_cfg.py
+++ b/CMGTools/Common/prod/PATCMG_cfg.py
@@ -195,12 +195,16 @@ process.outcmg = cms.OutputModule(
     )
 
 process.outpath += process.outcmg
-# you can uncomment this below to test the 16-bit-packed cmgCandidates
-# process.outcmg.outputCommands.append('keep cmgPackedCandidates_cmgCandidates_*_*') 
-# process.outcmg.outputCommands.append('drop cmgCandidates_cmgCandidates_*_*') 
-
-
-
+# These commands below will select the 'light' version of the CMG tuple:
+#  - 16bit PF Candidates
+#  - TriggerPrescales instead of fat single TriggerObject
+#  - slimmed PVs (without track references)
+process.outcmg.outputCommands.append('keep cmgPackedCandidates_cmgCandidates_*_*') 
+process.outcmg.outputCommands.append('drop cmgCandidates_cmgCandidates_*_*') 
+process.outcmg.outputCommands.append('keep *_cmgTriggerPrescales_*_*') 
+process.outcmg.outputCommands.append('drop *_cmgTriggerObjectSel_*_*') 
+process.outcmg.outputCommands.append('drop *_offlinePrimaryVertices_*_*') 
+process.outcmg.outputCommands.append('keep *_slimmedPrimaryVertices_*_*') 
 
 ########################################################
 ## Conditions 

--- a/CMGTools/TTHAnalysis/cfg/run_ttHLep8TeV_newNtpl_cfg.py
+++ b/CMGTools/TTHAnalysis/cfg/run_ttHLep8TeV_newNtpl_cfg.py
@@ -33,7 +33,9 @@ triggerAna = cfg.Analyzer(
 # this analyzer is just there to select a list of good primary vertices.
 ttHVertexAna = cfg.Analyzer(
     'VertexAnalyzer',
-    goodVertices = 'offlinePrimaryVertices',
+    #goodVertices = 'offlinePrimaryVertices',
+    goodVertices = 'slimmedPrimaryVertices',
+    allVertices = 'slimmedPrimaryVertices',
     vertexWeight = None,
     fixedWeight = 1,
     verbose = False
@@ -45,6 +47,7 @@ pileUpAna = cfg.Analyzer(
     "PileUpAnalyzer",
     # build unweighted pu distribution using number of pile up interactions if False
     # otherwise, use fill the distribution using number of true interactions
+    allVertices = 'slimmedPrimaryVertices',
     true = True,
     makeHists=False
     )


### PR DESCRIPTION
Turn on the following slimming options in the top-level cfg file
- 16bit PF Candidates instead of 32 bit ones
- TriggerPrescales instead of fat single TriggerObject
- slimmed PVs (without track references)

For the 16 bit candidates, in the absence of any other validation, I checked that re-reconstructing the ak5PFJetsCHS and ca8PFJetsCHS (both pruned and not pruned) from the 16 bit candidates the &eta; and &phi; are reproduced to an absolute accuracy of about 0.0001, and the p<sub>T</sub> and mass are similarly reproduced with a relative accuracy of ~0.0001.
A few plots:
   http://gpetrucc.web.cern.ch/gpetrucc/drop/plots/16bit/?match=ak5PF*_hD
   http://gpetrucc.web.cern.ch/gpetrucc/drop/plots/16bit/?match=ca8PFJetsCHSpr*cM
   http://gpetrucc.web.cern.ch/gpetrucc/drop/plots/16bit/?match=ca8PFJetsCHSpr*DMR
   http://gpetrucc.web.cern.ch/gpetrucc/drop/plots/16bit/?match=ca8PFJetsCHSpr*DPt
(note: uncorrected jets, with a only a minimal selection, no jet id, no pu id, no cleaning of leptons...)
