### PR TITLE
Heppy: cherry pick for heppy developments about photon isolation and randomCone code

### DIFF
--- a/PhysicsTools/Heppy/python/analyzers/objects/PhotonAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/PhotonAnalyzer.py
@@ -30,9 +30,11 @@ class PhotonAnalyzer( Analyzer ):
     # DECLARATION OF HANDLES OF PHOTONS STUFF                                                                                                                                   
     #----------------------------------------     
 
-        #photons
         self.handles['photons'] = AutoHandle( self.cfg_ana.photons,'std::vector<pat::Photon>')
         self.mchandles['packedGen'] = AutoHandle( 'packedGenParticles', 'std::vector<pat::PackedGenParticle>' )
+        self.handles['packedCandidates'] = AutoHandle( 'packedPFCandidates', 'std::vector<pat::PackedCandidate>')
+        self.handles['jets'] = AutoHandle( "slimmedJets", 'std::vector<pat::Jet>' )
+
 
     def beginLoop(self, setup):
         super(PhotonAnalyzer,self).beginLoop(setup)
@@ -113,35 +115,126 @@ class PhotonAnalyzer( Analyzer ):
           gen = match[gamma]
           if gen and gen.pt()>=0.5*gamma.pt() and gen.pt()<=2.*gamma.pt():
             gamma.mcMatchId = 22
-            sumPt = 0.;
+            sumPt03 = 0.;
+            sumPt04 = 0.;
             for part in packedGenParts:
               if abs(part.pdgId())==12: continue # exclude neutrinos
               if abs(part.pdgId())==14: continue
               if abs(part.pdgId())==16: continue
               if abs(part.pdgId())==18: continue
-              if deltaR(gen.eta(), gen.phi(), part.eta(), part.phi()) > 0.4: continue
-              sumPt += part.pt()
-            sumPt -= gen.pt()
-            if sumPt<0. : sumPt=0.
-            gamma.genIso = sumPt
+              deltar = deltaR(gen.eta(), gen.phi(), part.eta(), part.phi())
+              if deltar <= 0.3:
+                sumPt03 += part.pt()
+              if deltar <= 0.4:
+                sumPt04 += part.pt()
+            sumPt03 -= gen.pt()
+            sumPt04 -= gen.pt()
+            if sumPt03<0. : sumPt03=0.
+            if sumPt04<0. : sumPt04=0.
+            gamma.genIso03 = sumPt03
+            gamma.genIso04 = sumPt04
           else:
             genNoMom = matchNoMom[gamma]
             if genNoMom:
               gamma.mcMatchId = 7
-              sumPt = 0.;
+              sumPt03 = 0.;
+              sumPt04 = 0.;
               for part in packedGenParts:
                 if abs(part.pdgId())==12: continue # exclude neutrinos
                 if abs(part.pdgId())==14: continue
                 if abs(part.pdgId())==16: continue
                 if abs(part.pdgId())==18: continue
-                if deltaR(genNoMom.eta(), genNoMom.phi(), part.eta(), part.phi()) > 0.4: continue
-                sumPt += part.pt()
-              sumPt -= genNoMom.pt()
-              if sumPt<0. : sumPt=0.
-              gamma.genIso = sumPt
+                deltar = deltaR(genNoMom.eta(), genNoMom.phi(), part.eta(), part.phi());
+                if deltar <= 0.3:
+                  sumPt03 += part.pt()
+                if deltar <= 0.4:
+                  sumPt04 += part.pt()
+              sumPt03 -= genNoMom.pt()
+              sumPt04 -= genNoMom.pt()
+              if sumPt03<0. : sumPt03=0.
+              if sumPt04<0. : sumPt04=0.
+              gamma.genIso03 = sumPt03
+              gamma.genIso04 = sumPt04
             else:
               gamma.mcMatchId = 0
