### PR TITLE
Added attribute to allow selection of cone isolation for the SOS Analysis needs.

### DIFF
--- a/CMGTools/TTHAnalysis/cfg/run_susySoftlepton_cfg.py
+++ b/CMGTools/TTHAnalysis/cfg/run_susySoftlepton_cfg.py
@@ -36,6 +36,9 @@ ttHLepSkim.ptCuts = [5,3]
 # ttHJetAna.minLepPt = 20 
 ttHJetAna.jetPt = 30.0 
 
+# --- JET-ENERGY-SCALE SYSTEMATICS ---
+ttHJetAna.shiftJEC = 0, # set to +1 or -1 to get +/-1 sigma shifts
+
 # --- JET-MET SKIMMING ---
 #ttHJetMETSkim.jetPtCuts = [100,]
 #ttHJetMETSkim.metCut    = 100
@@ -74,9 +77,9 @@ treeProducer = cfg.Analyzer(
             'SingleMuNonIso' : ["HLT_Mu40_v*"],
             'MetTrigger' : ["HLT_PFMET150_v*"],
             'MetTriggerParked' : ["HLT_MET80_Parked_v*"],
-            'MET_120_HBHENoiseCleaned' : ["MET120_HBHENoiseCleaned*"],
-            'Mono_CentralPFJet80_PFMETNoMu95_NHEF0p95': ["MonoCentralPFJet80_PFMETNoMu95_NHEF0p95*"],
-            'Mono_CentralPFJet80_PFMETnoMu105_NHEF0p95':  ["MonoCentralPFJet80_PFMETnoMu105_NHEF0p95*"]
+            'MET_120_HBHENoiseCleaned' : ["HLT_MET120_HBHENoiseCleaned*"],
+            'Mono_CentralPFJet80_PFMETnoMu95_NHEF0p95': ["HLT_MonoCentralPFJet80_PFMETnoMu95_NHEF0p95*"],
+            'Mono_CentralPFJet80_PFMETnoMu105_NHEF0p95':  ["HLT_MonoCentralPFJet80_PFMETnoMu105_NHEF0p95*"]
         }
     )
 
@@ -89,18 +92,23 @@ from CMGTools.TTHAnalysis.samples.samples_8TeV_v517 import *
 #    mc.triggers = ["HLT_PFMET_150_v*" ]
 
 
-#selectedComponents = [ DY1JetsM50,DY2JetsM50,DY3JetsM50,DY4JetsM50,TTH122,TTH127,TTJetsSem1,TTJetsSem2 ] 
-#selectedComponents = [ T2DegenerateStop_2J_4 ]
+#selectedComponents = [ TTJetsLep ]                                                                                 ->  newTuples000*
+#selectedComponents = [ TbartW,TTH,TtW,TTWJets,TTZJets,WJets_HT250To300,WJets_HT300To400,WJets_HT400ToInf ]         ->  newTuples001*
+#selectedComponents = [ DYJetsM10,DYJetsM50,DY1JetsM50,DY2JetsM50,DY3JetsM50,DY4JetsM50 ]                           ->  newTuples002
+#selectedComponents = [ T2DegenerateStop_2J_1,T2DegenerateStop_2J_2,T2DegenerateStop_2J_3,T2DegenerateStop_2J_4 ]   ->  newTuples003*
+#selectedComponents = [ WJetsPtW50To70,WJetsPtW70To100,WJetsPtW100,WJets,W1Jets,W2Jets,W3Jets,W4Jets ]              ->  newTuples004
+#selectedComponents = [ WW,WZ,ZZ,WWJets,WZJets,ZZJets4L,ZZ2e2mu,ZZ2e2tau,ZZ2mu2tau,ZZTo4mu,ZZTo4tau,ZZTo4e ]        ->  newTuples005
+#selectedComponents = [ TTLep,TTJets,TTJetsSem,TTJetsSem2,TTJetsHad ]                                               ->  newTuples006
+#selectedComponents = [ ZNuNu50HT100,ZNuNu100HT200,ZNuNu200HT400,ZNuNu400 ]                                         ->  newTuples007 the QCDMuPt15 was originaly here but failed and submited as new set 008 with larger split
+#selectedComponents = [ QCDMuPt15 ]                                                                                 ->  newTuples008
 
-#selectedComponents = [ TTJetsLep ]                                                                                 ->  newTuples000
-#selectedComponents = [ TbartW,TTH,TtW,TTWJets,TTZJets,WJets_HT250To300,WJets_HT300To400,WJets_HT400ToInf ]         ->  newTuples001
-selectedComponents = [ DYJetsM10,DYJetsM50,DY1JetsM50,DY2JetsM50,DY3JetsM50,DY4JetsM50 ]
-#selectedComponents = [ T2DegenerateStop_2J_1,T2DegenerateStop_2J_2,T2DegenerateStop_2J_3,T2DegenerateStop_2J_4 ]   ->  newTuples003
+selectedComponents = [ TTJetsLep ]
+
 
 #-------- SEQUENCE
 
 #  ORIGINAL
