### PR TITLE
add taus in susyMultilpeton analysis + electron eta SC + extra jet variables for SUSY

### DIFF
--- a/CMGTools/TTHAnalysis/cfg/run_susyMultilepton_cfg.py
+++ b/CMGTools/TTHAnalysis/cfg/run_susyMultilepton_cfg.py
@@ -89,6 +89,10 @@ treeProducer = cfg.Analyzer(
      collections = susyMultilepton_collections,
 )
 
+## and the tau producer
+from PhysicsTools.Heppy.analyzers.objects.TauAnalyzer import TauAnalyzer
+TauAna = TauAnalyzer.defaultConfig
+
 #-------- SAMPLES AND TRIGGERS -----------
 
 #-------- SEQUENCE
@@ -113,6 +117,7 @@ sequence = cfg.Sequence(susyCoreSequence+[
 #for comp in selectedComponents:
 #    comp.splitFactor = 1
 #    comp.fineSplitFactor = 40
+
     
 from PhysicsTools.HeppyCore.framework.heppy import getHeppyOption
 test = getHeppyOption('test')
@@ -164,8 +169,16 @@ elif test == '2lss-sync': # sync
     comp.fineSplitFactor = 10
     selectedComponents = [ comp ]
 
+## output histogram
+from PhysicsTools.HeppyCore.framework.services.tfile import TFileService
+output_service = cfg.Service(
+    TFileService,
+    'outputfile',
+    name="outputfile",
+    fname='tree.root',
+    option='recreate'
+    )    
 
-            
 
 # the following is declared in case this cfg is used in input to the heppy.py script
 from PhysicsTools.HeppyCore.framework.eventsfwlite import Events
@@ -175,5 +188,5 @@ if getHeppyOption("nofetch"):
     event_class = Events 
 config = cfg.Config( components = selectedComponents,
                      sequence = sequence,
-                     services = [],  
+                     services = [output_service],  
                      events_class = event_class)

--- a/CMGTools/TTHAnalysis/python/analyzers/treeProducerSusyMultilepton.py
+++ b/CMGTools/TTHAnalysis/python/analyzers/treeProducerSusyMultilepton.py
@@ -116,7 +116,7 @@ susyMultilepton_collections.update({
             "selectedLeptons" : NTupleCollection("LepGood",  leptonTypeSusyExtra, 8, help="Leptons after the preselection"),
             "otherLeptons"    : NTupleCollection("LepOther", leptonTypeSusyExtra, 8, help="Leptons after the preselection"),
             ##------------------------------------------------
-            "cleanJets"       : NTupleCollection("Jet",     jetTypeSusy, 15, help="Cental jets after full selection and cleaning, sorted by pt"),
+            "cleanJets"       : NTupleCollection("Jet",     jetTypeSusyExtra, 15, help="Cental jets after full selection and cleaning, sorted by pt"),
             "cleanJetsFwd"    : NTupleCollection("JetFwd",  jetTypeSusy,  6, help="Forward jets after full selection and cleaning, sorted by pt"),            
             "fatJets"         : NTupleCollection("FatJet",  fatJetType,  15, help="AK8 jets, sorted by pt"),
             ##------------------------------------------------

--- a/PhysicsTools/Heppy/python/analyzers/objects/autophobj.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/autophobj.py
@@ -94,6 +94,7 @@ leptonTypeExtra = NTupleObjectType("leptonExtra", baseObjectTypes = [ leptonType
     NTupleVariable("dPhiScTrkIn",    lambda x : x.deltaPhiSuperClusterTrackAtVtx() if abs(x.pdgId())==11 else 0, help="Electron deltaPhiSuperClusterTrackAtVtx (without absolute value!)"),
     NTupleVariable("hadronicOverEm", lambda x : x.hadronicOverEm() if abs(x.pdgId())==11 else 0, help="Electron hadronicOverEm"),
     NTupleVariable("eInvMinusPInv",  lambda x : ((1.0/x.ecalEnergy() - x.eSuperClusterOverP()/x.ecalEnergy()) if x.ecalEnergy()>0. else 9e9) if abs(x.pdgId())==11 else 0, help="Electron 1/E - 1/p  (without absolute value!)"),
+    NTupleVariable("etaSc",    lambda x : x.superCluster().eta() if abs(x.pdgId())==11 else -100, help="Electron supercluster pseudorapidity"),
 ])
  
 


### PR DESCRIPTION
This PR adds :
- the full tau analyzer in the susyMultilepton analysis
- the counter histogram in the output file
  -the electron eta supercluster in the additional variables for leptons
- plug per default the jets extra variables for SUSY analyses (useful for jetId and potential handling of noisy jets in data)

(In case it is not the proper procedure for a PR, let me know)