-              gamma.genIso = -1.
+              gamma.genIso03 = -1.
+              gamma.genIso04 = -1.
+
+
+
+
+
+    def checkMatch( self, eta, phi, particles, deltar ):
+
+      for part in particles:
+        if deltaR(eta, phi, part.eta(), part.phi()) < deltar:
+          return True
+
+      return False
+
+
+
+
+
+    def computeRandomCone( self, event, eta, phi, deltarmax, charged, jets, photons ):
+
+      if self.checkMatch( eta, phi, jets, 2.*deltarmax ): 
+        return -1.
+    
+      if self.checkMatch( eta, phi, photons, 2.*deltarmax ): 
+        return -1.
+    
+      if self.checkMatch( eta, phi, event.selectedLeptons, deltarmax ): 
+        return -1.
+
+      iso = 0.
+
+      for part in charged:
+        if deltaR(eta, phi, part.eta(), part.phi()) > deltarmax : continue
+        #if deltaR(eta, phi, part.eta(), part.phi()) < 0.02: continue
+        iso += part.pt()
+
+      return iso
+
+
+
+
+            
+
+    def randomCone( self, event ):
+
+        patcands  = self.handles['packedCandidates'].product()
+        jets  = self.handles['jets'].product()
+
+        charged   = [ p for p in patcands if ( p.charge() != 0 and abs(p.pdgId())>20 and abs(p.dz())<=0.1 and p.fromPV()>1 and p.trackHighPurity() ) ]
+        photons10 = [ p for p in patcands if ( p.pdgId() == 22 and p.pt()>10. ) ]
+        jets20 = [ j for j in jets if j.pt() > 20 and abs(j.eta())<2.5 ]
+
+        for gamma in event.allphotons:
+
+          etaPhot = gamma.eta()
+          phiPhot = gamma.eta()
+          pi = 3.14159
+          phiRC = phiPhot + 0.5*pi
+          while phiRC>pi:
+            phiRC -= 2.*pi
+
+          gamma.chHadIsoRC03 = self.computeRandomCone( event, etaPhot, phiRC, 0.3, charged, jets20, photons10 )
+          gamma.chHadIsoRC   = self.computeRandomCone( event, etaPhot, phiRC, 0.4, charged, jets20, photons10 )
+
+          if gamma.chHadIsoRC>=0. : continue #good to go
+
+          #if not, try other side:
+          phiRC = phiPhot - 0.5*pi
+          while phiRC<-pi:
+            phiRC += 2.*pi
+
+          gamma.chHadIsoRC03 = self.computeRandomCone( event, etaPhot, phiRC, 0.3, charged, jets20, photons10 )
+          gamma.chHadIsoRC   = self.computeRandomCone( event, etaPhot, phiRC, 0.4, charged, jets20, photons10 )
+
+
+
+
 
     def printInfo(self, event):
         print '----------------'
@@ -165,11 +258,15 @@ class PhotonAnalyzer( Analyzer ):
         self.makePhotons(event)
 #        self.printInfo(event)   
 
+        if self.cfg_ana.do_randomCone:
+            self.randomCone(event)
+
         if not self.cfg_comp.isMC:
             return True
 
         if self.cfg_ana.do_mc_match and hasattr(event, 'genParticles'):
             self.matchPhotons(event)
+
 
         return True
 
@@ -181,5 +278,6 @@ setattr(PhotonAnalyzer,"defaultConfig",cfg.Analyzer(
     etaMax = 2.5,
     gammaID = "PhotonCutBasedIDLoose",
     do_mc_match = True,
+    do_randomCone = False,
   )
 )

--- a/PhysicsTools/Heppy/python/analyzers/objects/PhotonAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/PhotonAnalyzer.py
@@ -220,7 +220,7 @@ class PhotonAnalyzer( Analyzer ):
             phiRC -= 2.*pi
 
           gamma.chHadIsoRC03 = self.computeRandomCone( event, etaPhot, phiRC, 0.3, charged, jets20, photons10 )
-          gamma.chHadIsoRC   = self.computeRandomCone( event, etaPhot, phiRC, 0.4, charged, jets20, photons10 )
+          gamma.chHadIsoRC04 = self.computeRandomCone( event, etaPhot, phiRC, 0.4, charged, jets20, photons10 )
 
           if gamma.chHadIsoRC>=0. : continue #good to go
 

--- a/PhysicsTools/Heppy/python/analyzers/objects/PhotonAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/PhotonAnalyzer.py
@@ -222,16 +222,13 @@ class PhotonAnalyzer( Analyzer ):
           gamma.chHadIsoRC03 = self.computeRandomCone( event, etaPhot, phiRC, 0.3, charged, jets20, photons10 )
           gamma.chHadIsoRC04 = self.computeRandomCone( event, etaPhot, phiRC, 0.4, charged, jets20, photons10 )
 
-          if gamma.chHadIsoRC>=0. : continue #good to go
-
-          #if not, try other side:
+          #try other side
           phiRC = phiPhot - 0.5*pi
           while phiRC<-pi:
             phiRC += 2.*pi
 
-          gamma.chHadIsoRC03 = self.computeRandomCone( event, etaPhot, phiRC, 0.3, charged, jets20, photons10 )
-          gamma.chHadIsoRC   = self.computeRandomCone( event, etaPhot, phiRC, 0.4, charged, jets20, photons10 )
-
+          if gamma.chHadIsoRC03<0. : gamma.chHadIsoRC03 = self.computeRandomCone( event, etaPhot, phiRC, 0.3, charged, jets20, photons10 )
+          if gamma.chHadIsoRC04<0. : gamma.chHadIsoRC04 = self.computeRandomCone( event, etaPhot, phiRC, 0.4, charged, jets20, photons10 )  
 
 
 

