### PR TITLE
Fix eager download from EOS when processing multiple files per job

### DIFF
--- a/CMGTools/TTHAnalysis/python/tools/EOSEventsWithDownload.py
+++ b/CMGTools/TTHAnalysis/python/tools/EOSEventsWithDownload.py
@@ -44,7 +44,11 @@ class EOSEventsWithDownload(object):
             self.events = None # so it's closed
             if self._localCopy:
                 print "Removing local cache file %s" % self._localCopy
-                os.remove(self._localCopy)
+                try:
+                    os.remove(self._localCopy)
+                except:
+                    pass
+                self._localCopy = None
             for i,(fname,first,last) in enumerate(self._files):
                 if first <= iEv and iEv < last:
                     print "For event range [ %d, %d ) will use file %r " % (first,last,fname)
@@ -65,7 +69,7 @@ class EOSEventsWithDownload(object):
                     print "Will run from "+fname
                     self.events = FWLiteEvents([fname])
                     break
-        self.events.to(iEv)
+        self.events.to(iEv - self._files[self._fileindex][1])
         return self
     def __del__(self):
         todelete = getattr(self,'_localCopy',None)


### PR DESCRIPTION
The module to pre-download files from EOS in order to circumvent Winger latencies had two serious bugs, both affecting jobs processing more than one file:
- almost all events from all files after the first one were duplicates of the last event in that file, since the global index of the event in the job was used in place of the local index of the event in the file
- if the code encountered at any time a sequence of 3 files, the first being remote (that was fetched, downloaded and then deleted), then second being local (which was not fetched), on opening the third file it still tried to delete the temporary copy of the first and aborting since the file was not there anymore

This means that any component which had `comp.splitFactor > len(comp.files)` was being processed incorrectly.
