### PR TITLE
Split samples_13TeV_PHYS14.py into separate samples and triggers files; cleaning of high-level MT2 cfg 

### DIFF
--- a/CMGTools/TTHAnalysis/cfg/run_susyMT2_cfg.py
+++ b/CMGTools/TTHAnalysis/cfg/run_susyMT2_cfg.py
@@ -4,6 +4,10 @@ import PhysicsTools.HeppyCore.framework.config as cfg
 #Load all analyzers
 from CMGTools.TTHAnalysis.analyzers.susyCore_modules_cff import *
 
+#new stuff
+cfg.Analyzer.nosubdir = True 
+
+
 ##------------------------------------------
 ## Redefine what I need
 ##------------------------------------------

--- a/CMGTools/TTHAnalysis/cfg/run_susyMT2_cfg.py
+++ b/CMGTools/TTHAnalysis/cfg/run_susyMT2_cfg.py
@@ -4,7 +4,7 @@ import PhysicsTools.HeppyCore.framework.config as cfg
 #Load all analyzers
 from CMGTools.TTHAnalysis.analyzers.susyCore_modules_cff import *
 
-#new stuff
+# Comment this line if you want the diagnostic folders produced along with the output root file
 cfg.Analyzer.nosubdir = True 
 
 
@@ -112,7 +112,8 @@ ttHZskim = cfg.Analyzer(
 ##  PRODUCER
 ##------------------------------------------
 
-from CMGTools.TTHAnalysis.samples.samples_13TeV_PHYS14 import triggers_HT900, triggers_MET170, triggers_HTMET, triggers_MT2_mumu, triggers_MT2_ee, triggers_MT2_mue, triggers_1mu, triggers_photon155,triggers_1mu_isolow
+from CMGTools.TTHAnalysis.samples.triggers_13TeV_PHYS14 import triggers_HT900, triggers_MET170, triggers_HTMET, triggers_MT2_mumu, triggers_MT2_ee, triggers_MT2_mue, triggers_1mu, triggers_photon155,triggers_1mu_isolow
+
 
 triggerFlagsAna.triggerBits = {
             'HT900' : triggers_HT900,
@@ -156,66 +157,47 @@ sequence = cfg.Sequence(
     treeProducer,
     ])
 
-###---- to switch off the comptrssion
+###---- to switch off the compression
 #treeProducer.isCompressed = 0
 
-#-------- SAMPLES AND TRIGGERS -----------
-#from CMGTools.TTHAnalysis.samples.samples_13TeV_CSA14 import * 
-#from CMGTools.TTHAnalysis.samples.samples_13TeV_CSA14v2 import *
-from CMGTools.TTHAnalysis.samples.samples_13TeV_PHYS14 import *
-
-#selectedComponents = [ SingleMu, DoubleElectron, TTHToWW_PUS14, DYJetsToLL_M50_PU20bx25, TTJets_PUS14 ]
-
-#selectedComponents = [ TTJets_MSDecaysCKM_central_PU_S14_POSTLS170 ]
-#selectedComponents = [ WJetsToLNu_HT100to200_PU_S14_POSTLS170, WJetsToLNu_HT200to400_PU_S14_POSTLS170, WJetsToLNu_HT400to600_PU_S14_POSTLS170, WJetsToLNu_HT600toInf_PU_S14_POSTLS170 ]
-
-#selectedComponents = [ QCD_Pt1000to1400_PU_S14_POSTLS170, QCD_Pt10to15_PU_S14_POSTLS170, QCD_Pt15to30_PU_S14_POSTLS170, QCD_Pt120to170_PU_S14_POSTLS170, QCD_Pt170to300_PU_S14_POSTLS170, QCD_Pt1400to1800_PU_S14_POSTLS170, QCD_Pt1800_PU_S14_POSTLS170, QCD_Pt300to470_PU_S14_POSTLS170, QCD_Pt30to50_PU_S14_POSTLS170, QCD_Pt470to600_PU_S14_POSTLS170, QCD_Pt50to80_PU_S14_POSTLS170, QCD_Pt5to10_PU_S14_POSTLS170, QCD_Pt600to800_PU_S14_POSTLS170, QCD_Pt800to1000_PU_S14_POSTLS170, QCD_Pt80to120_PU_S14_POSTLS170 ]
-
-#selectedComponents = [ DYJets_M50_HT100to200_PU_S14_POSTLS170, DYJets_M50_HT200to400_PU_S14_POSTLS170, DYJets_M50_HT400to600_PU_S14_POSTLS170, DYJets_M50_HT600toInf_PU_S14_POSTLS170 ]
-
-#selectedComponents = [ GJets_HT100to200_PU_S14_POSTLS170, GJets_HT200to400_PU_S14_POSTLS170, GJets_HT400to600_PU_S14_POSTLS170, ZJetsToNuNu_HT200to400_PU_S14_POSTLS170, ZJetsToNuNu_HT400to600_PU_S14_POSTLS170, ZJetsToNuNu_HT600toInf_PU_S14_POSTLS170 ]
-
-#selectedComponents = [ SMS_T1bbbb_2J_mGl1000_mLSP900_PU_S14_POSTLS170, SMS_T1bbbb_2J_mGl1500_mLSP100_PU_S14_POSTLS170, SMS_T1qqqq_2J_mGl1400_mLSP100_PU_S14_POSTLS170, SMS_T1tttt_2J_mGl1200_mLSP800_PU_S14_POSTLS170, SMS_T1tttt_2J_mGl1500_mLSP100_PU_S14_POSTLS170 ]
-
-#selectedComponents = [ DYJetsM50_HT100to200_PU_S14_POSTLS170, DYJetsM50_HT200to400_PU_S14_POSTLS170, DYJetsM50_HT400to600_PU_S14_POSTLS170, DYJetsM50_HT600toInf_PU_S14_POSTLS170, SMS_T1bbbb_2J_mGl1000_mLSP900_PU_S14_POSTLS170, SMS_T1bbbb_2J_mGl1500_mLSP100_PU_S14_POSTLS170, SMS_T1qqqq_2J_mGl1400_mLSP100_PU_S14_POSTLS170, SMS_T1tttt_2J_mGl1200_mLSP800_PU_S14_POSTLS170, SMS_T1tttt_2J_mGl1500_mLSP100_PU_S14_POSTLS170 ]
-
-#selectedComponents = [ GJets_HT600toInf_PU_S14_POSTLS170 ]
-#, ZJetsToNuNu_HT100to200_PU_S14_POSTLS170 ]
-
-##selectedComponents = [ TTJets_PU20bx25 ]
-
-#selectedComponents = [ SMS_T1qqqq_2J_mGl1000_mLSP800_PU_S14_POSTLS170 ]
 
 #-------- HOW TO RUN
 test = 1
-if test==1:
-    # test a single component, using a single thread.
-    #comp=TTJets_PU20bx25 #TTJets_forSynch
-    #comp=SMS_T1qqqq_2J_mGl1400_mLSP100_PU_S14_POSTLS170 # small files for testing
-    #comp=SMS_T1bbbb_2J_mGl1000_mLSP900_PU_S14_POSTLS170
-    #comp=GJets_HT100to200_PU_S14_POSTLS170
-    #comp.files = ['/afs/cern.ch/work/p/pandolf/CMSSW_7_0_6_patch1_2/src/CMGTools/TTHAnalysis/cfg/pickevents.root']
-    #comp.files = ['/afs/cern.ch/user/p/pandolf/public/file_gammaJet.root']
-    #comp.files = ['/afs/cern.ch/work/p/pandolf/CMSSW_7_0_6_patch1_2/src/CMGTools/TTHAnalysis/cfg/file_gammaJet.root']
-    #comp.files = ['/afs/cern.ch/user//m/mmasciov/public/TTJets_forSynch_1.root']
-    ## 50 ns ttbar CSAv1
-    #    comp=TTJets_MSDecaysCKM_central_PU_S14_POSTLS170
-    ## 50 ns ttbar CSAv2
-    #    comp=TTJets
-    ## 25 ns ttbar PHYS14
-#    comp = TTJets
-#    comp.files = comp.files[:1]
-#    comp=TTJets
-#    comp.files = ['/afs/cern.ch/work/d/dalfonso/public/ttjets_miniaodsim_00C90EFC-3074-E411-A845-002590DB9262.root']
-    comp=GJets_HT200to400
-#    comp.files = ['/afs/cern.ch/work/d/dalfonso/public/gjets_ht200to400_miniaodsim_060B8ED3-8571-E411-A2CD-002590D0AFEA.root']
-    comp.files = ['/afs/cern.ch/user/d/dalfonso/public/TESTfilesPHY14/gjets_ht200to400_miniaodsim_fix.root']
-#    comp=DYJetsToLL_M50_PU4bx50
-#    comp.files = comp.files[:1]
+if test==0:
+    # ------------------------------------------------------------------------------------------- #
+    # --- all this lines taken from CMGTools.TTHAnalysis.samples.samples_13TeV_PHYS14 
+    # --- They may not be in synch anymore 
+    from CMGTools.TTHAnalysis.samples.ComponentCreator import ComponentCreator
+    kreator = ComponentCreator()
+    testComponent = kreator.makeMCComponent("testComponent", "/GJets_HT-200to400_Tune4C_13TeV-madgraph-tauola/Phys14DR-PU20bx25_PHYS14_25_V1-v1/MINIAODSIM", "CMS", ".*root",489.9)
+    mcSamples=[testComponent]
 
+    dataDir = os.environ['CMSSW_BASE']+"/src/CMGTools/TTHAnalysis/data"
+    json=dataDir+'/json/Cert_Run2012ABCD_22Jan2013ReReco.json'
+    from CMGTools.TTHAnalysis.setup.Efficiencies import *
+
+    for comp in mcSamples:
+        comp.isMC = True
+        comp.isData = False
+        comp.splitFactor = 250 
+        comp.puFileMC=dataDir+"/puProfile_Summer12_53X.root"
+        comp.puFileData=dataDir+"/puProfile_Data12.root"
+        comp.efficiency = eff2012
+    # ------------------------------------------------------------------------------------------- #
+
+    comp=testComponent
+    comp.files = ['/afs/cern.ch/user/d/dalfonso/public/TESTfilesPHY14/gjets_ht200to400_miniaodsim_fix.root']
+    selectedComponents = [comp]
+    comp.splitFactor = 10
+
+elif test==1:
+    from CMGTools.TTHAnalysis.samples.samples_13TeV_PHYS14 import *
+    comp=GJets_HT200to400
+    comp.files = ['/afs/cern.ch/user/d/dalfonso/public/TESTfilesPHY14/gjets_ht200to400_miniaodsim_fix.root']
     selectedComponents = [comp]
     comp.splitFactor = 10
 elif test==2:
+    from CMGTools.TTHAnalysis.samples.samples_13TeV_PHYS14 import *
     selectedComponents = [ SingleMu, DoubleElectron, TTHToWW_PUS14, DYJetsToLL_M50_PU20bx25, TTJets_PUS14 ]
     # test all components (1 thread per component).
     for comp in selectedComponents:

--- a/CMGTools/TTHAnalysis/cfg/run_susyMT2_cfg.py
+++ b/CMGTools/TTHAnalysis/cfg/run_susyMT2_cfg.py
@@ -162,7 +162,7 @@ sequence = cfg.Sequence(
 
 
 #-------- HOW TO RUN
-test = 1
+test = 0
 if test==0:
     # ------------------------------------------------------------------------------------------- #
     # --- all this lines taken from CMGTools.TTHAnalysis.samples.samples_13TeV_PHYS14 

--- a/CMGTools/TTHAnalysis/python/samples/samples_13TeV_PHYS14.py
+++ b/CMGTools/TTHAnalysis/python/samples/samples_13TeV_PHYS14.py
@@ -2,56 +2,9 @@ import PhysicsTools.HeppyCore.framework.config as cfg
 import os
 
 
+################## Triggers
+from CMGTools.TTHAnalysis.samples.triggers_13TeV_PHYS14 import *
 
-
-################## Triggers (FIXME: update to the PHYS14 Trigger Menu)
-
-
-triggers_mumu_run1   = ["HLT_Mu17_Mu8_v*","HLT_Mu17_TkMu8_v*"]
-triggers_mumu_iso    = [ "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v*", "HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v*" ]
-triggers_mumu_noniso = [ "HLT_Mu30_TkMu11_v*" ]
-triggers_mumu = triggers_mumu_iso + triggers_mumu_noniso
-
-triggers_ee_run1   = ["HLT_Ele17_CaloIdT_TrkIdVL_CaloIsoVL_TrkIsoVL_Ele8_CaloIdT_TrkIdVL_CaloIsoVL_TrkIsoVL_v*",
-                      "HLT_Ele17_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_Ele8_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_v*",
-                      "HLT_Ele15_Ele8_Ele5_CaloIdL_TrkIdVL_v*"]
-triggers_ee = [ "HLT_Ele23_Ele12_CaloId_TrackId_Iso_v*" ]
-triggers_3e = [ "HLT_Ele17_Ele12_Ele10_CaloId_TrackId_v*" ]
-triggers_mue   = [
-    "HLT_Mu23_TrkIsoVVL_Ele12_Gsf_CaloId_TrackId_Iso_MediumWP_v*",
-    "HLT_Mu8_TrkIsoVVL_Ele23_Gsf_CaloId_TrackId_Iso_MediumWP_v*"
-    ]
-
-triggers_multilep  = triggers_mumu + triggers_ee + triggers_3e + triggers_mue
-
-triggers_1mu_iso    = [ 'HLT_IsoMu24_eta2p1_IterTrk02_v*', 'HLT_IsoTkMu24_eta2p1_IterTrk02_v*'  ]
-triggers_1mu_isowid = [ 'HLT_IsoMu24_IterTrk02_v*', 'HLT_IsoTkMu24_IterTrk02_v*'  ]
-triggers_1mu_isolow = [ 'HLT_IsoMu20_eta2p1_IterTrk02_v*', 'HLT_IsoTkMu20_eta2p1_IterTrk02_v*'  ]
-triggers_1mu_noniso = [ 'HLT_Mu40_v*' ]
-triggers_1mu = triggers_1mu_iso  + triggers_1mu_isowid + triggers_1mu_isolow + triggers_1mu_noniso
-
-triggers_1e = [ "HLT_Ele27_eta2p1_WP85_Gsf_v*", "HLT_Ele32_eta2p1_WP85_Gsf_v*" ]
-
-triggersFR_1mu  = [ 'HLT_Mu5_v*', 'HLT_RelIso1p0Mu5_v*', 'HLT_Mu12_v*', 'HLT_Mu24_eta2p1_v*', 'HLT_Mu40_eta2p1_v*' ]
-triggersFR_mumu = [ 'HLT_Mu17_Mu8_v*', 'HLT_Mu17_TkMu8_v*', 'HLT_Mu8_v*', 'HLT_Mu17_v*' ]
-triggersFR_1e   = [ 'HLT_Ele17_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_v*', 'HLT_Ele17_CaloIdL_CaloIsoVL_v*', 'HLT_Ele8_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_v*', 'HLT_Ele8__CaloIdL_CaloIsoVL_v*']
-triggersFR_mue  = triggers_mue[:]
-triggersFR_MC = triggersFR_1mu + triggersFR_mumu + triggersFR_1e + triggersFR_mue
-
-
-
-### ----> for the MT2 analysis
-
-triggers_HT900 = ["HLT_PFHT900_v*"]
-triggers_MET170 = ["HLT_PFMET170_NoiseCleaned_v*"]
-triggers_HTMET = ["HLT_PFHT350_PFMET120_NoiseCleaned_v*"]
-
-triggers_photon155 = ["HLT_Photon155_v*"]
-
-triggers_MT2_mumu = triggers_mumu_iso
-triggers_MT2_ee   = triggers_ee
-
-triggers_MT2_mue = triggers_mue
 
 
 #####COMPONENT CREATOR

--- a/CMGTools/TTHAnalysis/python/samples/triggers_13TeV_PHYS14.py
+++ b/CMGTools/TTHAnalysis/python/samples/triggers_13TeV_PHYS14.py
@@ -1,0 +1,48 @@
+################## Triggers (FIXME: update to the PHYS14 Trigger Menu)
+
+
+triggers_mumu_run1   = ["HLT_Mu17_Mu8_v*","HLT_Mu17_TkMu8_v*"]
+triggers_mumu_iso    = [ "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v*", "HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v*" ]
+triggers_mumu_noniso = [ "HLT_Mu30_TkMu11_v*" ]
+triggers_mumu = triggers_mumu_iso + triggers_mumu_noniso
+
+triggers_ee_run1   = ["HLT_Ele17_CaloIdT_TrkIdVL_CaloIsoVL_TrkIsoVL_Ele8_CaloIdT_TrkIdVL_CaloIsoVL_TrkIsoVL_v*",
+                      "HLT_Ele17_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_Ele8_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_v*",
+                      "HLT_Ele15_Ele8_Ele5_CaloIdL_TrkIdVL_v*"]
+triggers_ee = [ "HLT_Ele23_Ele12_CaloId_TrackId_Iso_v*" ]
+triggers_3e = [ "HLT_Ele17_Ele12_Ele10_CaloId_TrackId_v*" ]
+triggers_mue   = [
+    "HLT_Mu23_TrkIsoVVL_Ele12_Gsf_CaloId_TrackId_Iso_MediumWP_v*",
+    "HLT_Mu8_TrkIsoVVL_Ele23_Gsf_CaloId_TrackId_Iso_MediumWP_v*"
+    ]
+
+triggers_multilep  = triggers_mumu + triggers_ee + triggers_3e + triggers_mue
+
+triggers_1mu_iso    = [ 'HLT_IsoMu24_eta2p1_IterTrk02_v*', 'HLT_IsoTkMu24_eta2p1_IterTrk02_v*'  ]
+triggers_1mu_isowid = [ 'HLT_IsoMu24_IterTrk02_v*', 'HLT_IsoTkMu24_IterTrk02_v*'  ]
+triggers_1mu_isolow = [ 'HLT_IsoMu20_eta2p1_IterTrk02_v*', 'HLT_IsoTkMu20_eta2p1_IterTrk02_v*'  ]
+triggers_1mu_noniso = [ 'HLT_Mu40_v*' ]
+triggers_1mu = triggers_1mu_iso  + triggers_1mu_isowid + triggers_1mu_isolow + triggers_1mu_noniso
+
+triggers_1e = [ "HLT_Ele27_eta2p1_WP85_Gsf_v*", "HLT_Ele32_eta2p1_WP85_Gsf_v*" ]
+
+triggersFR_1mu  = [ 'HLT_Mu5_v*', 'HLT_RelIso1p0Mu5_v*', 'HLT_Mu12_v*', 'HLT_Mu24_eta2p1_v*', 'HLT_Mu40_eta2p1_v*' ]
+triggersFR_mumu = [ 'HLT_Mu17_Mu8_v*', 'HLT_Mu17_TkMu8_v*', 'HLT_Mu8_v*', 'HLT_Mu17_v*' ]
+triggersFR_1e   = [ 'HLT_Ele17_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_v*', 'HLT_Ele17_CaloIdL_CaloIsoVL_v*', 'HLT_Ele8_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_v*', 'HLT_Ele8__CaloIdL_CaloIsoVL_v*']
+triggersFR_mue  = triggers_mue[:]
+triggersFR_MC = triggersFR_1mu + triggersFR_mumu + triggersFR_1e + triggersFR_mue
+
+
+
+### ----> for the MT2 analysis
+
+triggers_HT900 = ["HLT_PFHT900_v*"]
+triggers_MET170 = ["HLT_PFMET170_NoiseCleaned_v*"]
+triggers_HTMET = ["HLT_PFHT350_PFMET120_NoiseCleaned_v*"]
+
+triggers_photon155 = ["HLT_Photon155_v*"]
+
+triggers_MT2_mumu = triggers_mumu_iso
+triggers_MT2_ee   = triggers_ee
+
+triggers_MT2_mue = triggers_mue


### PR DESCRIPTION
- Trigger definitions are moved from samples_13TeV_PHYS14.py into a new and separate triggers_13TeV_PHYS14.py file
- samples_13TeV_PHYS14.py now imports the new trigger file, therefore nothing change for users loading samples_13TeV_PHYS14.py file as before.
- internal cleaning to the high-level MT2 cfg file (transparent to everybody else)
