### PR TITLE
add binaries for htmldir, multiloop and pyroot

### DIFF
--- a/CMGTools/RootTools/scripts/htmldir
+++ b/CMGTools/RootTools/scripts/htmldir
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+ipython $CMSSW_BASE/src/CMGTools/RootTools/python/html/DirectoryTree.py "$@"

--- a/CMGTools/RootTools/scripts/multiloop
+++ b/CMGTools/RootTools/scripts/multiloop
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+ipython $CMSSW_BASE/src/CMGTools/RootTools/python/fwlite/MultiLoop.py "$@"

--- a/CMGTools/RootTools/scripts/pyroot
+++ b/CMGTools/RootTools/scripts/pyroot
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+ipython -i $CMSSW_BASE/src/CMGTools/RootTools/python/PyRoot.py "$@"


### PR DESCRIPTION
so people don't have to define aliases.
use ipython instead of python
superseeds #41
