### PR TITLE
Fix multiloop to work in ipython when using multiprocessing

### DIFF
--- a/CMGTools/RootTools/python/fwlite/MultiLoop.py
+++ b/CMGTools/RootTools/python/fwlite/MultiLoop.py
@@ -133,10 +133,12 @@ def main( options, args ):
     if len(selComps)>1:
         shutil.copy( cfgFileName, outDir )
         pool = Pool(processes=min(len(selComps),10))
+        ## workaround for a scoping problem in ipython+multiprocessing
+        import CMGTools.RootTools.fwlite.MultiLoop as ML 
         for comp in selComps:
             print 'submitting', comp.name
-            pool.apply_async( runLoopAsync, [comp, outDir, cfg.config, options],
-                              callback=callBack)     
+            pool.apply_async( ML.runLoopAsync, [comp, outDir, cfg.config, options],
+                              callback=ML.callBack)     
         pool.close()
         pool.join()
     else:


### PR DESCRIPTION
The switch to ipython in #46 to get better stack traces introduces a bug when running interactively with multiloop on more than one chunk because for some reason ipython and the multiprocessing module don't interact well with global functions because of some issue with pickle (googling reveals that it's a known issue, but nobody really explains why it happens, too much black magic must be involved).
This fix avoids the problem, at least to the extent I was able to test it, by importing the MultiLoop module explicitly so that the functions are not global anymore.
A separate PR is beging made also for 70X, together with some other changes.
