### PR TITLE
Cmg mini aod lite v6 0 from cmssw 7 0 6 02 10 2014

### DIFF
--- a/CMGTools/TTHAnalysis/python/tools/eventVars_2lss.py
+++ b/CMGTools/TTHAnalysis/python/tools/eventVars_2lss.py
@@ -12,7 +12,7 @@ class EventVars2LSS:
         # make python lists as Collection does not support indexing in slices
         leps = [l for l in Collection(event,"LepGood","nLepGood",4)]
         jets = [j for j in Collection(event,"Jet","nJet25",8)]
-        (met, metphi)  = event.met, event.met_phi
+        (met, metphi)  = event.met_pt, event.met_phi
         njet = len(jets); nlep = len(leps)
         # prepare output
         ret = dict([(name,0.0) for name in self.branches])

--- a/CMGTools/TTHAnalysis/python/tools/ttbarEventReco_2lss.py
+++ b/CMGTools/TTHAnalysis/python/tools/ttbarEventReco_2lss.py
@@ -462,7 +462,7 @@ class TTEventReco:
         bjets = [ j for j in jets if j.btagCSV > 0.679 ]
         if len(bjets) == 0: 
             jsorted = jets[:]
-            jsorted.sort(key=lambda j:j.tagCSV) 
+            jsorted.sort(key=lambda j:j.btagCSV) 
             bjets.append(jsorted[-1])
         nb = len(bjets)
         (met, metphi)  = event.met_pt, event.met_phi


### PR DESCRIPTION
Fix the names of branches (met -> met_pt and tagCSV -> btagCSV) in the readers of the the input trees, needed for production of additional variables for FinalMVA in 2lss channel.
