### PR TITLE
Switch to das_client to get dbs3 files

### DIFF
--- a/CMGTools/Production/python/dataset.py
+++ b/CMGTools/Production/python/dataset.py
@@ -128,16 +128,16 @@ class CMSDataset( BaseDataset ):
         print 'buildListOfFilesDBS',begin,end
         sampleName = self.name.rstrip('/')
         query = sampleName
-        if self.run_range is not None:
-            if self.run_range[0] > 0:
-                query = "%s and run >= %i" % (query,self.run_range[0])
-            if self.run_range[1] > 0:
-                query = "%s and run <= %i" % (query,self.run_range[1])
-        dbs='dbs search --query="find file where dataset like %s"'%query
+        if self.run_range is not None and self.run_range != (-1,-1):
+            print self.run_range
+            raise RuntimeError, "Run ranges not supported at the moment with das_client"
+        dbs='das_client.py --query="file dataset=%s"'%query
         if begin >= 0:
-            dbs += ' --begin %d' % begin
+            dbs += ' --index %d' % begin
         if end >= 0:
-            dbs += ' --end %d' % end
+            dbs += ' --limit %d' % (end-begin+1)
+        else:
+            dbs += ' --limit 0' 
         print 'dbs\t: %s' % dbs
         dbsOut = os.popen(dbs)
         files = []
@@ -172,20 +172,19 @@ class CMSDataset( BaseDataset ):
 
         query = dataset
         if runmin > 0:
+            raise RuntimeError, "Run ranges not supported at the moment with das_client"
             query = "%s and run >= %i" % (query,runmin)
         if runmax > 0:
+            raise RuntimeError, "Run ranges not supported at the moment with das_client"
             query = "%s and run <= %i" % (query,runmax)
-        dbs='dbs search --query="find sum(file.numevents) where dataset like %s"'%query
+        dbs='das_client.py --query="summary dataset=%s"'%query
         dbsOut = os.popen(dbs).readlines()
 
         entries = []
         for line in dbsOut:
             line = line.replace('\n','')
-            if line:
-                try:
-                    entries.append(int(line))
-                except ValueError:
-                    pass
+            if "nevents" in line:
+                entries.append(int(line.split(":")[1]))
         if entries:
             return sum(entries)
         return -1
@@ -195,20 +194,19 @@ class CMSDataset( BaseDataset ):
 
         query = dataset
         if runmin > 0:
+            raise RuntimeError, "Run ranges not supported at the moment with das_client"
             query = "%s and run >= %i" % (query,runmin)
         if runmax > 0:
+            raise RuntimeError, "Run ranges not supported at the moment with das_client"
             query = "%s and run <= %i" % (query,runmax)
-        dbs = 'dbs search --query="find sum(block.numfiles) where dataset like %s"' % query
+        dbs='das_client.py --query="summary dataset=%s"'%query
         dbsOut = os.popen(dbs).readlines()
 
         entries = []
         for line in dbsOut:
             line = line.replace('\n','')
-            if line:
-                try:
-                    entries.append(int(line))
-                except ValueError:
-                    pass
+            if "nfiles" in line:
+                entries.append(int(line.split(":")[1]))
         if entries:
             return sum(entries)
         return -1

--- a/CMGTools/Production/python/dataset.py
+++ b/CMGTools/Production/python/dataset.py
@@ -129,8 +129,11 @@ class CMSDataset( BaseDataset ):
         sampleName = self.name.rstrip('/')
         query = sampleName
         if self.run_range is not None and self.run_range != (-1,-1):
-            print self.run_range
-            raise RuntimeError, "Run ranges not supported at the moment with das_client"
+            if self.run_range[0] == self.run_range[1]:
+                query += "   run=%s" % self.run_range[0]
+            else:
+                print "WARNING: queries with run ranges are slow in DAS"
+                query += "   run between [%s,%s]" % ( self.run_range[0],self.run_range[1] )
         dbs='das_client.py --query="file dataset=%s"'%query
         if begin >= 0:
             dbs += ' --index %d' % begin
@@ -171,12 +174,12 @@ class CMSDataset( BaseDataset ):
     def findPrimaryDatasetEntries(dataset, runmin, runmax):
 
         query = dataset
-        if runmin > 0:
-            raise RuntimeError, "Run ranges not supported at the moment with das_client"
-            query = "%s and run >= %i" % (query,runmin)
-        if runmax > 0:
-            raise RuntimeError, "Run ranges not supported at the moment with das_client"
-            query = "%s and run <= %i" % (query,runmax)
+        if runmin >0 or runmax > 0:
+            if runmin == runmax:
+                query = "%s run=%d" % (query,runmin)
+            else:
+                print "WARNING: queries with run ranges are slow in DAS"
+                query = "%s run between [%d, %d]" % (query,runmin if runmin > 0 else 1, runmax if runmax > 0 else 999999)
         dbs='das_client.py --query="summary dataset=%s"'%query
         dbsOut = os.popen(dbs).readlines()
 
@@ -193,12 +196,12 @@ class CMSDataset( BaseDataset ):
     def findPrimaryDatasetNumFiles(dataset, runmin, runmax):
 
         query = dataset
-        if runmin > 0:
-            raise RuntimeError, "Run ranges not supported at the moment with das_client"
-            query = "%s and run >= %i" % (query,runmin)
-        if runmax > 0:
-            raise RuntimeError, "Run ranges not supported at the moment with das_client"
-            query = "%s and run <= %i" % (query,runmax)
+        if runmin >0 or runmax > 0:
+            if runmin == runmax:
+                query = "%s run=%d" % (query,runmin)
+            else:
+                print "WARNING: queries with run ranges are slow in DAS"
+                query = "%s run between [%d, %d]" % (query,runmin if runmin > 0 else 1, runmax if runmax > 0 else 999999)
         dbs='das_client.py --query="summary dataset=%s"'%query
         dbsOut = os.popen(dbs).readlines()
 


### PR DESCRIPTION
Needed for recent datasets that are not visible with dbsql

Would benefit from more testing  (in particular on a dataset with more than 10k files)

Now run ranges are also implemented, but they can be extremely slow and result in timeout errors (after ~5 mins or so), especially if using ranges where one end is trivial (e.g. [1, 203986]).
In principle one could implement a workaround querying first the list of runs and then the files for each run, but that will also be quite slow (e.g. there's ~500 runs in the Run2012D era).
