### PR TITLE
Modification needed to shift JEC while running on the miniAOD samples.

### DIFF
--- a/CMGTools/RootTools/python/physicsobjects/JetReCalibrator.py
+++ b/CMGTools/RootTools/python/physicsobjects/JetReCalibrator.py
@@ -51,9 +51,9 @@ class JetReCalibrator:
         except RuntimeError, r:
             print "Caught %s when getting uncertainty for jet of pt %.1f, eta %.2f\n" % (r,corr * jet.pt() * jet.rawFactor(),jet.eta())
             jet.jetEnergyCorrUncertainty = 0.5
-        if jet.component(4).fraction() < 0.9 and jet.pt()*corr*jet.rawFactor() > 10:
-            metShift[0] -= jet.px()*(corr*jet.rawFactor() - 1)*(1-jet.component(3).fraction())
-            metShift[1] -= jet.py()*(corr*jet.rawFactor() - 1)*(1-jet.component(3).fraction()) 
+        if jet.photonEnergyFraction() < 0.9 and jet.pt()*corr*jet.rawFactor() > 10:
+            metShift[0] -= jet.px()*(corr*jet.rawFactor() - 1)*(1-jet.muonEnergyFraction())
+            metShift[1] -= jet.py()*(corr*jet.rawFactor() - 1)*(1-jet.muonEnergyFraction()) 
         if delta != 0:
             #print "   jet with corr pt %6.2f has an uncertainty %.2f " % (jet.pt()*jet.rawFactor()*corr, jet.jetEnergyCorrUncertainty)
             corr *= max(0, 1+delta*jet.jetEnergyCorrUncertainty)
@@ -64,7 +64,6 @@ class JetReCalibrator:
         if corr <= 0:
             return False
         jet.setP4(jet.p4() * (corr * jet.rawFactor()))
-        jet.setRawFactor(1.0/corr)
         return True
 
 class Type1METCorrection:


### PR DESCRIPTION
```
float chf = component(1).fraction();
float nhf = component(5).fraction();
float phf = component(4).fraction();
float muf = component(3).fraction();
float elf = component(2).fraction();
```

https://github.com/CERN-PH-CMG/cmg-cmssw/blob/a875832047532c5469aa9795751f0363cd5d9244/AnalysisDataFormats/CMGTools/src/PFJet.cc#L55
