### PR TITLE
change the way to determine the CMSSW version in CMG_MiniAOD_Lite_V6_0_from-CMSSW_7_0_6

### DIFF
--- a/CMGTools/Common/python/Tools/cmsswRelease.py
+++ b/CMGTools/Common/python/Tools/cmsswRelease.py
@@ -1,7 +1,7 @@
 import os
 
 def cmsswRelease():
-    return os.environ['CMSSW_BASE'].split('/')[-1]
+    return os.environ['CMSSW_VERSION']
 
 def cmsswIs44X():
     return cmsswRelease().find('CMSSW_4_4_') != -1


### PR DESCRIPTION
This PR changes the way to determine the CMSSW version. It uses the environmental variable "CMSSW_VERSION" instead of "CMSSW_BASE".
