### PR TITLE
Heppy - associated vertex generalization for cases with no good Vertices

### DIFF
--- a/PhysicsTools/Heppy/python/analyzers/objects/IsoTrackAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/IsoTrackAnalyzer.py
@@ -99,7 +99,7 @@ class IsoTrackAnalyzer( Analyzer ):
 
 
 ## ===> Redundant:: require the Track Candidate with a  minimum dz
-            track.associatedVertex = event.goodVertices[0]
+            track.associatedVertex = event.goodVertices[0] if len(event.goodVertices)>0 else event.vertices[0]
 
 ## ===> compute the isolation and find the most isolated track
 

--- a/PhysicsTools/Heppy/python/analyzers/objects/LeptonAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/LeptonAnalyzer.py
@@ -234,7 +234,7 @@ class LeptonAnalyzer( Analyzer ):
           else: raise RuntimeError,  "Unsupported value for mu_effectiveAreas: can only use Data2012 (rho: ?) and Phys14_v1 (rho: fixedGridRhoFastjetAll)"
         # Attach the vertex to them, for dxy/dz calculation
         for mu in allmuons:
-            mu.associatedVertex = event.goodVertices[0]
+            mu.associatedVertex = event.goodVertices[0] if len(event.goodVertices)>0 else event.vertices[0]
 
         # Compute relIso in 0.3 and 0.4 cones
         for mu in allmuons:
@@ -308,7 +308,7 @@ class LeptonAnalyzer( Analyzer ):
 
         # Attach the vertex
         for ele in allelectrons:
-            ele.associatedVertex = event.goodVertices[0]
+            ele.associatedVertex = event.goodVertices[0] if len(event.goodVertices)>0 else event.vertices[0]
 
         # Compute relIso with R=0.3 and R=0.4 cones
         for ele in allelectrons:

--- a/PhysicsTools/Heppy/python/analyzers/objects/TauAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/TauAnalyzer.py
@@ -44,7 +44,7 @@ class TauAnalyzer( Analyzer ):
 
         foundTau = False
         for tau in alltaus:
-            tau.associatedVertex = event.goodVertices[0]
+            tau.associatedVertex = event.goodVertices[0] if len(event.goodVertices)>0 else event.vertices[0]
             tau.lepVeto = False
             tau.idDecayMode = tau.tauID("decayModeFinding")
             tau.idDecayModeNewDMs = tau.tauID("decayModeFindingNewDMs")


### PR DESCRIPTION
fix crashes from lepton/tau/isotrack associated vertex when one chooses the option 'keepFailingEvents=True' in VertexAnalizer
