### PR TITLE
Add IsoTrack branch and relax the jet multiplicity cutoff for SingleLept...

### DIFF
--- a/CMGTools/TTHAnalysis/cfg/run_susySinglelepton_cfg.py
+++ b/CMGTools/TTHAnalysis/cfg/run_susySinglelepton_cfg.py
@@ -10,6 +10,13 @@ from CMGTools.RootTools.RootTools import *
 #Load all analyzers
 from CMGTools.TTHAnalysis.analyzers.susyCore_modules_cff import * 
 
+ttHLepAna.loose_muon_pt  = 10
+ttHLepAna.loose_muon_relIso = 0.2
+ttHLepAna.loose_electron_pt  = 10
+ttHLepAna.loose_electron_relIso = 0.2
+ttHLepAna.ele_isoCorr = "deltaBeta" 
+
+
 # Redefine what I need
 
 # --- LEPTON SKIMMING ---
@@ -18,6 +25,9 @@ ttHLepSkim.maxLeptons = 999
 #ttHLepSkim.idCut  = ""
 #ttHLepSkim.ptCuts = []
 
+# --- JET-LEPTON CLEANING ---
+ttHJetAna.minLepPt = 10 
+ttHJetMCAna.smearJets     = False # do we need to smear the jets?
 
 # Event Analyzer for susy multi-lepton (at the moment, it's the TTH one)
 ttHEventAna = cfg.Analyzer(
@@ -25,6 +35,22 @@ ttHEventAna = cfg.Analyzer(
     minJets25 = 0,
     )
 
+
+ttHIsoTrackAna = cfg.Analyzer(
+            'ttHIsoTrackAnalyzer',
+            candidates='packedPFCandidates',
+            candidatesTypes='std::vector<pat::PackedCandidate>',
+            ptMin = 5, # for pion 
+            ptMinEMU = 5, # for EMU
+            dzMax = 0.1,
+            isoDR = 0.3,
+            ptPartMin = 0,
+            dzPartMax = 0.1,
+            maxAbsIso = 8,
+            MaxIsoSum = 0.1, ### unused
+            MaxIsoSumEMU = 0.2, ### unused
+            doSecondVeto = False
+            )
 
 from CMGTools.TTHAnalysis.samples.samples_8TeV_v517 import triggers_1mu, triggers_1muHT, triggers_1eleHT
 
@@ -49,6 +75,7 @@ selectedComponents = [ SingleMu, DoubleElectron, TTHToWW_PUS14, DYJetsM50_PU20bx
 #-------- SEQUENCE
 
 sequence = cfg.Sequence(susyCoreSequence+[
+    ttHIsoTrackAna,
     ttHEventAna,
     treeProducer,
     ])

--- a/CMGTools/TTHAnalysis/python/analyzers/treeProducerSusySingleLepton.py
+++ b/CMGTools/TTHAnalysis/python/analyzers/treeProducerSusySingleLepton.py
@@ -39,8 +39,9 @@ class treeProducerSusySingleLepton( treeProducerSusyCore ):
             "selectedLeptons" : NTupleCollection("LepGood", leptonTypeSusy, 8, help="Leptons after the preselection"),
             "otherLeptons"    : NTupleCollection("LepOther", leptonTypeSusy, 8, help="Leptons after the preselection"),
             "selectedTaus"    : NTupleCollection("TauGood", tauTypeSusy, 3, help="Taus after the preselection"),
+            "selectedIsoTrack"    : NTupleCollection("isoTrack", isoTrackType, 50, help="isoTrack, sorted by pt"),
             ##------------------------------------------------
-            "cleanJetsAll"       : NTupleCollection("Jet",     jetTypeSusy, 8, help="Cental jets after full selection and cleaning, sorted by pt"),
+            "cleanJetsAll"       : NTupleCollection("Jet",     jetTypeSusy, 25, help="Cental jets after full selection and cleaning, sorted by pt"),
         })
 
         ## Book the variables, but only if we're called explicitly and not through a base class


### PR DESCRIPTION
Add IsoTrack branch and relax the jet multiplicity cutoff in CMGTools/TTHAnalysis/python/analyzers/treeProducerSusySingleLepton.py 

The Lepton RelIso are set to the loose RelISo values to avoid over-cleaning the jet collection.
