### PR TITLE
HeppyCore looper: fix sub-file splitting boundaries

### DIFF
--- a/PhysicsTools/HeppyCore/python/framework/looper.py
+++ b/PhysicsTools/HeppyCore/python/framework/looper.py
@@ -104,7 +104,9 @@ class Looper(object):
                 totevents = min(len(self.events),int(nEvents)) if (nEvents and int(nEvents) not in [-1,0]) else len(self.events)
                 self.nEvents = int(ceil(totevents/float(fineSplitFactor)))
                 self.firstEvent = firstEvent + fineSplitIndex * self.nEvents
-                #print "For component %s will process %d events starting from the %d one" % (self.cfg_comp.name, self.nEvents, self.firstEvent)
+                if self.firstEvent + self.nEvents >= totevents:
+                    self.nEvents = totevents - self.firstEvent 
+                #print "For component %s will process %d events starting from the %d one, ending at %d excluded" % (self.cfg_comp.name, self.nEvents, self.firstEvent, self.nEvents + self.firstEvent)
         # self.event is set in self.process
         self.event = None
         services = dict()


### PR DESCRIPTION
When running with `fineSplitFactor > 1`, i.e. with more than one job per file, the looper was trying to process more events than there were in the file, possibly result in a few events at the end of the job being duplicated, or in a crash when using the code to pre-download files from EOS.
