### PR TITLE
fix cut-based electron id in cmg::Electron

### DIFF
--- a/AnalysisDataFormats/CMGTools/src/Electron.cc
+++ b/AnalysisDataFormats/CMGTools/src/Electron.cc
@@ -53,7 +53,7 @@ bool cmg::Electron::electronID(ElectronID id, const reco::Vertex *vtx, double rh
     if (id == POG_Cuts_Full_Veto || id == POG_Cuts_Full_Loose || id == POG_Cuts_Full_Medium || id == POG_Cuts_Full_Tight) {
         if (vtx == 0)     throw cms::Exception("InvalidArgument", "POG_Cuts_Full_XXX ids require a vertex");
         d0vtx = ele.gsfTrack()->dxy(vtx->position());
-        dzvtx = ele.gsfTrack()->dxy(vtx->position());
+        dzvtx = ele.gsfTrack()->dz(vtx->position());
     } 
     // isolation
     float iso_ch = 0.0, iso_em = 0.0, iso_nh = 0.0;


### PR DESCRIPTION
Doesn't need to be propagated to 7.0.X since we don't have the cmg::Electron there
