### PR TITLE
More gen jet options and matched gen info for leptons and photons

### DIFF
--- a/CMGTools/TTHAnalysis/python/analyzers/susyCore_modules_cff.py
+++ b/CMGTools/TTHAnalysis/python/analyzers/susyCore_modules_cff.py
@@ -272,6 +272,7 @@ jetAna = cfg.Analyzer(
     cleanJetsFromTaus = False,
     cleanJetsFromIsoTracks = False,
     doQG = False,
+    cleanGenJetsFromPhoton = False
     )
 
 ## Fat Jets Analyzer (generic)

--- a/CMGTools/TTHAnalysis/python/analyzers/susyCore_modules_cff.py
+++ b/CMGTools/TTHAnalysis/python/analyzers/susyCore_modules_cff.py
@@ -323,6 +323,8 @@ from CMGTools.TTHAnalysis.analyzers.ttHCoreEventAnalyzer import ttHCoreEventAnal
 ttHCoreEventAna = cfg.Analyzer(
     ttHCoreEventAnalyzer, name='ttHCoreEventAnalyzer',
     maxLeps = 4, ## leptons to consider
+    mhtForBiasedDPhi = "mhtJet40jvec",
+    jetForBiasedDPhi = "cleanJets",
     )
 
 ## Jet-MET based Skim (generic, but requirements depend on the final state)

--- a/CMGTools/TTHAnalysis/python/analyzers/ttHAlphaTVarAnalyzer.py
+++ b/CMGTools/TTHAnalysis/python/analyzers/ttHAlphaTVarAnalyzer.py
@@ -22,7 +22,7 @@ from PhysicsTools.Heppy.analyzers.core.AutoHandle import AutoHandle
 from PhysicsTools.Heppy.physicsobjects.PhysicsObjects import Jet
 
 import ROOT
-from ROOT import AlphaT
+from ROOT.heppy import AlphaT
 
 
 import os
@@ -44,31 +44,31 @@ class ttHAlphaTVarAnalyzer( Analyzer ):
 
 
     # Calculate alphaT using jet ET
-    def makeAlphaT(self, event):
+    def makeAlphaT(self, jets):
 
-        if len(event.cleanJets) == 0:
-            event.alphaT = 0
-            return
+        if len(jets) == 0:
+            return 0.
         
         px  = ROOT.std.vector('double')()
         py  = ROOT.std.vector('double')()
         et  = ROOT.std.vector('double')()
-#Make alphaT from lead 10 jets
-	for jet in event.cleanJets[:10]:
+
+        #Make alphaT from lead 10 jets
+	for jet in jets[:10]:
             px.push_back(jet.px())
             py.push_back(jet.py())
             et.push_back(jet.et())
-            pass
 
         alphaTCalc   = AlphaT()
-        event.alphaT = alphaTCalc.getAlphaT( et, px, py )
-
-        return
+        return alphaTCalc.getAlphaT( et, px, py )
 
     def process(self, event):
         self.readCollections( event.input )
 
-        event.alphaT = -999
-        self.makeAlphaT(event)
+        event.alphaT = self.makeAlphaT(event.cleanJets)
+
+        #Do the same with gen jets for MC
+        if self.cfg_comp.isMC:
+            event.genAlphaT = self.makeAlphaT(event.cleanGenJets)
 
         return True

--- a/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
@@ -183,6 +183,10 @@ class JetAnalyzer( Analyzer ):
                     event.deltaMetFromJetSmearing[1] += j.deltaMetFromJetSmearing[1]
             event.cleanGenJets = cleanNearestJetOnly(event.genJets, leptons, self.jetLepDR)
             
+            if self.cfg_ana.cleanGenJetsFromPhoton:
+                event.cleanGenJets = cleanNearestJetOnly(event.cleanGenJets, photons, self.jetLepDR)
+
+            
             #event.nGenJets25 = 0
             #event.nGenJets25Cen = 0
             #event.nGenJets25Fwd = 0
