### PR TITLE
little changes to DEFAULT SUSY LEP ANALYZER configuration

### DIFF
--- a/CMGTools/TTHAnalysis/python/analyzers/susyCore_modules_cff.py
+++ b/CMGTools/TTHAnalysis/python/analyzers/susyCore_modules_cff.py
@@ -160,7 +160,7 @@ lepAna = cfg.Analyzer(
     # loose electron selection
     loose_electron_id     = "POG_Cuts_ID_2012_Veto_full5x5",
     loose_electron_pt     = 7,
-    loose_electron_eta    = 2.4,
+    loose_electron_eta    = 2.5,
     loose_electron_dxy    = 0.05,
     loose_electron_dz     = 0.1,
     loose_electron_relIso = 0.5,
@@ -178,7 +178,7 @@ lepAna = cfg.Analyzer(
     miniIsolationPUCorr = 'rhoArea', # Allowed options: 'rhoArea' (EAs for 03 cone scaled by R^2), 'deltaBeta', 'raw' (uncorrected), 'weights' (delta beta weights; not validated)
     miniIsolationVetoLeptons = None, # use 'inclusive' to veto inclusive leptons and their footprint in all isolation cones
     # minimum deltaR between a loose electron and a loose muon (on overlaps, discard the electron)
-    min_dr_electron_muon = 0.02,
+    min_dr_electron_muon = 0.05,
     # do MC matching 
     do_mc_match = True, # note: it will in any case try it only on MC, not on data
     match_inclusiveLeptons = False, # match to all inclusive leptons


### PR DESCRIPTION
these pull request contains two little changes to the default lepAnalyzer configuration in sysyCore. the electron pseudorapidity acceptance cut is now 2.5 (no reasons to cut at 2.4) and the muon-electron cross cleaning (with muon priority) uses a dR cone of 0.05. this cut value is the one chosen by the HZZ4l group. dR =0.02 was not supported by any study.
