### PR TITLE
Heppy: restore defaultFloatType functionality

### DIFF
--- a/PhysicsTools/Heppy/python/analyzers/core/AutoFillTreeProducer.py
+++ b/PhysicsTools/Heppy/python/analyzers/core/AutoFillTreeProducer.py
@@ -33,8 +33,6 @@ class AutoFillTreeProducer( TreeAnalyzerNumpy ):
 
     def beginLoop(self, setup) :
         super(AutoFillTreeProducer, self).beginLoop(setup)
-        ## Declare how we store floats by default
-        self.tree.setDefaultFloatType("F"); # otherwise it's "D"
 
     def declareHandles(self):
         super(AutoFillTreeProducer, self).declareHandles()

--- a/PhysicsTools/Heppy/python/analyzers/core/TreeAnalyzerNumpy.py
+++ b/PhysicsTools/Heppy/python/analyzers/core/TreeAnalyzerNumpy.py
@@ -29,6 +29,7 @@ class TreeAnalyzerNumpy( Analyzer ):
             print 'Compression', isCompressed
             self.file = TFile( fileName, 'recreate', '', isCompressed )
         self.tree = Tree('tree', self.name)
+        self.tree.setDefaultFloatType(getattr(self.cfg_ana, 'defaultFloatType','D')); # or 'F'
         self.declareVariables(setup)
         
     def declareVariables(self,setup):


### PR DESCRIPTION
People should add in the cfg of their analyzer `defaultFloatType = 'F'` if they want floats, as was the default for TTHAnalysis in 7.0.X

See [e-group thread](https://groups.cern.ch/group/cmg-cmgtools/Lists/Archive/Flat.aspx?RootFolder=%2Fgroup%2Fcmg-cmgtools%2FLists%2FArchive%2Ffeedback%20on%20heppy%20migration%20%28and%20PHYS14%29&FolderCTID=0x01200200966AC7BB9E71BE4482BFF9930DF2EAB1) for more info
