### PR TITLE
bugfix in MultiChainEvent

### DIFF
--- a/DataFormats/FWLite/src/MultiChainEvent.cc
+++ b/DataFormats/FWLite/src/MultiChainEvent.cc
@@ -367,9 +367,6 @@ edm::WrapperBase const* MultiChainEvent::getByProductID(edm::ProductID const&iID
   if (edp == nullptr) {
     (const_cast<MultiChainEvent*>(this))->toSec(event1_->id());
     edp = event2_->getByProductID(iID);
-    if (edp == nullptr) {
-      throw cms::Exception("ProductNotFound") << "Cannot find product " << iID;
-    }
   }
   return edp;
 }


### PR DESCRIPTION
Fix bug when running with CMSSW pre-processor (that uses secondaryFileNames) and using  code checking references (e.g. the IsolationComputer)
- pull request to CMSSW: https://github.com/cms-sw/cmssw/pull/8423
- [e-group thread](https://groups.cern.ch/group/cmg-cmgtools/Lists/Archive/Flat.aspx?RootFolder=%2Fgroup%2Fcmg-cmgtools%2FLists%2FArchive%2Fcmg%20preprocessor%20step&FolderCTID=0x01200200966AC7BB9E71BE4482BFF9930DF2EAB1)

Note: to benefit from this you need to add `/DataFormats/FWLite/` to your `.git/info/sparse-checkout`, tell git to check it out with `git read-tree -mu HEAD` and then compile that package.
