### PR TITLE
Fixed run_susyAlphaT bug

### DIFF
--- a/CMGTools/TTHAnalysis/cfg/run_susyAlphaT_cfg.py
+++ b/CMGTools/TTHAnalysis/cfg/run_susyAlphaT_cfg.py
@@ -61,6 +61,8 @@ ttHJetMCAna.smearJets     = False
 # NOTE: Currently energy sums are calculated with 40 GeV jets (ttHCoreEventAnalyzer.py)
 #       However, the input collection is cleanjets which have a 50 GeV cut so this is a labeling problem
 
+ttHMetAna.doMetNoMu=True
+
 ttHJetMETSkim.htCut       = ('htJet50j', 0)
 ttHJetMETSkim.mhtCut      = ('htJet40j', 0)
 ttHJetMETSkim.nBJet       = ('CSVM', 0, "jet.pt() > 50")     # require at least 0 jets passing CSVM and pt > 50
@@ -99,6 +101,10 @@ ttHIsoTrackAna = cfg.Analyzer(
 ttHAlphaTAna = cfg.Analyzer(
             'ttHAlphaTVarAnalyzer'
             )
+
+ttHAlphaTControlAna = cfg.Analyzer(
+                        'ttHAlphaTControlAnalyzer'
+                        )
 
 ##------------------------------------------
 ##  PRODUCER
@@ -162,12 +168,13 @@ selectedComponents.extend( TTbar )
 sequence = cfg.Sequence(susyCoreSequence + [
                         ttHIsoTrackAna,
                         ttHAlphaTAna,
+                        ttHAlphaTControlAna,
                         treeProducer,
                         ])
 
 
 #-------- HOW TO RUN
-test = 4
+test = 1
 
 # Test a single component, using a single thread.
 #--------------------------------------------------

--- a/CMGTools/TTHAnalysis/python/analyzers/treeProducerSusyAlphaT.py
+++ b/CMGTools/TTHAnalysis/python/analyzers/treeProducerSusyAlphaT.py
@@ -58,7 +58,7 @@ class treeProducerSusyAlphaT( treeProducerSusyCore ):
             # put more here
             # "pseudoJet1"       : NTupleObject("pseudoJet1",     fourVectorType, help="pseudoJet1 for hemishphere"),
             # "pseudoJet2"       : NTupleObject("pseudoJet2",     fourVectorType, help="pseudoJet2 for hemishphere"),
-             "biasedDPhiJet"       : NTupleObject("biasedDPhiJet",     fourVectorType, help="jet closest to missing energy vector"),
+             #"biasedDPhiJet"       : NTupleObject("biasedDPhiJet",     fourVectorType, help="jet closest to missing energy vector"),
              "metNoMu":         NTupleObject("metNoMu",fourVectorType, help="met computed with muom momentum substracted"),
             })
         self.collections.update({

--- a/CMGTools/TTHAnalysis/python/analyzers/ttHIsoTrackSkimmer.py
+++ b/CMGTools/TTHAnalysis/python/analyzers/ttHIsoTrackSkimmer.py
@@ -45,11 +45,11 @@ class ttHIsoTrackSkimmer( Analyzer ):
 	    allowTrack = False
 	    for i in range (0,len(event.selectedMuons)) :
 		if (i == self.cfg_ana.allowedMuon): break
-		if(deltaR(event.selectedMuons[i].eta(), event.selectedMuons[i].phi(), obj.eta(), obj.phi()) < 0.01) : allowTrack=True
+		if(deltaR(event.selectedMuons[i].eta(), event.selectedMuons[i].phi(), obj.eta(), obj.phi()) < 0.02) : allowTrack=True
 
 	    for i in range (0,len(event.selectedElectrons)) :
 		if (i == self.cfg_ana.allowedElectron): break
-		if(deltaR(event.selectedElectrons[i].eta(), event.selectedElectrons[i].phi(), obj.eta(), obj.phi()) < 0.01) : allowTrack=True
+		if(deltaR(event.selectedElectrons[i].eta(), event.selectedElectrons[i].phi(), obj.eta(), obj.phi()) < 0.02) : allowTrack=True
 
             if not self.idFunc(obj):
                 continue


### PR DESCRIPTION
Added the relevant modules to run_susyAlphaT so it will now run properly.

Corrected the Iso track skimmer matching criteria to use dR<0.02 instead of 0.01 . (In line with what RA1 used on the 8 TeV data)