-sequence = cfg.Sequence(susyCoreSequence+[
+sequence = cfg.Sequence( [ eventSelector ] + susyCoreSequence+[
     ttHEventAna,
     stFilterAna,
     metFilterAna,
@@ -112,26 +120,29 @@ sequence = cfg.Sequence(susyCoreSequence+[
 # 
 # sequence = cfg.Sequence( [ eventSelector ] + susyCoreSequence+[
 #     ttHEventAna,
+#     stFilterAna,
 #     metFilterAna,
 #     treeProducer,
 #     ])
 
 
 #-------- HOW TO RUN
-test = 2
+test = 1
 if test==1:
     # test a single component, using a single thread.
     comp = selectedComponents[0]
-    comp.files = comp.files[:1]         #   Comment-out this line to run interactively / Comment-in to run with lxbatch
-#     comp.files = comp.files[853:854]    #   for debug purposes.
+    comp.files = comp.files[:1]         #   files to run interactively with "multiloop"
     selectedComponents = [comp]
-    comp.splitFactor = 500
+    comp.splitFactor = 1
 elif test==2:    
     # test all components (1 thread per component).
     for comp in selectedComponents:
         comp.splitFactor = 500
-#         comp.files = comp.files[:1]
-
+        comp.files = comp.files[:1]
+elif test==3:    
+    # run all components on lxbatch ( no need to set "comp.files = comp.files[A:B]" in this case ).
+    for comp in selectedComponents:
+        comp.splitFactor = 500
 
 
 config = cfg.Config( components = selectedComponents,

--- a/CMGTools/TTHAnalysis/cfg/run_susySoftlepton_cfg.py
+++ b/CMGTools/TTHAnalysis/cfg/run_susySoftlepton_cfg.py
@@ -15,17 +15,22 @@ from CMGTools.TTHAnalysis.analyzers.susyCore_modules_cff import *
 # --- LEPTON DEFINITION ---
 
 ttHLepAna.loose_muon_pt = 3
-ttHLepAna.loose_muon_dxy = 0.02,
-ttHLepAna.loose_muon_dz = 0.5,
-ttHLepAna.loose_muon_relIso = 0.2
+ttHLepAna.loose_muon_dxy = 0.02
+ttHLepAna.loose_muon_dz = 0.5
+ttHLepAna.loose_muon_relIso = 0.5
 ttHLepAna.loose_muon_absIso = 5
 ttHLepAna.loose_muon_ptIsoThreshold = 25
+ttHLepAna.loose_muon_relIsoCone04 = True            # True -> use cone 0.4 for relIso, False -> use cone 0.3 for relIso (default)
+# ttHLepAna.doMuScleFitCorrections = "rereco"
+
 ttHLepAna.loose_electron_pt = 5
-ttHLepAna.loose_electron_dxy = 0.02,
-ttHLepAna.loose_electron_dz = 0.5,
-ttHLepAna.loose_electron_relIso = 0.2
+ttHLepAna.loose_electron_dxy = 0.02
+ttHLepAna.loose_electron_dz = 0.5
+ttHLepAna.loose_electron_relIso = 0.5
 ttHLepAna.loose_electron_absIso = 5
 ttHLepAna.loose_electron_ptIsoThreshold = 25
+ttHLepAna.loose_electron_relIsoCone04 = True        # True -> use cone 0.4 for relIso, False -> use cone 0.3 for relIso (default)
+
 
 # --- LEPTON SKIMMING ---
 ttHLepSkim.minLeptons = 0
@@ -37,7 +42,7 @@ ttHLepSkim.ptCuts = [5,3]
 ttHJetAna.jetPt = 30.0 
 
 # --- JET-ENERGY-SCALE SYSTEMATICS ---
-ttHJetAna.shiftJEC = 0, # set to +1 or -1 to get +/-1 sigma shifts
+ttHJetAna.shiftJEC = 0 # set to +1 or -1 to get +/-1 sigma shifts
 
 # --- JET-MET SKIMMING ---
 #ttHJetMETSkim.jetPtCuts = [100,]
@@ -92,23 +97,13 @@ from CMGTools.TTHAnalysis.samples.samples_8TeV_v517 import *
 #    mc.triggers = ["HLT_PFMET_150_v*" ]
 
 
-#selectedComponents = [ TTJetsLep ]                                                                                 ->  newTuples000*
-#selectedComponents = [ TbartW,TTH,TtW,TTWJets,TTZJets,WJets_HT250To300,WJets_HT300To400,WJets_HT400ToInf ]         ->  newTuples001*
-#selectedComponents = [ DYJetsM10,DYJetsM50,DY1JetsM50,DY2JetsM50,DY3JetsM50,DY4JetsM50 ]                           ->  newTuples002
-#selectedComponents = [ T2DegenerateStop_2J_1,T2DegenerateStop_2J_2,T2DegenerateStop_2J_3,T2DegenerateStop_2J_4 ]   ->  newTuples003*
-#selectedComponents = [ WJetsPtW50To70,WJetsPtW70To100,WJetsPtW100,WJets,W1Jets,W2Jets,W3Jets,W4Jets ]              ->  newTuples004
-#selectedComponents = [ WW,WZ,ZZ,WWJets,WZJets,ZZJets4L,ZZ2e2mu,ZZ2e2tau,ZZ2mu2tau,ZZTo4mu,ZZTo4tau,ZZTo4e ]        ->  newTuples005
-#selectedComponents = [ TTLep,TTJets,TTJetsSem,TTJetsSem2,TTJetsHad ]                                               ->  newTuples006
-#selectedComponents = [ ZNuNu50HT100,ZNuNu100HT200,ZNuNu200HT400,ZNuNu400 ]                                         ->  newTuples007 the QCDMuPt15 was originaly here but failed and submited as new set 008 with larger split
-#selectedComponents = [ QCDMuPt15 ]                                                                                 ->  newTuples008
-
-selectedComponents = [ TTJetsLep ]
+selectedComponents = [ WWJets ]
 
 
 #-------- SEQUENCE
 
 #  ORIGINAL
-sequence = cfg.Sequence( [ eventSelector ] + susyCoreSequence+[
+sequence = cfg.Sequence(susyCoreSequence+[
     ttHEventAna,
     stFilterAna,
     metFilterAna,

--- a/CMGTools/TTHAnalysis/python/analyzers/ttHLepAnalyzerSusy.py
+++ b/CMGTools/TTHAnalysis/python/analyzers/ttHLepAnalyzerSusy.py
@@ -91,7 +91,7 @@ class ttHLepAnalyzerSusy( Analyzer ):
                 if (mu.muonID(self.cfg_ana.loose_muon_id) and 
                         mu.pt() > self.cfg_ana.loose_muon_pt and abs(mu.eta()) < self.cfg_ana.loose_muon_eta and 
                         abs(mu.dxy()) < self.cfg_ana.loose_muon_dxy and abs(mu.dz()) < self.cfg_ana.loose_muon_dz and
-                        mu.relIso03 < (self.cfg_ana.loose_muon_relIso if (mu.pt() > self.cfg_ana.loose_muon_ptIsoThreshold) else 9e99) and 
+                        (mu.relIso04 if (hasattr(self.cfg_ana,'loose_muon_relIsoCone04') and self.cfg_ana.loose_muon_relIsoCone04) else mu.relIso03) < (self.cfg_ana.loose_muon_relIso if (mu.pt() > self.cfg_ana.loose_muon_ptIsoThreshold) else 9e99) and 
                         mu.absIso03 < ((self.cfg_ana.loose_muon_absIso if hasattr(self.cfg_ana,'loose_muon_absIso') else 9e99) if (mu.pt() < self.cfg_ana.loose_muon_ptIsoThreshold) else 9e99)):
                     mu.looseIdSusy = True
                     if(mu.sourcePtr().isSoftMuon(event.goodVertices[0])):
@@ -120,7 +120,7 @@ class ttHLepAnalyzerSusy( Analyzer ):
                 if (ele.electronID(self.cfg_ana.loose_electron_id) and
                          ele.pt()>self.cfg_ana.loose_electron_pt and abs(ele.eta())<self.cfg_ana.loose_electron_eta and 
                          abs(ele.dxy()) < self.cfg_ana.loose_electron_dxy and abs(ele.dz())<self.cfg_ana.loose_electron_dz and 
-                         ele.relIso03 < (self.cfg_ana.loose_electron_relIso if (ele.pt() > self.cfg_ana.loose_electron_ptIsoThreshold) else 9e99) and 
+                         (ele.relIso04 if (hasattr(self.cfg_ana,'loose_electron_relIsoCone04') and self.cfg_ana.loose_electron_relIsoCone04) else ele.relIso03) < (self.cfg_ana.loose_electron_relIso if (ele.pt() > self.cfg_ana.loose_electron_ptIsoThreshold) else 9e99) and 
                          ele.absIso03 < ((self.cfg_ana.loose_electron_absIso if hasattr(self.cfg_ana,'loose_electron_absIso') else 9e99) if (ele.pt() < self.cfg_ana.loose_electron_ptIsoThreshold) else 9e99) and
                          ele.numberOfHits() <= self.cfg_ana.loose_electron_lostHits and
                          bestMatch(ele, looseMuons)[1] > self.cfg_ana.min_dr_electron_muon ):


### PR DESCRIPTION
Added an option in ttHLepAnalyzerSusy.py to allow the usage of lepton isolation
defined in a cone 0.4 (for the SOS Analysis needs).
This lepton isolation is selected with an attribute defined in the "susySoftlepton_cfg.py"
file. Other users will continue to use the lepton isolation defined in a cone 0.3