--- a/PhysicsTools/Heppy/python/analyzers/objects/autophobj.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/autophobj.py
@@ -94,6 +94,7 @@ leptonTypeExtra = NTupleObjectType("leptonExtra", baseObjectTypes = [ leptonType
     NTupleVariable("dPhiScTrkIn",    lambda x : x.deltaPhiSuperClusterTrackAtVtx() if abs(x.pdgId())==11 else 0, help="Electron deltaPhiSuperClusterTrackAtVtx (without absolute value!)"),
     NTupleVariable("hadronicOverEm", lambda x : x.hadronicOverEm() if abs(x.pdgId())==11 else 0, help="Electron hadronicOverEm"),
     NTupleVariable("eInvMinusPInv",  lambda x : ((1.0/x.ecalEnergy() - x.eSuperClusterOverP()/x.ecalEnergy()) if x.ecalEnergy()>0. else 9e9) if abs(x.pdgId())==11 else 0, help="Electron 1/E - 1/p  (without absolute value!)"),
+    NTupleVariable("etaSc", lambda x : x.superCluster().eta() if abs(x.pdgId())==11 else -100, help="Electron supercluster pseudorapidity"),
 ])
  
 

--- a/PhysicsTools/Heppy/python/analyzers/objects/autophobj.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/autophobj.py
@@ -94,7 +94,6 @@ leptonTypeExtra = NTupleObjectType("leptonExtra", baseObjectTypes = [ leptonType
     NTupleVariable("dPhiScTrkIn",    lambda x : x.deltaPhiSuperClusterTrackAtVtx() if abs(x.pdgId())==11 else 0, help="Electron deltaPhiSuperClusterTrackAtVtx (without absolute value!)"),
     NTupleVariable("hadronicOverEm", lambda x : x.hadronicOverEm() if abs(x.pdgId())==11 else 0, help="Electron hadronicOverEm"),
     NTupleVariable("eInvMinusPInv",  lambda x : ((1.0/x.ecalEnergy() - x.eSuperClusterOverP()/x.ecalEnergy()) if x.ecalEnergy()>0. else 9e9) if abs(x.pdgId())==11 else 0, help="Electron 1/E - 1/p  (without absolute value!)"),
-    NTupleVariable("etaSc", lambda x : x.superCluster().eta() if abs(x.pdgId())==11 else -100, help="Electron supercluster pseudorapidity"),
 ])
  
 
@@ -143,7 +142,8 @@ photonType = NTupleObjectType("gamma", baseObjectTypes = [ particleType ], varia
     #NTupleVariable("chHadIso",  lambda x : x.chargedHadronIso(), float, help="chargedHadronIsolation for photons"),
     #NTupleVariable("neuHadIso",  lambda x : x.neutralHadronIso(), float, help="neutralHadronIsolation for photons"),
     #NTupleVariable("phIso",  lambda x : x.photonIso(), float, help="gammaIsolation for photons"),
-    NTupleVariable("chHadIso",  lambda x : x.recoChargedHadronIso(), float, help="chargedHadronIsolation for photons"),
+    NTupleVariable("chHadIso",  lambda x : x.recoChargedHadronIso(), float, help="chargedHadronIsolation for photons (reco::Photon method, deltaR = 0.3)"),
+    NTupleVariable("chHadIso04",  lambda x : x.chargedHadronIso(), float, help="chargedHadronIsolation for photons (PAT method, deltaR = 0.4)"),
     NTupleVariable("neuHadIso",  lambda x : x.recoNeutralHadronIso(), float, help="neutralHadronIsolation for photons"),
     NTupleVariable("phIso",  lambda x : x.recoPhotonIso(), float, help="gammaIsolation for photons"),
     NTupleVariable("mcMatchId",  lambda x : x.mcMatchId, int, mcOnly=True, help="Match to source from hard scatter (pdgId of heaviest particle in chain, 25 for H, 6 for t, 23/24 for W/Z), zero if non-prompt or fake"),

--- a/PhysicsTools/Heppy/python/physicsobjects/Photon.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Photon.py
@@ -37,7 +37,7 @@ class Photon(PhysicsObject ):
         keepThisPhoton = True
         if name == "PhotonCutBasedIDLoose_CSA14":
             if abs(self.physObj.eta())<1.479 :
-                if self.full5x5_sigmaIetaIeta() > 0.012 : keepThisPhoton = False
+                if self.full5x5_sigmaIetaIeta() > 0.015 : keepThisPhoton = False
                 if self.hOVERe() > 0.0559       : keepThisPhoton = False
             else :
                 if self.full5x5_sigmaIetaIeta() > 0.035 : keepThisPhoton = False


### PR DESCRIPTION
- implemented randomCone charged isolation for photons
- now saving photon charged isolation both with deltaR 0.3 and 0.4
- now saving photon gen iso both with deltaR 0.3 and 0.4

This pull request needs to be coupled with another one adapting the code on the cmgTools side

@pandolf: 
Can you also comment on the reason of the following two changes?
- NTupleVariable("etaSc", lambda x : x.superCluster().eta() if abs(x.pdgId())==11 else -100, help="Electron supercluster pseudorapidity"),
- if self.full5x5_sigmaIetaIeta() > 0.012 : keepThisPhoton = False
- if self.full5x5_sigmaIetaIeta() > 0.015 : keepThisPhoton = False