@@ -372,6 +376,7 @@ setattr(JetAnalyzer,"defaultConfig", cfg.Analyzer(
     cleanJetsFromFirstPhoton = False,
     cleanJetsFromTaus = False,
     cleanJetsFromIsoTracks = False,
-    jecPath = ""
+    jecPath = "",
+    cleanGenJetsFromPhoton = False
     )
 )

--- a/PhysicsTools/Heppy/python/analyzers/objects/LeptonAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/LeptonAnalyzer.py
@@ -390,6 +390,7 @@ class LeptonAnalyzer( Analyzer ):
             gen = match[lep]
             lep.mcMatchId  = (gen.sourceId if gen != None else  0)
             lep.mcMatchTau = (gen in event.gentauleps if gen else -99)
+            lep.mcLep=gen
 
     def isFromB(self,particle,bid=5, done={}):
         for i in xrange( particle.numberOfMothers() ): 

--- a/PhysicsTools/Heppy/python/analyzers/objects/PhotonAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/PhotonAnalyzer.py
@@ -111,6 +111,7 @@ class PhotonAnalyzer( Analyzer ):
         packedGenParts = [ p for p in self.mchandles['packedGen'].product() if abs(p.eta()) < 3.1 ]
         for gamma in event.allphotons:
           gen = match[gamma]
+          gamma.mcGamma = gen
           if gen and gen.pt()>=0.5*gamma.pt() and gen.pt()<=2.*gamma.pt():
             gamma.mcMatchId = 22
             sumPt = 0.;

--- a/PhysicsTools/Heppy/python/analyzers/objects/autophobj.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/autophobj.py
@@ -59,6 +59,7 @@ leptonType = NTupleObjectType("lepton", baseObjectTypes = [ particleType ], vari
     NTupleVariable("mcMatchId",  lambda x : x.mcMatchId, int, mcOnly=True, help="Match to source from hard scatter (pdgId of heaviest particle in chain, 25 for H, 6 for t, 23/24 for W/Z), zero if non-prompt or fake"),
     NTupleVariable("mcMatchAny", lambda x : x.mcMatchAny, int, mcOnly=True, help="Match to any final state leptons: 0 if unmatched, 1 if light flavour (including prompt), 4 if charm, 5 if bottom"),
     NTupleVariable("mcMatchTau", lambda x : x.mcMatchTau, int, mcOnly=True, help="True if the leptons comes from a tau"),
+    NTupleVariable("mcPt",   lambda x : x.mcLep.pt() if getattr(x,"mcLep",None) else 0., mcOnly=True, help="p_{T} of associated gen lepton"),
 ])
 
 ### EXTENDED VERSION WITH INDIVIUAL DISCRIMINATING VARIABLES
@@ -147,6 +148,7 @@ photonType = NTupleObjectType("gamma", baseObjectTypes = [ particleType ], varia
     NTupleVariable("neuHadIso",  lambda x : x.recoNeutralHadronIso(), float, help="neutralHadronIsolation for photons"),
     NTupleVariable("phIso",  lambda x : x.recoPhotonIso(), float, help="gammaIsolation for photons"),
     NTupleVariable("mcMatchId",  lambda x : x.mcMatchId, int, mcOnly=True, help="Match to source from hard scatter (pdgId of heaviest particle in chain, 25 for H, 6 for t, 23/24 for W/Z), zero if non-prompt or fake"),
+    NTupleVariable("mcPt",   lambda x : x.mcGamma.pt() if getattr(x,"mcGamma",None) else 0., mcOnly=True, help="p_{T} of associated gen photon"),
 ])
 
 ##------------------------------------------  


### PR DESCRIPTION
Added option to Jet Analyzer that allows gen jets to be cleaned from reco photons.

Added matched mcPt information into the tree for leptons and photons in a way analogous to jets.

Fixed problem with the alphaT variable analyzer after the RootTools cleanup

Make HT, MHT and alphaT from gen jets as well.
