### PR TITLE
H->ZZ->4l analysis (and a couple of small Heppy improvements)

### DIFF
--- a/CMGTools/HToZZ4L/cfg/run_hzz4l_cfg.py
+++ b/CMGTools/HToZZ4L/cfg/run_hzz4l_cfg.py
@@ -1,0 +1,38 @@
+##########################################################
+##       CONFIGURATION FOR HZZ4L TREES                  ##
+##########################################################
+import PhysicsTools.HeppyCore.framework.config as cfg
+
+#Load all analyzers
+from CMGTools.HToZZ4L.analyzers.hzz4lCore_modules_cff import * 
+
+
+#-------- SAMPLES AND TRIGGERS -----------
+
+#-------- SEQUENCE
+from CMGTools.HToZZ4L.samples.samples_13TeV_PHYS14 import *
+
+selectedComponents = []
+sequence = cfg.Sequence(hzz4lCoreSequence)
+
+
+    
+test = 1
+if test == 1:
+    comp = GGHZZ4L
+    comp.files = comp.files[:1]
+    comp.files = [ 'root://eoscms//eos/cms/store/mc/Phys14DR/GluGluToHToZZTo4L_M-125_13TeV-powheg-pythia6/MINIAODSIM/PU20bx25_tsg_PHYS14_25_V1-v1/00000/3295EF7C-2070-E411-89C4-7845C4FC35DB.root ' ]
+    comp.splitFactor = 1
+    comp.fineSplitFactor = 1
+    selectedComponents = [ comp ]
+
+
+
+# the following is declared in case this cfg is used in input to the heppy.py script
+from PhysicsTools.HeppyCore.framework.eventsfwlite import Events
+config = cfg.Config( components = selectedComponents,
+                     sequence = sequence,
+                     services = [],  
+                     events_class = Events)
+
+

--- a/CMGTools/HToZZ4L/cfg/run_hzz4l_cfg.py
+++ b/CMGTools/HToZZ4L/cfg/run_hzz4l_cfg.py
@@ -15,17 +15,31 @@ from CMGTools.HToZZ4L.samples.samples_13TeV_PHYS14 import *
 selectedComponents = []
 sequence = cfg.Sequence(hzz4lCoreSequence)
 
+for comp in mcSamples:
+    comp.triggers = triggers_multilep
+    comp.vetoTriggers = []
 
-    
-test = 1
-if test == 1:
+from PhysicsTools.HeppyCore.framework.heppy import getHeppyOption
+test = getHeppyOption('test')
+if test == "1":
     comp = GGHZZ4L
-    comp.files = comp.files[:1]
+    comp.files = [ 'root://eoscms//eos/cms/store/mc/Phys14DR/GluGluToHToZZTo4L_M-125_13TeV-powheg-pythia6/MINIAODSIM/PU20bx25_tsg_PHYS14_25_V1-v1/00000/3295EF7C-2070-E411-89C4-7845C4FC35DB.root ' ]
+    comp.splitFactor = 1
+    comp.fineSplitFactor = 1 if getHeppyOption('single') else 5
+    selectedComponents = [ comp ]
+elif test == '2':
+    for comp in selectedComponents:
+        comp.files = comp.files[:1]
+        comp.splitFactor = 1
+        comp.fineSplitFactor = 1
+elif test == 'Debug':
+    comp = GGHZZ4L
     comp.files = [ 'root://eoscms//eos/cms/store/mc/Phys14DR/GluGluToHToZZTo4L_M-125_13TeV-powheg-pythia6/MINIAODSIM/PU20bx25_tsg_PHYS14_25_V1-v1/00000/3295EF7C-2070-E411-89C4-7845C4FC35DB.root ' ]
     comp.splitFactor = 1
     comp.fineSplitFactor = 1
     selectedComponents = [ comp ]
-
+    eventSelector.toSelect = [ (1,1,2), (1,1,53), (1,1,69), (1,1,75), (1,1,79) ] 
+    sequence = cfg.Sequence([eventSelector] + hzz4lCoreSequence)
 
 
 # the following is declared in case this cfg is used in input to the heppy.py script

--- a/CMGTools/HToZZ4L/python/analyzers/FSRPhotonMaker.py
+++ b/CMGTools/HToZZ4L/python/analyzers/FSRPhotonMaker.py
@@ -56,10 +56,11 @@ class FSRPhotonMaker( Analyzer ):
                     break;
         isolatedPhotons=[]        
         for g in forIso:
-            g.absIsoCH = self.IsolationComputer.chargedAbsIso(g.physObj,0.3,0,0.2)
-            g.absIsoPU = self.IsolationComputer.puAbsIso(g.physObj,0.3,0,0.2)
-            g.absIsoNH = self.IsolationComputer.neutralAbsIsoRaw(g.physObj,0.3,0,0.5)
-            g.relIso   = (g.absIsoCH+g.absIsoPU+g.absIsoNH)/g.pt()
+            g.absIsoCH = self.IsolationComputer.chargedAbsIso(g.physObj,0.3,0.0001,0.2)
+            g.absIsoPU = self.IsolationComputer.puAbsIso(g.physObj,0.3,0.0001,0.2)
+            g.absIsoNH = self.IsolationComputer.neutralHadAbsIsoRaw(g.physObj,0.3,0.01,0.5)
+            g.absIsoPH = self.IsolationComputer.photonAbsIsoRaw(g.physObj,0.3,0.01,0.5)
+            g.relIso   = (g.absIsoCH+g.absIsoPU+g.absIsoNH+g.absIsoPH)/g.pt()
             if g.relIso<1.0:
                 isolatedPhotons.append(g)
 

--- a/CMGTools/HToZZ4L/python/analyzers/FSRPhotonMaker.py
+++ b/CMGTools/HToZZ4L/python/analyzers/FSRPhotonMaker.py
@@ -1,0 +1,70 @@
+from math import *
+from PhysicsTools.Heppy.analyzers.core.Analyzer import Analyzer
+from PhysicsTools.HeppyCore.utils.deltar import deltaR, deltaPhi
+from PhysicsTools.Heppy.physicsobjects.PhysicsObject import PhysicsObject
+
+
+from PhysicsTools.HeppyCore.framework.event import Event
+from PhysicsTools.HeppyCore.statistics.counter import Counter, Counters
+from PhysicsTools.Heppy.analyzers.core.AutoHandle import AutoHandle
+
+
+from ROOT import heppy
+
+import os
+import itertools
+        
+class FSRPhotonMaker( Analyzer ):
+    def __init__(self, cfg_ana, cfg_comp, looperName ):
+        super(FSRPhotonMaker,self).__init__(cfg_ana,cfg_comp,looperName)
+        self.leptonTag  = cfg_ana.leptons
+        self.electronID = cfg_ana.electronID
+        self.IsolationComputer = heppy.IsolationComputer(0.3)
+
+    def declareHandles(self):
+        super(FSRPhotonMaker, self).declareHandles()
+        self.handles['pf'] = AutoHandle( "packedPFCandidates",'std::vector<pat::PackedCandidate>')
+
+    def beginLoop(self, setup):
+        super(FSRPhotonMaker,self).beginLoop(setup)
+
+    def process(self, event):
+        self.readCollections( event.input )
+        pf = map( PhysicsObject, self.handles['pf'].product() )
+        leptons = getattr(event,self.leptonTag)
+        self.IsolationComputer.setPackedCandidates(self.handles['pf'].product())
+
+
+        #first trim the photons that are only near leptons
+        direct=[]
+        forIso=[]
+
+
+        for p in pf:
+            if p.pdgId() !=22 or (p.pt()>2.0 and abs(p.eta())<2.4):
+                continue
+            for l in leptons:
+                if abs(l.pdgId())==11 and self.electronID(l):
+                    if (abs(p.eta()-l.eta())<0.05 or deltaPhi(p.phi(),l.phi())<0.2) or deltaR(p.eta(),p.phi(),l.eta(),l.phi())<0.15: 
+                        continue;
+
+                DR =deltaR(l.eta(),l.phi(),p.eta(),p.phi())     
+                if DR<0.07 and p.pt()>2.0:
+                    direct.append(p)
+                    break;
+                elif  DR<0.5 and p.pt()>4.0:   
+                    forIso.append(p)
+                    break;
+                    
+
+        isolatedPhotons=[]        
+        for g in forIso:
+            iso = (self.IsolationComputer.chargedAbsIso(g.physObj,0.3,0,0.2)+self.IsolationComputer.puAbsIso(g.physObj,0.3,0,0.2)+self.IsolationComputer.neutralAbsIsoRaw(g.physObj,0.3,0,0.5))/g.pt()
+            if iso<1.0:
+                isolatedPhotons.append(g)
+
+        event.fsrPhotons = isolatedPhotons+direct
+
+
+        return True
+        

--- a/CMGTools/HToZZ4L/python/analyzers/FourLeptonAnalyzer.py
+++ b/CMGTools/HToZZ4L/python/analyzers/FourLeptonAnalyzer.py
@@ -63,6 +63,8 @@ class FourLeptonAnalyzer( FourLeptonAnalyzerBase ):
         #smart cut
         passed=cutFlow.applyCut(self.stupidCut,'Smart cut',1,'fourLeptonsFinal')
 
+        #compute MELA
+        passed=cutFlow.applyCut(self.fillMEs,'Fill MEs',1,'fourLeptonsWithME')
 
         #Save the best
         if len(subevent.fourLeptonsFinal)>0:

--- a/CMGTools/HToZZ4L/python/analyzers/FourLeptonAnalyzer.py
+++ b/CMGTools/HToZZ4L/python/analyzers/FourLeptonAnalyzer.py
@@ -78,6 +78,7 @@ class FourLeptonAnalyzer( FourLeptonAnalyzerBase ):
         passedFSR=cutFlow.applyCut(lambda x: x.hasFSR(),'FSR tagged',1,'fourLeptonsFSR')
         if passedFSR:
             for c in subevent.fourLeptonsFSR:
-                print 'Mass' ,c.fsrUncorrected().M(),c.M()
+                #print 'Mass' ,c.fsrUncorrected().M(),c.M()
+                pass
 
         return True        

--- a/CMGTools/HToZZ4L/python/analyzers/FourLeptonAnalyzer.py
+++ b/CMGTools/HToZZ4L/python/analyzers/FourLeptonAnalyzer.py
@@ -1,0 +1,81 @@
+from math import *
+from CMGTools.HToZZ4L.analyzers.FourLeptonAnalyzerBase import *
+
+        
+class FourLeptonAnalyzer( FourLeptonAnalyzerBase ):
+    def __init__(self, cfg_ana, cfg_comp, looperName ):
+        super(FourLeptonAnalyzer,self).__init__(cfg_ana,cfg_comp,looperName)
+        self.tag = cfg_ana.tag
+    def declareHandles(self):
+        super(FourLeptonAnalyzer, self).declareHandles()
+
+    def beginLoop(self, setup):
+        super(FourLeptonAnalyzer,self).beginLoop(setup)
+        self.counters.addCounter('FourLepton')
+        count = self.counters.counter('FourLepton')
+        count.register('all events')
+
+
+    def process(self, event):
+        self.readCollections( event.input )
+
+        subevent = EventBox()
+        setattr(event,'fourLeptonAnalyzer'+self.tag,subevent)
+
+        #startup counter
+        self.counters.counter('FourLepton').inc('all events')
+
+        #create a cut flow
+        cutFlow = CutFlowMaker(self.counters.counter("FourLepton"),subevent,event.selectedLeptons)
+
+        passed = cutFlow.applyCut(lambda x:True,'At least four loose leptons',4,'looseLeptons')
+
+        #Remove any loose electrons that are near to tight muons!
+        cleanOverlap = OverlapCleaner(cutFlow.obj1,0.05,11,13,lambda x: (x.physObj.isGlobalMuon() or  x.physObj.isPFMuon()))
+        passed = cutFlow.applyCut(cleanOverlap,'Electron cross cleaning',4,'cleanedLeptons')
+
+        #Ask for four goodleptons
+        passed = cutFlow.applyCut(self.leptonID,'At least four good non isolated Leptons',4,'goodLeptons')
+
+
+        #Create Four Lepton Candidates
+        subevent.fourLeptonPreCands = self.findOSSFQuads(cutFlow.obj1,event.fsrPhotons)
+        cutFlow.setSource1(subevent.fourLeptonPreCands)
+
+        #Apply isolation on all legs
+        passed=cutFlow.applyCut(self.fourLeptonIsolation,'At least four OSSF Isolated leptons   ',1,'fourLeptonsIsolated')
+
+        #Apply minimum Z mass
+        passed=cutFlow.applyCut(self.fourLeptonMassZ1Z2,'Z masses between 12 and 120 GeV',1,'fourLeptonsZMass')
+
+        #Apply ghost suppression
+        passed=cutFlow.applyCut(self.ghostSuppression,'Ghost suppression ',1,'fourLeptonsGhostSuppressed')
+
+        #Pt Thresholds
+        passed=cutFlow.applyCut(self.fourLeptonPtThresholds,'Pt 20 and 10 GeV',1,'fourLeptonsPtThresholds')
+
+        #QCD suppression
+        passed=cutFlow.applyCut(self.qcdSuppression,'QCD suppression',1,'fourLeptonsPtThresholds')
+
+        #Z1 mass
+        passed=cutFlow.applyCut(self.fourLeptonMassZ1,'Z1 Mass cut',1,'fourLeptonsMass')
+
+        #smart cut
+        passed=cutFlow.applyCut(self.stupidCut,'Smart cut',1,'fourLeptonsFinal')
+
+
+        #Save the best
+        if len(subevent.fourLeptonsFinal)>0:
+            subevent.fourLeptonsFinal=sorted(subevent.fourLeptonsFinal,key=lambda x: x.leg2.leg1.pt()+x.leg2.leg2.pt(),reverse=True)
+            subevent.fourLeptonsFinal=sorted(subevent.fourLeptonsFinal,key=lambda x: abs(x.leg1.M()-91.118))
+            setattr(event,'bestFourLeptons'+self.tag,[subevent.fourLeptonsFinal[0]])
+        else:    
+            setattr(event,'bestFourLeptons'+self.tag,[])
+
+        #FSR test
+        passedFSR=cutFlow.applyCut(lambda x: x.hasFSR(),'FSR tagged',1,'fourLeptonsFSR')
+        if passedFSR:
+            for c in subevent.fourLeptonsFSR:
+                print 'Mass' ,c.fsrUncorrected().M(),c.M()
+
+        return True        

--- a/CMGTools/HToZZ4L/python/analyzers/FourLeptonAnalyzer2P2F.py
+++ b/CMGTools/HToZZ4L/python/analyzers/FourLeptonAnalyzer2P2F.py
@@ -1,0 +1,55 @@
+from math import *
+from CMGTools.HToZZ4L.analyzers.FourLeptonAnalyzer import *
+
+        
+class FourLeptonAnalyzer2P2F( FourLeptonAnalyzer ):
+    def __init__(self, cfg_ana, cfg_comp, looperName ):
+        super(FourLeptonAnalyzer2P2F,self).__init__(cfg_ana,cfg_comp,looperName)
+        self.tag = cfg_ana.tag
+    def declareHandles(self):
+        super(FourLeptonAnalyzer2P2F, self).declareHandles()
+
+    def beginLoop(self, setup):
+        super(FourLeptonAnalyzer2P2F,self).beginLoop(setup)
+        self.counters.addCounter('FourLepton')
+        count = self.counters.counter('FourLepton')
+        count.register('all events')
+
+
+    #For the good lepton preselection redefine the thingy so that leptons are loose    
+    def leptonID(self,lepton):
+        return self.leptonID_loose(lepton)
+
+
+    def fourLeptonIsolation(self,fourLepton):
+        ##Fancy! Here require that Z1 leptons pass tight ID and isolationand the two other leptons fail ID or isolation
+        leptons = fourLepton.daughterLeptons()
+        photons = fourLepton.daughterPhotons()
+        for l in [fourLepton.leg1.leg1,fourLepton.leg1.leg2]:
+            if not self.leptonID_tight(l):
+                return False
+            l.fsrPhotons=[]
+            for g in photons:
+                if deltaR(g.eta(),g.phi(),l.eta(),l.phi())<0.4:
+                    l.fsrPhotons.append(g)
+            if abs(l.pdgId())==11:
+                if not (self.electronIsolation(l)):
+                    return False
+            if abs(l.pdgId())==13:
+                if not self.muonIsolation(l):
+                    return False
+
+        for l in [fourLepton.leg2.leg1,fourLepton.leg2.leg2]:
+            if  self.leptonID_tight(l):
+                return False
+            l.fsrPhotons=[]
+            for g in photons:
+                if deltaR(g.eta(),g.phi(),l.eta(),l.phi())<0.4:
+                    l.fsrPhotons.append(g)
+            if abs(l.pdgId())==11:
+                if  self.electronIsolation(l):
+                    return False
+            if abs(l.pdgId())==13:
+                if  self.muonIsolation(l):
+                    return False
+        return True        

--- a/CMGTools/HToZZ4L/python/analyzers/FourLeptonAnalyzer3P1F.py
+++ b/CMGTools/HToZZ4L/python/analyzers/FourLeptonAnalyzer3P1F.py
@@ -1,0 +1,62 @@
+from math import *
+from CMGTools.HToZZ4L.analyzers.FourLeptonAnalyzer import *
+
+        
+class FourLeptonAnalyzer3P1F( FourLeptonAnalyzer ):
+    def __init__(self, cfg_ana, cfg_comp, looperName ):
+        super(FourLeptonAnalyzer3P1F,self).__init__(cfg_ana,cfg_comp,looperName)
+        self.tag = cfg_ana.tag
+    def declareHandles(self):
+        super(FourLeptonAnalyzer3P1F, self).declareHandles()
+
+    def beginLoop(self, setup):
+        super(FourLeptonAnalyzer3P1F,self).beginLoop(setup)
+        self.counters.addCounter('FourLepton')
+        count = self.counters.counter('FourLepton')
+        count.register('all events')
+
+
+    #For the good lepton preselection redefine the thingy so that leptons are loose    
+    def leptonID(self,lepton):
+        return self.leptonID_loose(lepton)
+
+
+    def fourLeptonIsolation(self,fourLepton):
+        ##Fancy! Here require that Z1 leptons pass tight ID and isolationand the two other leptons fail ID or isolation
+        leptons = fourLepton.daughterLeptons()
+        photons = fourLepton.daughterPhotons()
+        for l in [fourLepton.leg1.leg1,fourLepton.leg1.leg2]:
+            if not self.leptonID_tight(l):
+                return False
+            l.fsrPhotons=[]
+            for g in photons:
+                if deltaR(g.eta(),g.phi(),l.eta(),l.phi())<0.4:
+                    l.fsrPhotons.append(g)
+            if abs(l.pdgId())==11:
+                if not (self.electronIsolation(l)):
+                    return False
+            if abs(l.pdgId())==13:
+                if not self.muonIsolation(l):
+                    return False
+
+        failed=0        
+        for l in [fourLepton.leg2.leg1,fourLepton.leg2.leg2]:
+            if  not self.leptonID_tight(l):
+                failed=failed+1
+                continue 
+            l.fsrPhotons=[]
+            for g in photons:
+                if deltaR(g.eta(),g.phi(),l.eta(),l.phi())<0.4:
+                    l.fsrPhotons.append(g)
+            if abs(l.pdgId())==11:
+                if  not self.electronIsolation(l):
+                    failed=failed+1
+                    continue
+            if abs(l.pdgId())==13:
+                if  not self.muonIsolation(l):
+                    failed=failed+1
+                    continue
+        if failed==1:
+            return True        
+        else:
+            return False

--- a/CMGTools/HToZZ4L/python/analyzers/FourLeptonAnalyzerBase.py
+++ b/CMGTools/HToZZ4L/python/analyzers/FourLeptonAnalyzerBase.py
@@ -92,10 +92,10 @@ class FourLeptonAnalyzerBase( Analyzer ):
         return dilepton.M()>12.0 and dilepton.M()<120.
 
     def fourLeptonMassZ1Z2(self,fourLepton):
-        return self.diLeptonMass(fourLepton.leg1) and self.diLeptonMass(fourLepton.leg1)
+        return self.diLeptonMass(fourLepton.leg1) and self.diLeptonMass(fourLepton.leg2)
 
     def fourLeptonMassZ1(self,fourLepton):
-        return fourLepton.leg1.M()>40.0
+        return fourLepton.leg1.M()>60.0
 
     def stupidCut(self,fourLepton):
         #if not 4mu/4e  pass 

--- a/CMGTools/HToZZ4L/python/analyzers/FourLeptonAnalyzerBase.py
+++ b/CMGTools/HToZZ4L/python/analyzers/FourLeptonAnalyzerBase.py
@@ -95,7 +95,7 @@ class FourLeptonAnalyzerBase( Analyzer ):
         return self.diLeptonMass(fourLepton.leg1) and self.diLeptonMass(fourLepton.leg2)
 
     def fourLeptonMassZ1(self,fourLepton):
-        return fourLepton.leg1.M()>60.0
+        return fourLepton.leg1.M()>40.0
 
     def stupidCut(self,fourLepton):
         #if not 4mu/4e  pass 

--- a/CMGTools/HToZZ4L/python/analyzers/FourLeptonAnalyzerBase.py
+++ b/CMGTools/HToZZ4L/python/analyzers/FourLeptonAnalyzerBase.py
@@ -102,6 +102,7 @@ class FourLeptonAnalyzerBase( Analyzer ):
         if abs(fourLepton.leg1.leg1.pdgId())!=abs(fourLepton.leg2.leg1.pdgId()):
             return True
 
+        #print "Nominal, mZ1 %.3f, mZ2 %.3f: %s" % (fourLepton.leg1.M(),fourLepton.leg2.M(),fourLepton)
         #find Alternative pairing.Do not forget FSR
         leptons  = [ fourLepton.leg1.leg1, fourLepton.leg1.leg2, fourLepton.leg2.leg1, fourLepton.leg2.leg2 ]
         quads = []
@@ -111,6 +112,9 @@ class FourLeptonAnalyzerBase( Analyzer ):
                 continue
             # skip those that fail cuts except Z2 mass
             if not self.fourLeptonIsolation(quad) or not self.fourLeptonMassZ1(quad) or not self.qcdSuppression(quad):
+                continue
+            # skip those that have a worse Z1 mass than the nominal
+            if abs(fourLepton.leg1.M()-91.118) < abs(quad.leg1.M()-91.118):
                 continue
             #print "Found alternate, mZ1 %.3f, mZ2 %.3f: %s" % (quad.leg1.M(),quad.leg2.M(),quad)
             quads.append(quad)

--- a/CMGTools/HToZZ4L/python/analyzers/FourLeptonAnalyzerBase.py
+++ b/CMGTools/HToZZ4L/python/analyzers/FourLeptonAnalyzerBase.py
@@ -10,6 +10,7 @@ from CMGTools.HToZZ4L.tools.CutFlowMaker  import CutFlowMaker
 
 import os
 import itertools
+import ROOT
 
 class EventBox(object):
     def __init__(self):
@@ -42,6 +43,7 @@ class EventBox(object):
 class FourLeptonAnalyzerBase( Analyzer ):
     def __init__(self, cfg_ana, cfg_comp, looperName ):
         super(FourLeptonAnalyzerBase,self).__init__(cfg_ana,cfg_comp,looperName)
+        self._MEMs = ROOT.MEMCalculatorsWrapper(13.0)
 
     def declareHandles(self):
         super(FourLeptonAnalyzerBase, self).declareHandles()
@@ -258,5 +260,12 @@ class FourLeptonAnalyzerBase( Analyzer ):
             del g.nearestLepton
             
                 
-
+    def fillMEs(self,quad):
+        legs = [ quad.leg1.leg1, quad.leg1.leg2, quad.leg2.leg1, quad.leg2.leg2 ]
+        lvs  = [ ROOT.TLorentzVector(l.px(),l.py(),l.pz(),l.energy()) for l in legs ]
+        ids  = [ l.pdgId() for l in legs ]
+        quad.melaAngles = self._MEMs.computeAngles(lvs[0],ids[0], lvs[1],ids[1], lvs[2],ids[2], lvs[3],ids[3])
+        self._MEMs.computeAll(lvs[0],ids[0], lvs[1],ids[1], lvs[2],ids[2], lvs[3],ids[3])
+        quad.KD = self._MEMs.getKD()
+        return True
 

--- a/CMGTools/HToZZ4L/python/analyzers/FourLeptonAnalyzerBase.py
+++ b/CMGTools/HToZZ4L/python/analyzers/FourLeptonAnalyzerBase.py
@@ -1,0 +1,262 @@
+from math import *
+from PhysicsTools.Heppy.analyzers.core.Analyzer import Analyzer
+from PhysicsTools.HeppyCore.utils.deltar import deltaR, deltaPhi
+from PhysicsTools.HeppyCore.framework.event import *
+
+from CMGTools.HToZZ4L.tools.DiObject import DiObject
+from CMGTools.HToZZ4L.tools.DiObjectPair import DiObjectPair
+from CMGTools.HToZZ4L.tools.OverlapCleaner import OverlapCleaner
+from CMGTools.HToZZ4L.tools.CutFlowMaker  import CutFlowMaker
+
+import os
+import itertools
+
+class EventBox(object):
+    def __init__(self):
+        pass
+
+    def __str__(self):
+
+        header = 'EVENT BOX ---> {type} <------ EVENT BOX'.format( type=self.__class__.__name__)
+        varlines = []
+        for var,value in sorted(vars(self).iteritems()):
+            tmp = value
+            # check for recursivity
+            recursive = False
+            if hasattr(value, '__getitem__'):
+                if (len(value)>0 and value[0].__class__ == value.__class__):
+                    recursive = True
+            if isinstance( value, collections.Iterable ) and \
+                   not isinstance(value, (str,unicode)) and \
+                   not isinstance(value, TChain) and \
+                   not recursive :
+                tmp = map(str, value)
+            varlines.append( '\t{var:<15}:   {value}'.format(var=var, value=tmp) )
+        all = [ header ]
+        all.extend(varlines)
+        return '\n'.join( all )
+
+
+
+        
+class FourLeptonAnalyzerBase( Analyzer ):
+    def __init__(self, cfg_ana, cfg_comp, looperName ):
+        super(FourLeptonAnalyzerBase,self).__init__(cfg_ana,cfg_comp,looperName)
+
+    def declareHandles(self):
+        super(FourLeptonAnalyzerBase, self).declareHandles()
+
+    def beginLoop(self, setup):
+        super(FourLeptonAnalyzerBase,self).beginLoop(setup)
+
+    def process(self, event):
+        self.readCollections( event.input )
+
+
+
+    def leptonID_tight(self,lepton):
+        if abs(lepton.sip3D())>4:
+            return False
+        if abs(lepton.pdgId())==13:
+            if not ((lepton.physObj.isGlobalMuon() or lepton.physObj.isTrackerMuon()) and lepton.physObj.isPFMuon()):
+                return False
+        elif abs(lepton.pdgId())==11:
+            if not lepton.electronID("POG_MVA_ID_Run2_NonTrig_HZZ"):
+                return False
+        return True    
+
+
+    def leptonID_loose(self,lepton):
+        if abs(lepton.sip3D())>4:
+            return False
+        if abs(lepton.pdgId())==13:
+            if lepton.physObj.isTrackerMuon() and not (lepton.physObj.isGlobalMuon()):
+                if not (lepton.physObj.numberOfMatchedStations())>0:
+                    return False
+        return True    
+
+
+    def leptonID(self,lepton):
+        return self.leptonID_tight(lepton)
+
+
+    def muonIsolation(self,lepton):
+        return lepton.absIso(0.5)/lepton.pt()<0.4
+
+    def electronIsolation(self,lepton):
+        return lepton.absIsoFromEA("04")/lepton.pt()<0.5
+
+    def diLeptonMass(self,dilepton):
+        return dilepton.M()>12.0 and dilepton.M()<120.
+
+    def fourLeptonMassZ1Z2(self,fourLepton):
+        return self.diLeptonMass(fourLepton.leg1) and self.diLeptonMass(fourLepton.leg1)
+
+    def fourLeptonMassZ1(self,fourLepton):
+        return fourLepton.leg1.M()>40.0
+
+    def stupidCut(self,fourLepton):
+        #if not 4mu/4e  pass 
+        if abs(fourLepton.leg1.leg1.pdgId())!=abs(fourLepton.leg2.leg1.pdgId()):
+            return True
+
+        #find Alternative pairing.Do not forget FSR
+        alternate =DiObjectPair(fourLepton.leg1.leg1, fourLepton.leg2.leg2,fourLepton.leg1.leg2,fourLepton.leg2.leg1)
+        if (abs(alternate.leg1.M()-91.118)<  abs(fourLepton.leg1.M()-91.118)) and  alternate.leg2.M()<12.:
+            return False
+        return True
+
+
+
+
+    def fourLeptonPtThresholds(self, fourLepton):
+        leading_pt = fourLepton.sortedPtLeg(0).pt() 
+        subleading_pt = fourLepton.sortedPtLeg(1).pt() 
+        return leading_pt>20  and subleading_pt>10
+
+
+    def fourLeptonIsolation(self,fourLepton):
+        ##First ! attach the FSR photons of this candidate to the leptons!
+        
+
+
+
+        leptons = fourLepton.daughterLeptons()
+        photons = fourLepton.daughterPhotons()
+
+        
+
+
+        for l in leptons:
+            l.fsrPhotons=[]
+            for g in photons:
+                if deltaR(g.eta(),g.phi(),l.eta(),l.phi())<0.4:
+                    l.fsrPhotons.append(g)
+            if abs(l.pdgId())==11:
+                if not self.electronIsolation(l):
+                    return False
+            if abs(l.pdgId())==13:
+                if not self.muonIsolation(l):
+                    return False
+        return True        
+
+    def ghostSuppression(self, fourLepton):
+        leptons = fourLepton.daughterLeptons()
+        for l1,l2 in itertools.combinations(leptons,2):
+            if deltaR(l1.eta(),l1.phi(),l2.eta(),l2.phi())<0.02:
+                return False
+        return True    
+
+
+
+    def qcdSuppression(self, fourLepton):
+        return fourLepton.minOSPairMass()>4.0
+
+        
+
+    def findOSSFQuads(self, leptons,photons):
+        '''Make combinatorics and make permulations of four leptons
+           Cut the permutations by asking Z1 nearest to Z and also 
+           that plus is the first
+           Include FSR if in cfg file
+        '''
+        out = []
+        for l1, l2,l3,l4 in itertools.permutations(leptons, 4):
+            if (l1.pdgId()+l2.pdgId())!=0: 
+                continue;
+            if (l3.pdgId()+l4.pdgId())!=0:
+                continue;
+            if (l1.pdgId()<l2.pdgId())!=0: 
+                continue;
+            if (l3.pdgId()<l4.pdgId())!=0: 
+                continue;
+
+            quadObject =DiObjectPair(l1, l2,l3,l4)
+            self.attachFSR(quadObject,photons)
+            if abs(quadObject.leg1.M()-91.118)>abs(quadObject.leg2.M()-91.118):
+                continue;
+            out.append(quadObject)
+
+        return out
+
+
+
+    def attachFSR(self,quad,photons):
+        #first attach photons to the closest leptons
+        attachData={}
+        
+        legs=[quad.leg1.leg1,quad.leg1.leg2,quad.leg2.leg1,quad.leg2.leg2]
+
+        assocPhotons=[]
+        for g in photons:
+            for l in legs:
+                DR=deltaR(l.eta(),l.phi(),g.eta(),g.phi())
+                if DR>0.5:
+                    continue;
+                
+                if hasattr(g,'DR'):
+                    if DR<g.DR:
+                        g.DR=DR
+                        g.nearestLepton = l
+                else:        
+                    g.DR=DR
+                    g.nearestLepton = l
+                assocPhotons.append(g)
+
+        
+        #Now we have the association . Check criteria
+        #First on Z1
+        z1Photons=[]
+        z2Photons=[]
+
+        z1Above4=False
+        z2Above4=False
+        for g in assocPhotons:
+            if g.nearestLepton in [quad.leg1.leg1,quad.leg1.leg2]:
+                mll = quad.leg1.M()
+                mllg = (quad.leg1.leg1.p4()+quad.leg1.leg2.p4()+g.p4()).M()
+                if mllg<4 or mllg>100:
+                    continue
+                if abs(mllg-91.188)>abs(mll-91.188):
+                    continue
+                z1Photons.append(g)
+                if g.pt()>4:
+                    z1Above4 = True
+
+            if g.nearestLepton in [quad.leg2.leg1,quad.leg2.leg2]:
+                mll = quad.leg2.M()
+                mllg = (quad.leg2.leg1.p4()+quad.leg2.leg2.p4()+g.p4()).M()
+                if mllg<4 or mllg>100:
+                    continue
+                if abs(mllg-91.188)>abs(mll-91.188):
+                    continue
+                z2Photons.append(g)
+                if g.pt()>4:
+                    z2Above4 = True
+                
+            
+
+        if len(z1Photons)>0:
+            if z1Above4: #Take the highest pt
+                fsr = max(z1Photons,key=lambda x: x.pt())
+                quad.leg1.setFSR(fsr)
+            else:    #Take the smallest DR
+                fsr = min(z1Photons,key=lambda x: x.DR)
+                quad.leg1.setFSR(fsr)
+        if len(z2Photons)>0:
+            if z2Above4: #Take the highest pt
+                fsr = max(z2Photons,key=lambda x: x.pt())
+                quad.leg2.setFSR(fsr)
+            else:    #Take the smallest DR
+                fsr = min(z2Photons,key=lambda x: x.DR)
+                quad.leg2.setFSR(fsr)
+
+        quad.updateP4()        
+        #cleanup for next combination!        
+        for g in assocPhotons:
+            del g.DR
+            del g.nearestLepton
+            
+                
+
+

--- a/CMGTools/HToZZ4L/python/analyzers/FourLeptonAnalyzerBase.py
+++ b/CMGTools/HToZZ4L/python/analyzers/FourLeptonAnalyzerBase.py
@@ -208,7 +208,6 @@ class FourLeptonAnalyzerBase( Analyzer ):
                 DR=deltaR(l.eta(),l.phi(),g.eta(),g.phi())
                 if DR>0.5:
                     continue;
-                
                 if hasattr(g,'DR'):
                     if DR<g.DR:
                         g.DR=DR
@@ -216,6 +215,7 @@ class FourLeptonAnalyzerBase( Analyzer ):
                 else:        
                     g.DR=DR
                     g.nearestLepton = l
+            if hasattr(g,'DR'):
                 assocPhotons.append(g)
 
         

--- a/CMGTools/HToZZ4L/python/analyzers/FourLeptonAnalyzerBase.py
+++ b/CMGTools/HToZZ4L/python/analyzers/FourLeptonAnalyzerBase.py
@@ -276,6 +276,22 @@ class FourLeptonAnalyzerBase( Analyzer ):
     def fillMEs(self,quad):
         legs = [ quad.leg1.leg1, quad.leg1.leg2, quad.leg2.leg1, quad.leg2.leg2 ]
         lvs  = [ ROOT.TLorentzVector(l.px(),l.py(),l.pz(),l.energy()) for l in legs ]
+
+        if hasattr(quad.leg1,'fsrPhoton'):
+            photon = ROOT.TLorentzVector(quad.leg1.fsrPhoton.px(),quad.leg1.fsrPhoton.py(),quad.leg1.fsrPhoton.pz(),quad.leg1.fsrPhoton.energy())
+            if quad.leg1.fsrDR1() < quad.leg1.fsrDR2():
+                lvs[0] = lvs[0]+photon
+            else:
+                lvs[1]=lvs[1]+photon
+
+        if hasattr(quad.leg2,'fsrPhoton'):
+            photon = ROOT.TLorentzVector(quad.leg2.fsrPhoton.px(),quad.leg2.fsrPhoton.py(),quad.leg2.fsrPhoton.pz(),quad.leg2.fsrPhoton.energy())
+            if quad.leg2.fsrDR1() < quad.leg2.fsrDR2():
+                lvs[2] = lvs[2]+photon
+            else:
+                lvs[3]=lvs[3]+photon
+
+
         ids  = [ l.pdgId() for l in legs ]
         quad.melaAngles = self._MEMs.computeAngles(lvs[0],ids[0], lvs[1],ids[1], lvs[2],ids[2], lvs[3],ids[3])
         self._MEMs.computeAll(lvs[0],ids[0], lvs[1],ids[1], lvs[2],ids[2], lvs[3],ids[3])

--- a/CMGTools/HToZZ4L/python/analyzers/FourLeptonAnalyzerSS.py
+++ b/CMGTools/HToZZ4L/python/analyzers/FourLeptonAnalyzerSS.py
@@ -1,0 +1,68 @@
+from math import *
+from CMGTools.HToZZ4L.analyzers.FourLeptonAnalyzer import *
+
+        
+class FourLeptonAnalyzerSS( FourLeptonAnalyzer ):
+    def __init__(self, cfg_ana, cfg_comp, looperName ):
+        super(FourLeptonAnalyzerSS,self).__init__(cfg_ana,cfg_comp,looperName)
+        self.tag = cfg_ana.tag
+
+    def declareHandles(self):
+        super(FourLeptonAnalyzerSS, self).declareHandles()
+
+    def beginLoop(self, setup):
+        super(FourLeptonAnalyzerSS,self).beginLoop(setup)
+        self.counters.addCounter('FourLepton')
+        count = self.counters.counter('FourLepton')
+        count.register('all events')
+
+
+    #For the good lepton preselection redefine the thingy so that leptons are loose    
+    def leptonID(self,lepton):
+        return self.leptonID_loose(lepton)
+
+
+    #Redefine the QUADS so Z2 is SF/SS!!!
+    def findOSSFQuads(self, leptons,photons):
+        '''Make combinatorics and make permulations of four leptons
+           Cut the permutations by asking Z1 nearest to Z and also 
+           that plus is the first
+           Include FSR if in cfg file
+        '''
+        out = []
+        for l1, l2,l3,l4 in itertools.permutations(leptons, 4):
+            if (l1.pdgId()+l2.pdgId())!=0: 
+                continue;
+            if (l3.pdgId()!=l4.pdgId()):
+                continue;
+            if (l1.pdgId()<l2.pdgId())!=0: 
+                continue;
+            quadObject =DiObjectPair(l1, l2,l3,l4)
+            self.attachFSR(quadObject,photons)
+            if abs(quadObject.leg1.M()-91.118)>abs(quadObject.leg2.M()-91.118):
+                continue;
+            out.append(quadObject)
+
+        return out
+
+
+
+
+    def fourLeptonIsolation(self,fourLepton):
+        ##Fancy! Here apply only tight ID on Z1 and no ID in Z2
+        leptons = fourLepton.daughterLeptons()
+        photons = fourLepton.daughterPhotons()
+        for l in [fourLepton.leg1.leg1,fourLepton.leg1.leg2]:
+            if not self.leptonID_tight(l):
+                return False
+            l.fsrPhotons=[]
+            for g in photons:
+                if deltaR(g.eta(),g.phi(),l.eta(),l.phi())<0.4:
+                    l.fsrPhotons.append(g)
+            if abs(l.pdgId())==11:
+                if not (self.electronIsolation(l)):
+                    return False
+            if abs(l.pdgId())==13:
+                if not self.muonIsolation(l):
+                    return False
+        return True        

--- a/CMGTools/HToZZ4L/python/analyzers/FourLeptonEventSkimmer.py
+++ b/CMGTools/HToZZ4L/python/analyzers/FourLeptonEventSkimmer.py
@@ -1,0 +1,25 @@
+from math import *
+from PhysicsTools.Heppy.analyzers.core.Analyzer import Analyzer
+from PhysicsTools.HeppyCore.framework.event import Event
+import os
+import itertools
+        
+class FourLeptonEventSkimmer( Analyzer ):
+    def __init__(self, cfg_ana, cfg_comp, looperName ):
+        super(FourLeptonEventSkimmer,self).__init__(cfg_ana,cfg_comp,looperName)
+        self.required = cfg_ana.required
+    def declareHandles(self):
+        super(FourLeptonEventSkimmer, self).declareHandles()
+
+    def beginLoop(self, setup):
+        super(FourLeptonEventSkimmer,self).beginLoop(setup)
+
+    def process(self, event):
+        self.readCollections( event.input )
+
+        for col in self.required:
+            if hasattr(event,col):
+                if len(getattr(event,col))>0:
+                    return True
+        
+        return False    

--- a/CMGTools/HToZZ4L/python/analyzers/GenFSRAnalyzer.py
+++ b/CMGTools/HToZZ4L/python/analyzers/GenFSRAnalyzer.py
@@ -1,0 +1,104 @@
+from math import *
+from PhysicsTools.Heppy.analyzers.core.Analyzer import Analyzer
+from PhysicsTools.HeppyCore.utils.deltar import deltaR, deltaPhi
+from PhysicsTools.Heppy.physicsobjects.PhysicsObject import PhysicsObject
+
+from PhysicsTools.HeppyCore.framework.event import Event
+from PhysicsTools.HeppyCore.statistics.counter import Counter, Counters
+from PhysicsTools.Heppy.analyzers.core.AutoHandle import AutoHandle
+
+import ROOT
+from ROOT import heppy
+
+import os
+import itertools
+import numpy
+        
+class GenFSRAnalyzer( Analyzer ):
+    def __init__(self, cfg_ana, cfg_comp, looperName ):
+        super(GenFSRAnalyzer,self).__init__(cfg_ana,cfg_comp,looperName)
+
+        self.file = ROOT.TFile("fsrTree.root", 'recreate' )
+        self.tree = ROOT.TTree("tree","tree")
+        self.vars={}
+
+        self.vars['mZ']=numpy.zeros(1,float)
+        self.tree.Branch('mZ',self.vars['mZ'],'mZ/D')
+
+        self.vars['mllgamma']=numpy.zeros(1,float)
+        self.tree.Branch('mllgamma',self.vars['mllgamma'],'mllgamma/D')
+
+        self.vars['mll']=numpy.zeros(1,float)
+        self.tree.Branch('mll',self.vars['mll'],'mll/D')
+
+        self.vars['mStar']=numpy.zeros(1,float)
+        self.tree.Branch('mStar',self.vars['mStar'],'mStar/D')
+
+        self.vars['P']=numpy.zeros(1,float)
+        self.tree.Branch('P',self.vars['P'],'P/D')
+
+        self.vars['E']=numpy.zeros(1,float)
+        self.tree.Branch('E',self.vars['E'],'E/D')
+
+        self.vars['ET']=numpy.zeros(1,float)
+        self.tree.Branch('ET',self.vars['ET'],'ET/D')
+
+        self.vars['cosTheta']=numpy.zeros(1,float)
+        self.tree.Branch('cosTheta',self.vars['cosTheta'],'cosTheta/D')
+
+        self.vars['DR']=numpy.zeros(1,float)
+        self.tree.Branch('DR',self.vars['DR'],'DR/D')
+
+
+
+    def declareHandles(self):
+        pass
+    
+    def beginLoop(self, setup):
+        super(GenFSRAnalyzer,self).beginLoop(setup)
+
+
+    def fetchFinalStateLeptons(self,particle):
+        finalState=[]
+        for i in range(0,particle.numberOfDaughters()):
+            d=particle.daughter(i)
+            if d.status()==1 and abs(d.pdgId()) in [11,13]:
+                finalState.append(d)
+            else:
+                finalState=finalState+self.fetchFinalStateLeptons(d)
+        return finalState
+    
+    def process(self, event):
+
+
+        for l in event.genParticles:
+            if abs(l.pdgId()) in [11,13] and l.status()==2:
+                hasFSR=False
+                for d in range(0,l.numberOfDaughters()):
+                    daughter=l.daughter(d)
+                    if daughter.pdgId()==22:
+                        hasFSR=True
+                if hasFSR:        
+                    self.vars['mZ'][0] = l.mother(0).mother(0).mass()
+                    self.vars['mStar'][0] =(l.daughter(0).p4()+l.daughter(1).p4()).M()
+                    self.vars['P'][0] =l.daughter(0).p()
+                    self.vars['E'][0] =l.daughter(1).energy()
+                    self.vars['ET'][0] =l.daughter(1).pt()
+                    self.vars['cosTheta'][0] =l.daughter(0).p4().Vect().Dot(l.daughter(1).p4().Vect())/(l.daughter(0).p()*l.daughter(1).energy())
+                    self.vars['DR'][0] =deltaR(l.daughter(0).eta(),l.daughter(0).phi(),l.daughter(1).eta(),l.daughter(1).phi())
+
+                    finalStateLeptons=self.fetchFinalStateLeptons(l.mother(0).mother(0))
+                    if len(finalStateLeptons)<2:
+                        continue;
+                    print 'Final state leptons',len(finalStateLeptons)
+                    self.vars['mll'][0] =(finalStateLeptons[0].p4()+finalStateLeptons[1].p4()).M() 
+                    self.vars['mllgamma'][0] =(finalStateLeptons[0].p4()+finalStateLeptons[1].p4()+l.daughter(1).p4()).M() 
+                    self.tree.Fill()
+        return False
+
+    def write(self,setup):
+        super(GenFSRAnalyzer, self).write(setup)
+        self.file.cd()
+        self.tree.Write()
+        self.file.Close()
+        

--- a/CMGTools/HToZZ4L/python/analyzers/fourLeptonTree.py
+++ b/CMGTools/HToZZ4L/python/analyzers/fourLeptonTree.py
@@ -1,0 +1,36 @@
+from PhysicsTools.Heppy.analyzers.core.AutoFillTreeProducer  import * 
+
+ZZType = NTupleObjectType("ZZType", baseObjectTypes=[fourVectorType], variables = [
+    NTupleVariable("hasFSR",   lambda x : x.hasFSR(), int),
+    NTupleVariable("z1_hasFSR",   lambda x : x.leg1.hasFSR(), int),
+    NTupleVariable("z2_hasFSR",   lambda x : x.leg2.hasFSR(), int),
+    NTupleSubObject("z1",  lambda x : x.leg1,fourVectorType),
+    NTupleSubObject("z2",  lambda x : x.leg2,fourVectorType),
+    NTupleSubObject("z1_l1",  lambda x : x.leg1.leg1,leptonType),
+    NTupleSubObject("z1_l2",  lambda x : x.leg1.leg2,leptonType),
+    NTupleSubObject("z2_l1",  lambda x : x.leg2.leg1,leptonType),
+    NTupleSubObject("z2_l2",  lambda x : x.leg2.leg2,leptonType)
+])
+
+
+hzz_globalVariables = [
+    NTupleVariable("rho",  lambda ev: ev.rho, float, help="kt6PFJets rho"),
+    NTupleVariable("nVert",  lambda ev: len(ev.goodVertices), int, help="Number of good vertices"),
+    NTupleVariable("nJet30", lambda ev: len([j for j in ev.cleanJets]), int, help="Number of jets with pt > 30"),
+]
+
+hzz_globalObjects = {
+    "met" : NTupleObject("met", metType)
+}
+
+
+hzz_collections = {
+    "bestFourLeptonsSignal"  : NTupleCollection("zz",    ZZType, 1, help="Four Lepton Candidates"),    
+    "bestFourLeptons2P2F"    : NTupleCollection("zz2P2F",ZZType, 1, help="Four Lepton Candidates 2Pass 2 Fail"),    
+    "bestFourLeptons3P1F"    : NTupleCollection("zz3P1F",ZZType, 1, help="Four Lepton Candidates 3 Pass 1 Fail"),   
+    "bestFourLeptonsSS"      : NTupleCollection("zzSS",  ZZType, 1, help="Four Lepton Candidates SS"),   
+    # ---------------
+    "selectedLeptons" : NTupleCollection("Lep", leptonTypeExtra, 10, help="Leptons after the preselection"),
+    "cleanJets"       : NTupleCollection("Jet", jetTypeExtra,    20, help="Cental jets after full selection and cleaning, sorted by pt"),
+    "discardedJets"   : NTupleCollection("DiscJet", jetTypeExtra, 15, help="Jets discarted in the jet-lepton cleaning"),
+}

--- a/CMGTools/HToZZ4L/python/analyzers/fourLeptonTree.py
+++ b/CMGTools/HToZZ4L/python/analyzers/fourLeptonTree.py
@@ -1,17 +1,4 @@
-from PhysicsTools.Heppy.analyzers.core.AutoFillTreeProducer  import * 
-
-ZZType = NTupleObjectType("ZZType", baseObjectTypes=[fourVectorType], variables = [
-    NTupleVariable("hasFSR",   lambda x : x.hasFSR(), int),
-    NTupleVariable("z1_hasFSR",   lambda x : x.leg1.hasFSR(), int),
-    NTupleVariable("z2_hasFSR",   lambda x : x.leg2.hasFSR(), int),
-    NTupleSubObject("z1",  lambda x : x.leg1,fourVectorType),
-    NTupleSubObject("z2",  lambda x : x.leg2,fourVectorType),
-    NTupleSubObject("z1_l1",  lambda x : x.leg1.leg1,leptonType),
-    NTupleSubObject("z1_l2",  lambda x : x.leg1.leg2,leptonType),
-    NTupleSubObject("z2_l1",  lambda x : x.leg2.leg1,leptonType),
-    NTupleSubObject("z2_l2",  lambda x : x.leg2.leg2,leptonType)
-])
-
+from CMGTools.HToZZ4L.analyzers.zzTypes import *
 
 hzz_globalVariables = [
     NTupleVariable("rho",  lambda ev: ev.rho, float, help="kt6PFJets rho"),
@@ -30,7 +17,7 @@ hzz_collections = {
     "bestFourLeptons3P1F"    : NTupleCollection("zz3P1F",ZZType, 1, help="Four Lepton Candidates 3 Pass 1 Fail"),   
     "bestFourLeptonsSS"      : NTupleCollection("zzSS",  ZZType, 1, help="Four Lepton Candidates SS"),   
     # ---------------
-    "selectedLeptons" : NTupleCollection("Lep", leptonTypeExtra, 10, help="Leptons after the preselection"),
-    "cleanJets"       : NTupleCollection("Jet", jetTypeExtra,    20, help="Cental jets after full selection and cleaning, sorted by pt"),
-    "discardedJets"   : NTupleCollection("DiscJet", jetTypeExtra, 15, help="Jets discarted in the jet-lepton cleaning"),
+    "selectedLeptons" : NTupleCollection("Lep",    leptonTypeHZZ, 10, help="Leptons after the preselection"),
+    "cleanJets"       : NTupleCollection("Jet",     jetTypeExtra, 10, help="Cental jets after full selection and cleaning, sorted by pt"),
+    "discardedJets"   : NTupleCollection("DiscJet", jetTypeExtra,  5, help="Jets discarted in the jet-lepton cleaning"),
 }

--- a/CMGTools/HToZZ4L/python/analyzers/fourLeptonTree.py
+++ b/CMGTools/HToZZ4L/python/analyzers/fourLeptonTree.py
@@ -20,4 +20,5 @@ hzz_collections = {
     "selectedLeptons" : NTupleCollection("Lep",    leptonTypeHZZ, 10, help="Leptons after the preselection"),
     "cleanJets"       : NTupleCollection("Jet",     jetTypeExtra, 10, help="Cental jets after full selection and cleaning, sorted by pt"),
     "discardedJets"   : NTupleCollection("DiscJet", jetTypeExtra,  5, help="Jets discarted in the jet-lepton cleaning"),
+    "fsrPhotonsNoIso" : NTupleCollection("FSR",    fsrPhotonTypeHZZ, 10, help="Photons for FSR recovery (isolation not applied)"),
 }

--- a/CMGTools/HToZZ4L/python/analyzers/hzz4lCore_modules_cff.py
+++ b/CMGTools/HToZZ4L/python/analyzers/hzz4lCore_modules_cff.py
@@ -1,0 +1,262 @@
+import PhysicsTools.HeppyCore.framework.config as cfg
+from PhysicsTools.Heppy.analyzers.core.all import *
+from PhysicsTools.Heppy.analyzers.objects.all import *
+from PhysicsTools.Heppy.analyzers.gen.all import *
+from CMGTools.HToZZ4L.analyzers.FourLeptonAnalyzer import *
+from CMGTools.HToZZ4L.analyzers.FourLeptonAnalyzer2P2F import *
+from CMGTools.HToZZ4L.analyzers.FourLeptonAnalyzer3P1F import *
+from CMGTools.HToZZ4L.analyzers.FourLeptonAnalyzerSS import *
+from CMGTools.HToZZ4L.analyzers.FourLeptonEventSkimmer import *
+
+from CMGTools.HToZZ4L.analyzers.FSRPhotonMaker import *
+from CMGTools.HToZZ4L.analyzers.GenFSRAnalyzer import *
+from CMGTools.HToZZ4L.analyzers.fourLeptonTree import *
+
+import os
+
+
+PDFWeights = []
+
+genAna = cfg.Analyzer(
+    GeneratorAnalyzer, name="GeneratorAnalyzer",
+    # BSM particles that can appear with status <= 2 and should be kept
+    stableBSMParticleIds = [ 1000022 ],
+    # Particles of which we want to save the pre-FSR momentum (a la status 3).
+    # Note that for quarks and gluons the post-FSR doesn't make sense,
+    # so those should always be in the list
+    savePreFSRParticleIds = [ 1,2,3,4,5, 11,12,13,14,15,16, 21 ],
+    # Make also the list of all genParticles, for other analyzers to handle
+    makeAllGenParticles = True,
+    # Make also the splitted lists
+    makeSplittedGenLists = True,
+    allGenTaus = False,
+    # Print out debug information
+    verbose = False,
+    )
+
+
+genFSRAna = cfg.Analyzer(
+    GenFSRAnalyzer, name="GenFSRAnalyzer"
+    )
+
+
+# Find the initial events before the skim
+skimAnalyzer = cfg.Analyzer(
+    SkimAnalyzerCount, name='skimAnalyzerCount',
+    useLumiBlocks = False,
+    )
+
+# Pick individual events (normally not in the path)
+eventSelector = cfg.Analyzer(
+    EventSelector,name="EventSelector",
+    toSelect = []  # here put the event numbers (actual event numbers from CMSSW)
+    )
+# Apply json file (if the dataset has one)
+jsonAna = cfg.Analyzer(
+    JSONAnalyzer, name="JSONAnalyzer",
+    )
+
+# Filter using the 'triggers' and 'vetoTriggers' specified in the dataset
+triggerAna = cfg.Analyzer(
+    TriggerBitFilter, name="TriggerBitFilter",
+    )
+# Create flags for trigger bits
+triggerFlagsAna = cfg.Analyzer(
+    TriggerBitAnalyzer, name="TriggerFlags",
+    processName = 'HLT',
+    triggerBits = {
+        # "<name>" : [ 'HLT_<Something>_v*', 'HLT_<SomethingElse>_v*' ] 
+    }
+    )
+
+
+# Select a list of good primary vertices (generic)
+vertexAna = cfg.Analyzer(
+    VertexAnalyzer, name="VertexAnalyzer",
+    vertexWeight = None,
+    fixedWeight = 1,
+    verbose = False
+    )
+
+
+# This analyzer actually does the pile-up reweighting (generic)
+pileUpAna = cfg.Analyzer(
+    PileUpAnalyzer, name="PileUpAnalyzer",
+    true = True,  # use number of true interactions for reweighting
+    makeHists=False
+    )
+
+pdfwAna = cfg.Analyzer(
+    PDFWeightsAnalyzer, name="PDFWeightsAnalyzer",
+    PDFWeights = [ pdf for pdf,num in PDFWeights ]
+    )
+
+
+
+lepAna = cfg.Analyzer(
+    LeptonAnalyzer, name="leptonAnalyzer",
+    # input collections
+    muons='slimmedMuons',
+    electrons='slimmedElectrons',
+    rhoMuon= 'fixedGridRhoFastjetAll',
+    rhoElectron = 'fixedGridRhoFastjetAll',
+    # energy scale corrections and ghost muon suppression (off by default)
+    doMuScleFitCorrections=False, # "rereco"
+    doRochesterCorrections=False,
+    doElectronScaleCorrections=False, # "embedded" in 5.18 for regression
+    doSegmentBasedMuonCleaning=True,
+    # inclusive very loose muon selection
+    inclusive_muon_id  = "",
+    inclusive_muon_pt  = 5,
+    inclusive_muon_eta = 2.4,
+    inclusive_muon_dxy = 0.5,
+    inclusive_muon_dz  = 1.0,
+    # loose muon selection
+    loose_muon_id     = "",
+    loose_muon_pt     = 5,
+    loose_muon_eta    = 2.4,
+    loose_muon_dxy    = 0.5,
+    loose_muon_dz     = 1,
+    loose_muon_isoCut = lambda muon : True,
+    # inclusive very loose electron selection
+    inclusive_electron_id  = "",
+    inclusive_electron_pt  = 7,
+    inclusive_electron_eta = 2.5,
+    inclusive_electron_dxy = 0.5,
+    inclusive_electron_dz  = 1.0,
+    inclusive_electron_lostHits = 1.0,
+    # loose electron selection
+    loose_electron_id     = "",
+    loose_electron_pt     = 7,
+    loose_electron_eta    = 2.5,
+    loose_electron_dxy    = 0.5,
+    loose_electron_dz     = 1.0,
+    loose_electron_isoCut = lambda x: True,
+    loose_electron_lostHits = 1.0,
+    # muon isolation correction method (can be "rhoArea" or "deltaBeta")
+    mu_isoCorr = "deltaBeta" ,
+    mu_effectiveAreas = "Phys14_25ns_v1", #(can be 'Data2012' or 'Phys14_25ns_v1')
+    # electron isolation correction method (can be "rhoArea" or "deltaBeta")
+    ele_isoCorr = "rhoArea" ,
+    el_effectiveAreas = "Phys14_25ns_v1" , #(can be 'Data2012' or 'Phys14_25ns_v1')
+    ele_tightId = "Cuts_2012" ,
+    # Mini-isolation, with pT dependent cone: will fill in the miniRelIso, miniRelIsoCharged, miniRelIsoNeutral variables of the leptons (see https://indico.cern.ch/event/368826/ )
+    doMiniIsolation = False, # off by default since it requires access to all PFCandidates 
+    packedCandidates = 'packedPFCandidates',
+    miniIsolationPUCorr = 'rhoArea', # Allowed options: 'rhoArea' (EAs for 03 cone scaled by R^2), 'deltaBeta', 'raw' (uncorrected), 'weights' (delta beta weights; not validated)
+    miniIsolationVetoLeptons = None, # use 'inclusive' to veto inclusive leptons and their footprint in all isolation cones
+    # minimum deltaR between a loose electron and a loose muon (on overlaps, discard the electron)
+    min_dr_electron_muon = 100.0,
+    # do MC matching 
+    do_mc_match = True, # note: it will in any case try it only on MC, not on data
+    match_inclusiveLeptons = False, # match to all inclusive leptons
+    )
+
+
+## Jets Analyzer (generic)
+jetAna = cfg.Analyzer(
+    JetAnalyzer, name='jetAnalyzer',
+    jetCol = 'slimmedJets',
+    jetPt = 30.,
+    jetEta = 4.7,
+    jetEtaCentral = 4.7,
+    jetLepDR = 0.4,
+    jetLepArbitration = (lambda jet,lepton : lepton), # you can decide which to keep in case of overlaps; e.g. if the jet is b-tagged you might want to keep the jet
+    minLepPt = 10,
+    relaxJetId = False,  
+    doPuId = False, # Not commissioned in 7.0.X
+    recalibrateJets = False, # True, False, 'MC', 'Data'
+    mcGT     = "PHYS14_25_V2",
+    jecPath = "%s/src/CMGTools/RootTools/data/jec/" % os.environ['CMSSW_BASE'],
+    shiftJEC = 0, # set to +1 or -1 to get +/-1 sigma shifts
+    smearJets = False,
+    shiftJER = 0, # set to +1 or -1 to get +/-1 sigma shifts  
+    cleanJetsFromFirstPhoton = False,
+    cleanJetsFromTaus = False,
+    cleanJetsFromIsoTracks = False,
+    cleanGenJetsFromPhoton = False,
+    doQG = False,
+    )
+
+
+metAna = cfg.Analyzer(
+    METAnalyzer, name="metAnalyzer",
+    doTkMet = False,
+    doMetNoMu = False,
+    doMetNoPhoton = False,
+    recalibrate = False,
+    candidates='packedPFCandidates',
+    candidatesTypes='std::vector<pat::PackedCandidate>',
+    dzMax = 0.1,
+    )
+
+
+
+fsrPhotonMaker = cfg.Analyzer(
+    FSRPhotonMaker, name="fsrPhotonMaker",
+    leptons="selectedLeptons",
+    electronID = lambda x: x.electronID("POG_MVA_ID_Run2_NonTrig_HZZ")
+)
+
+
+fourLeptonAnalyzerSignal = cfg.Analyzer(
+    FourLeptonAnalyzer, name="fourLeptonAnalyzerSignal",
+    tag = "Signal"
+)
+
+fourLeptonAnalyzer2P2F = cfg.Analyzer(
+    FourLeptonAnalyzer2P2F, name="fourLeptonAnalyzer2P2F",
+    tag = "2P2F"
+)
+
+fourLeptonAnalyzer3P1F = cfg.Analyzer(
+    FourLeptonAnalyzer3P1F, name="fourLeptonAnalyzer3P1F",
+    tag = "3P1F"
+)
+
+fourLeptonAnalyzerSS = cfg.Analyzer(
+    FourLeptonAnalyzerSS, name="fourLeptonAnalyzerSS",
+    tag = "SS"
+)
+
+fourLeptonEventSkimmer = cfg.Analyzer(
+    FourLeptonEventSkimmer, name="fourLeptonEventSkimmer",
+    required = ['bestFourLeptonsSignal','bestFourLeptons2P2F','bestFourLeptons3P1F','bestFourLeptonsSS']
+
+)
+
+treeProducer = cfg.Analyzer(
+     AutoFillTreeProducer, name='fourLeptonTreeProducer',
+     vectorTree = False,
+     saveTLorentzVectors = False,  # can set to True to get also the TLorentzVectors, but trees will be bigger
+     globalVariables = hzz_globalVariables,
+     globalObjects = hzz_globalObjects,
+     collections = hzz_collections,
+     defaultFloatType = 'F',
+)
+
+
+
+
+# Core sequence of all common modules
+hzz4lCoreSequence = [
+    skimAnalyzer,
+    genAna,
+#    genFSRAna,
+   #eventSelector,
+    jsonAna,
+    triggerAna,
+    pileUpAna,
+    vertexAna,
+    lepAna,
+    jetAna,
+    metAna,
+    triggerFlagsAna,
+    fsrPhotonMaker,
+    fourLeptonAnalyzerSignal, 
+    fourLeptonAnalyzer2P2F,
+    fourLeptonAnalyzer3P1F,
+    fourLeptonAnalyzerSS,
+    fourLeptonEventSkimmer,
+    treeProducer
+]

--- a/CMGTools/HToZZ4L/python/analyzers/hzz4lCore_modules_cff.py
+++ b/CMGTools/HToZZ4L/python/analyzers/hzz4lCore_modules_cff.py
@@ -11,6 +11,7 @@ from CMGTools.HToZZ4L.analyzers.FourLeptonEventSkimmer import *
 from CMGTools.HToZZ4L.analyzers.FSRPhotonMaker import *
 from CMGTools.HToZZ4L.analyzers.GenFSRAnalyzer import *
 from CMGTools.HToZZ4L.analyzers.fourLeptonTree import *
+from CMGTools.HToZZ4L.samples.samples_13TeV_PHYS14 import triggers_mumu_iso,triggers_ee,triggers_3e,triggers_mue
 
 import os
 
@@ -65,8 +66,10 @@ triggerFlagsAna = cfg.Analyzer(
     TriggerBitAnalyzer, name="TriggerFlags",
     processName = 'HLT',
     triggerBits = {
-        # "<name>" : [ 'HLT_<Something>_v*', 'HLT_<SomethingElse>_v*' ] 
-    }
+        'DoubleMu' : triggers_mumu_iso,
+        'DoubleEl' : triggers_ee,
+        'TripleEl' : triggers_3e,                                                                                                                                               'MuEG'     : triggers_mue,
+        }
     )
 
 
@@ -105,6 +108,7 @@ lepAna = cfg.Analyzer(
     doRochesterCorrections=False,
     doElectronScaleCorrections=False, # "embedded" in 5.18 for regression
     doSegmentBasedMuonCleaning=True,
+    notCleaningElectrons=True, # no deltaR(ele,mu) cleaning at this step
     # inclusive very loose muon selection
     inclusive_muon_id  = "",
     inclusive_muon_pt  = 5,

--- a/CMGTools/HToZZ4L/python/analyzers/hzz4lCore_modules_cff.py
+++ b/CMGTools/HToZZ4L/python/analyzers/hzz4lCore_modules_cff.py
@@ -110,13 +110,13 @@ lepAna = cfg.Analyzer(
     doSegmentBasedMuonCleaning=True,
     notCleaningElectrons=True, # no deltaR(ele,mu) cleaning at this step
     # inclusive very loose muon selection
-    inclusive_muon_id  = "",
+    inclusive_muon_id  = "POG_Global_OR_TMArbitrated",
     inclusive_muon_pt  = 5,
     inclusive_muon_eta = 2.4,
     inclusive_muon_dxy = 0.5,
     inclusive_muon_dz  = 1.0,
     # loose muon selection
-    loose_muon_id     = "",
+    loose_muon_id     = "POG_Global_OR_TMArbitrated",
     loose_muon_pt     = 5,
     loose_muon_eta    = 2.4,
     loose_muon_dxy    = 0.5,
@@ -140,10 +140,11 @@ lepAna = cfg.Analyzer(
     # muon isolation correction method (can be "rhoArea" or "deltaBeta")
     mu_isoCorr = "deltaBeta" ,
     mu_effectiveAreas = "Phys14_25ns_v1", #(can be 'Data2012' or 'Phys14_25ns_v1')
+    mu_tightId = "POG_ID_Loose",
     # electron isolation correction method (can be "rhoArea" or "deltaBeta")
     ele_isoCorr = "rhoArea" ,
     el_effectiveAreas = "Phys14_25ns_v1" , #(can be 'Data2012' or 'Phys14_25ns_v1')
-    ele_tightId = "Cuts_2012" ,
+    ele_tightId = "POG_MVA_ID_Run2_NonTrig_HZZ",
     # Mini-isolation, with pT dependent cone: will fill in the miniRelIso, miniRelIsoCharged, miniRelIsoNeutral variables of the leptons (see https://indico.cern.ch/event/368826/ )
     doMiniIsolation = False, # off by default since it requires access to all PFCandidates 
     packedCandidates = 'packedPFCandidates',
@@ -166,9 +167,10 @@ jetAna = cfg.Analyzer(
     jetEtaCentral = 4.7,
     jetLepDR = 0.4,
     jetLepArbitration = (lambda jet,lepton : lepton), # you can decide which to keep in case of overlaps; e.g. if the jet is b-tagged you might want to keep the jet
-    minLepPt = 10,
+    minLepPt = 0,
+    lepSelCut = lambda lepton : lepton.sip3D() < 4 and lepton.tightId() and lepton.relIso04 < (0.4 if abs(lepton.pdgId())==13 else 0.5),
     relaxJetId = False,  
-    doPuId = False, # Not commissioned in 7.0.X
+    doPuId = True,
     recalibrateJets = False, # True, False, 'MC', 'Data'
     mcGT     = "PHYS14_25_V2",
     jecPath = "%s/src/CMGTools/RootTools/data/jec/" % os.environ['CMSSW_BASE'],

--- a/CMGTools/HToZZ4L/python/analyzers/zzTypes.py
+++ b/CMGTools/HToZZ4L/python/analyzers/zzTypes.py
@@ -21,6 +21,12 @@ ZZType = NTupleObjectType("ZZType", baseObjectTypes=[fourVectorType], variables 
     NTupleSubObject("z1_l2",  lambda x : x.leg1.leg2,leptonTypeHZZ),
     NTupleSubObject("z2_l1",  lambda x : x.leg2.leg1,leptonTypeHZZ),
     NTupleSubObject("z2_l2",  lambda x : x.leg2.leg2,leptonTypeHZZ),
+    NTupleVariable("mll_12",   lambda x : (x.leg1.leg1.p4()+x.leg1.leg2.p4()).M()),
+    NTupleVariable("mll_13",   lambda x : (x.leg1.leg1.p4()+x.leg2.leg1.p4()).M()),
+    NTupleVariable("mll_14",   lambda x : (x.leg1.leg1.p4()+x.leg2.leg2.p4()).M()),
+    NTupleVariable("mll_23",   lambda x : (x.leg1.leg2.p4()+x.leg2.leg1.p4()).M()),
+    NTupleVariable("mll_24",   lambda x : (x.leg1.leg2.p4()+x.leg2.leg2.p4()).M()),
+    NTupleVariable("mll_34",   lambda x : (x.leg2.leg1.p4()+x.leg2.leg2.p4()).M()),
     # -------
     NTupleVariable("KD",   lambda x : getattr(x, 'KD', -1.0), help="MELA KD"),
     NTupleVariable("MELAcosthetastar", lambda x : x.melaAngles.costhetastar if hasattr(x,'melaAngles') else -99.0, help="MELA angle costhetastar"),

--- a/CMGTools/HToZZ4L/python/analyzers/zzTypes.py
+++ b/CMGTools/HToZZ4L/python/analyzers/zzTypes.py
@@ -11,6 +11,15 @@ leptonTypeHZZ = NTupleObjectType("leptonHZZ", baseObjectTypes = [ leptonTypeExtr
     NTupleVariable("EffectiveArea04",   lambda x : x.EffectiveArea04,                 help="EA for isolation"),
 ])
 
+fsrPhotonTypeHZZ = NTupleObjectType("fsrPhotonHZZ", baseObjectTypes = [ particleType ], variables = [
+    NTupleVariable("chargedHadIso",   lambda x : getattr(x,'absIsoCH',-1.0),   help="PF Iso, R=0.3, charged hadrons only"),
+    NTupleVariable("neutralHadIso",   lambda x : getattr(x,'absIsoNH',-1.0),   help="PF Iso, R=0.3, neutral hadrons only"),
+    NTupleVariable("puChargedHadIso", lambda x : getattr(x,'absIsoPU',-1.0),   help="PF Iso, R=0.3, pileup charged hadrons only"),
+    NTupleVariable("relIso",          lambda x : getattr(x,'relIso', -1.0),    help="PF Rel Iso, R=0.3, charged + netural had + pileup"),
+    NTupleSubObject("closestLepton",  lambda x : x.globalClosestLepton, particleType),
+    NTupleVariable("closestLeptonDR", lambda x : deltaR(x.eta(),x.phi(),x.globalClosestLepton.eta(),x.globalClosestLepton.phi())),
+]) 
+
 ZZType = NTupleObjectType("ZZType", baseObjectTypes=[fourVectorType], variables = [
     NTupleVariable("hasFSR",   lambda x : x.hasFSR(), int),
     NTupleVariable("z1_hasFSR",   lambda x : x.leg1.hasFSR(), int),

--- a/CMGTools/HToZZ4L/python/analyzers/zzTypes.py
+++ b/CMGTools/HToZZ4L/python/analyzers/zzTypes.py
@@ -1,0 +1,34 @@
+from PhysicsTools.Heppy.analyzers.core.AutoFillTreeProducer  import * 
+
+leptonTypeHZZ = NTupleObjectType("leptonHZZ", baseObjectTypes = [ leptonTypeExtra ], variables = [
+    NTupleVariable("mvaIdPhys14",   lambda lepton : lepton.mvaRun2("NonTrigPhys14") if abs(lepton.pdgId()) == 11 else 1, help="EGamma POG MVA ID for non-triggering electrons, Phys14 re-training; 1 for muons"),
+    # Extra isolation variables
+    NTupleVariable("chargedHadIso04",   lambda x : x.chargedHadronIsoR(0.4)/x.pt(),   help="PF Iso, R=0.4, charged hadrons only"),
+    NTupleVariable("neutralHadIso04",   lambda x : x.neutralHadronIsoR(0.4)/x.pt(),   help="PF Iso, R=0.4, neutral hadrons only"),
+    NTupleVariable("photonIso04",       lambda x : x.photonIsoR(0.4)/x.pt(),          help="PF Iso, R=0.4, photons only"),
+    NTupleVariable("puChargedHadIso04", lambda x : x.puChargedHadronIsoR(0.4)/x.pt(), help="PF Iso, R=0.4, pileup charged hadrons only"),
+    NTupleVariable("rho",               lambda x : x.rho,                             help="rho for isolation"),
+    NTupleVariable("EffectiveArea04",   lambda x : x.EffectiveArea04,                 help="EA for isolation"),
+])
+
+ZZType = NTupleObjectType("ZZType", baseObjectTypes=[fourVectorType], variables = [
+    NTupleVariable("hasFSR",   lambda x : x.hasFSR(), int),
+    NTupleVariable("z1_hasFSR",   lambda x : x.leg1.hasFSR(), int),
+    NTupleVariable("z2_hasFSR",   lambda x : x.leg2.hasFSR(), int),
+    NTupleSubObject("z1",  lambda x : x.leg1,fourVectorType),
+    NTupleSubObject("z2",  lambda x : x.leg2,fourVectorType),
+    NTupleSubObject("z1_l1",  lambda x : x.leg1.leg1,leptonTypeHZZ),
+    NTupleSubObject("z1_l2",  lambda x : x.leg1.leg2,leptonTypeHZZ),
+    NTupleSubObject("z2_l1",  lambda x : x.leg2.leg1,leptonTypeHZZ),
+    NTupleSubObject("z2_l2",  lambda x : x.leg2.leg2,leptonTypeHZZ),
+    # -------
+    NTupleVariable("KD",   lambda x : getattr(x, 'KD', -1.0), help="MELA KD"),
+    NTupleVariable("MELAcosthetastar", lambda x : x.melaAngles.costhetastar if hasattr(x,'melaAngles') else -99.0, help="MELA angle costhetastar"),
+    NTupleVariable("MELAcostheta1", lambda x : x.melaAngles.costheta1 if hasattr(x,'melaAngles') else -99.0, help="MELA angle costheta1"),
+    NTupleVariable("MELAcostheta2", lambda x : x.melaAngles.costheta2 if hasattr(x,'melaAngles') else -99.0, help="MELA angle costheta2"),
+    NTupleVariable("MELAphi", lambda x : x.melaAngles.phi if hasattr(x,'melaAngles') else -99.0, help="MELA angle phi"),
+    NTupleVariable("MELAphistar1", lambda x : x.melaAngles.phistar1 if hasattr(x,'melaAngles') else -99.0, help="MELA angle phistar1"),
+
+])
+
+

--- a/CMGTools/HToZZ4L/python/analyzers/zzTypes.py
+++ b/CMGTools/HToZZ4L/python/analyzers/zzTypes.py
@@ -13,6 +13,7 @@ leptonTypeHZZ = NTupleObjectType("leptonHZZ", baseObjectTypes = [ leptonTypeExtr
 
 fsrPhotonTypeHZZ = NTupleObjectType("fsrPhotonHZZ", baseObjectTypes = [ particleType ], variables = [
     NTupleVariable("chargedHadIso",   lambda x : getattr(x,'absIsoCH',-1.0),   help="PF Iso, R=0.3, charged hadrons only"),
+    NTupleVariable("photonIso",       lambda x : getattr(x,'absIsoPH',-1.0),   help="PF Iso, R=0.3, photons only"),
     NTupleVariable("neutralHadIso",   lambda x : getattr(x,'absIsoNH',-1.0),   help="PF Iso, R=0.3, neutral hadrons only"),
     NTupleVariable("puChargedHadIso", lambda x : getattr(x,'absIsoPU',-1.0),   help="PF Iso, R=0.3, pileup charged hadrons only"),
     NTupleVariable("relIso",          lambda x : getattr(x,'relIso', -1.0),    help="PF Rel Iso, R=0.3, charged + netural had + pileup"),
@@ -36,6 +37,13 @@ ZZType = NTupleObjectType("ZZType", baseObjectTypes=[fourVectorType], variables 
     NTupleVariable("mll_23",   lambda x : (x.leg1.leg2.p4()+x.leg2.leg1.p4()).M()),
     NTupleVariable("mll_24",   lambda x : (x.leg1.leg2.p4()+x.leg2.leg2.p4()).M()),
     NTupleVariable("mll_34",   lambda x : (x.leg2.leg1.p4()+x.leg2.leg2.p4()).M()),
+    # -------
+    NTupleVariable("z1_pho_pt",  lambda x : (x.leg1.fsrPhoton.pt()  if x.leg1.hasFSR() else -99.0) ),
+    NTupleVariable("z1_pho_eta", lambda x : (x.leg1.fsrPhoton.eta() if x.leg1.hasFSR() else -99.0) ),
+    NTupleVariable("z1_pho_phi", lambda x : (x.leg1.fsrPhoton.phi() if x.leg1.hasFSR() else -99.0) ),
+    NTupleVariable("z2_pho_pt",  lambda x : (x.leg2.fsrPhoton.pt()  if x.leg2.hasFSR() else -99.0) ),
+    NTupleVariable("z2_pho_eta", lambda x : (x.leg2.fsrPhoton.eta() if x.leg2.hasFSR() else -99.0) ),
+    NTupleVariable("z2_pho_phi", lambda x : (x.leg2.fsrPhoton.phi() if x.leg2.hasFSR() else -99.0) ),
     # -------
     NTupleVariable("KD",   lambda x : getattr(x, 'KD', -1.0), help="MELA KD"),
     NTupleVariable("MELAcosthetastar", lambda x : x.melaAngles.costhetastar if hasattr(x,'melaAngles') else -99.0, help="MELA angle costhetastar"),

--- a/CMGTools/HToZZ4L/python/samples/samples_13TeV_PHYS14.py
+++ b/CMGTools/HToZZ4L/python/samples/samples_13TeV_PHYS14.py
@@ -23,7 +23,7 @@ triggers_mue   = [
     ]
 
 
-triggers_multilep  = triggers_mumu + triggers_ee + triggers_3e + triggers_mue
+triggers_multilep  = triggers_mumu_iso + triggers_ee + triggers_3e + triggers_mue
 
 
 #####COMPONENT CREATOR

--- a/CMGTools/HToZZ4L/python/samples/samples_13TeV_PHYS14.py
+++ b/CMGTools/HToZZ4L/python/samples/samples_13TeV_PHYS14.py
@@ -1,0 +1,115 @@
+import PhysicsTools.HeppyCore.framework.config as cfg
+import os
+
+
+
+
+################## Triggers (FIXME: update to the PHYS14 Trigger Menu)
+
+
+triggers_mumu_run1   = ["HLT_Mu17_Mu8_v*","HLT_Mu17_TkMu8_v*"]
+triggers_mumu_iso    = [ "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v*", "HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v*" ]
+triggers_mumu_noniso = [ "HLT_Mu30_TkMu11_v*" ]
+triggers_mumu = triggers_mumu_iso + triggers_mumu_noniso
+
+triggers_ee_run1   = ["HLT_Ele17_CaloIdT_TrkIdVL_CaloIsoVL_TrkIsoVL_Ele8_CaloIdT_TrkIdVL_CaloIsoVL_TrkIsoVL_v*",
+                      "HLT_Ele17_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_Ele8_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_v*",
+                      "HLT_Ele15_Ele8_Ele5_CaloIdL_TrkIdVL_v*"]
+triggers_ee = [ "HLT_Ele23_Ele12_CaloId_TrackId_Iso_v*" ]
+triggers_3e = [ "HLT_Ele17_Ele12_Ele10_CaloId_TrackId_v*" ]
+triggers_mue   = [
+    "HLT_Mu23_TrkIsoVVL_Ele12_Gsf_CaloId_TrackId_Iso_MediumWP_v*",
+    "HLT_Mu8_TrkIsoVVL_Ele23_Gsf_CaloId_TrackId_Iso_MediumWP_v*"
+    ]
+
+
+triggers_multilep  = triggers_mumu + triggers_ee + triggers_3e + triggers_mue
+
+
+#####COMPONENT CREATOR
+from CMGTools.TTHAnalysis.samples.ComponentCreator import ComponentCreator
+kreator = ComponentCreator()
+
+
+##################  PU40 bx25ns (not default, so samples have a _PU40bx25 postfix) ################## 
+GGHZZ4L_PU40bx25 = kreator.makeMCComponent("GGHZZ4L_PU40bx25", "/GluGluToHToZZTo4L_M-125_13TeV-powheg-pythia6/Phys14DR-PU40bx25_PHYS14_25_V1-v1/MINIAODSIM", "CMS", ".*root", 43.92*2.76E-04)
+mcSamplesPHYS14_PU40bx25 = [GGHZZ4L_PU40bx25]
+
+
+################## PU20 bx25ns (default of phys14, so no postfix) ##############
+
+# DY inclusive (cross section from FEWZ, StandardModelCrossSectionsat13TeV)
+DYJetsToLL_M50 = kreator.makeMCComponent("DYJetsToLL_M50", "/DYJetsToLL_M-50_13TeV-madgraph-pythia8/Phys14DR-PU20bx25_PHYS14_25_V1-v1/MINIAODSIM", "CMS", ".*root", 2008.*3)
+# DY HT bins: cross sections for DYJets taken from McM LO times inclusive k-factor from FEWZ(2008 pb x3)/McM(4746)
+DYJetsToLL_M50_HT100to200 = kreator.makeMCComponent("DYJetsToLL_M50_HT100to200", "/DYJetsToLL_M-50_HT-100to200_Tune4C_13TeV-madgraph-tauola/Phys14DR-PU20bx25_PHYS14_25_V1-v1/MINIAODSIM", "CMS", ".*root",194.3*1.27)
+DYJetsToLL_M50_HT200to400 = kreator.makeMCComponent("DYJetsToLL_M50_HT200to400", "/DYJetsToLL_M-50_HT-200to400_Tune4C_13TeV-madgraph-tauola/Phys14DR-PU20bx25_PHYS14_25_V1-v1/MINIAODSIM", "CMS", ".*root",52.24*1.27)
+DYJetsToLL_M50_HT400to600 = kreator.makeMCComponent("DYJetsToLL_M50_HT400to600", "/DYJetsToLL_M-50_HT-400to600_Tune4C_13TeV-madgraph-tauola/Phys14DR-PU20bx25_PHYS14_25_V1-v1/MINIAODSIM", "CMS", ".*root",6.546*1.27)
+DYJetsToLL_M50_HT600toInf = kreator.makeMCComponent("DYJetsToLL_M50_HT600toInf", "/DYJetsToLL_M-50_HT-600toInf_Tune4C_13TeV-madgraph-tauola/Phys14DR-PU20bx25_PHYS14_25_V1-v1/MINIAODSIM", "CMS", ".*root",2.179*1.27)
+DYJetsM50HT = [
+DYJetsToLL_M50_HT100to200,
+DYJetsToLL_M50_HT200to400,
+DYJetsToLL_M50_HT400to600,
+DYJetsToLL_M50_HT600toInf,
+]
+
+# TTbar cross section: MCFM with dynamic scale, StandardModelCrossSectionsat13TeV
+TTJets = kreator.makeMCComponent("TTJets", "/TTJets_MSDecaysCKM_central_Tune4C_13TeV-madgraph-tauola/Phys14DR-PU20bx25_PHYS14_25_V1-v1/MINIAODSIM", "CMS", ".*root",809.1)
+# TTV cross sections are from 13 TeV MG5_aMC@NLO v2.2.1, NNPDF 2.3nlo, fixed scale = mtop + 0.5*mv
+TTWJets = kreator.makeMCComponent("TTWJets", "/TTWJets_Tune4C_13TeV-madgraph-tauola/Phys14DR-PU20bx25_PHYS14_25_V1-v1/MINIAODSIM", "CMS", ".*root",0.6647)
+TTZJets = kreator.makeMCComponent("TTZJets", "/TTZJets_Tune4C_13TeV-madgraph-tauola/Phys14DR-PU20bx25_PHYS14_25_V1-v1/MINIAODSIM", "CMS", ".*root",0.8565)
+# TTH cross section from LHC Higgs XS WG: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/CERNYellowReportPageAt1314TeV?rev=15
+TTH = kreator.makeMCComponent("TTH", "/TTbarH_M-125_13TeV_amcatnlo-pythia8-tauola/Phys14DR-PU20bx25_tsg_PHYS14_25_V1-v2/MINIAODSIM", "CMS", ".*root",0.5085)
+
+# cross section from StandardModelCrossSectionsat13TeV (NLO MCFM, mll > 12) times BR=(3*0.108)*(3*0.0337)
+WZJetsTo3LNu = kreator.makeMCComponent("WZJetsTo3LNu", "/WZJetsTo3LNu_Tune4C_13TeV-madgraph-tauola/Phys14DR-PU20bx25_PHYS14_25_V1-v1/MINIAODSIM", "CMS", ".*root",2.165)
+# cross section from StandardModelCrossSectionsat13TeV (NLO MCFM, mll > 12) times BR=(3*0.0337)**2
+ZZTo4L = kreator.makeMCComponent("ZZTo4L","/ZZTo4L_Tune4C_13TeV-powheg-pythia8/Phys14DR-PU20bx25_PHYS14_25_V1-v1/MINIAODSIM", "CMS", ".*root", 	31.8*(3*0.03366**2))
+
+# GGH cross section from LHC Higgs XS WG: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/CERNYellowReportPageAt1314TeV?rev=15
+GGHZZ4L = kreator.makeMCComponent("GGHZZ4L", "/GluGluToHToZZTo4L_M-125_13TeV-powheg-pythia6/Phys14DR-PU20bx25_tsg_PHYS14_25_V1-v1/MINIAODSIM", "CMS", ".*root", 43.92*2.76E-04)
+
+
+mcSamplesPHYS14_PU20bx25 =  [DYJetsToLL_M50] + DYJetsM50HT  + [ TTJets, TTWJets, TTZJets, TTH, WZJetsTo3LNu, ZZTo4L, GGHZZ4L]
+
+
+mcSamples = mcSamplesPHYS14_PU20bx25 + mcSamplesPHYS14_PU40bx25 
+
+#-----------DATA---------------
+dataDir = os.environ['CMSSW_BASE']+"/src/CMGTools/TTHAnalysis/data"
+#lumi: 12.21+7.27+0.134 = 19.62 /fb @ 8TeV
+json=dataDir+'/json/Cert_Run2012ABCD_22Jan2013ReReco.json'
+
+#SingleMu = cfg.DataComponent(
+#    name = 'SingleMu',
+#    files = kreator.getFilesFromEOS('SingleMu', 
+#                                    '/SingleMu/Run2012D-15Apr2014-v1/AOD/02e0a1be-c9c7-11e3-bfe2-0024e83ef644/MINIAOD/CMSSW_7_0_9_patch2_GR_70_V2_AN1',
+#                                    '/eos/cms/store/cmst3/user/cmgtools/CMG/%s'),
+#    intLumi = 1,
+#    triggers = [],
+#    json = json
+#    )
+
+           
+dataSamplesMu=[]
+dataSamplesE=[]
+dataSamplesMuE=[]
+dataSamplesAll = dataSamplesMu+dataSamplesE+dataSamplesMuE
+
+from CMGTools.TTHAnalysis.setup.Efficiencies import *
+
+
+#Define splitting
+for comp in mcSamples:
+    comp.isMC = True
+    comp.isData = False
+    comp.splitFactor = 250 #  if comp.name in [ "WJets", "DY3JetsM50", "DY4JetsM50","W1Jets","W2Jets","W3Jets","W4Jets","TTJetsHad" ] else 100
+    comp.puFileMC=dataDir+"/puProfile_Summer12_53X.root"
+    comp.puFileData=dataDir+"/puProfile_Data12.root"
+    comp.efficiency = eff2012
+
+#for comp in dataSamplesAll:
+#    comp.splitFactor = 1000
+#    comp.isMC = False
+#    comp.isData = True
+
+

--- a/CMGTools/HToZZ4L/python/scripts/eventDumper.py
+++ b/CMGTools/HToZZ4L/python/scripts/eventDumper.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+from math import *
+import re, string
+from CMGTools.TTHAnalysis.treeReAnalyzer import *
+
+from optparse import OptionParser
+import json
+
+parser = OptionParser(usage="usage: %prog [options] rootfile [what] \nrun with --help to get list of options")
+parser.add_option("-r", "--run-range",  dest="runrange", default=(0,99999999), type="float", nargs=2, help="Run range")
+parser.add_option("-c", "--cut-file",  dest="cutfile", default=None, type="string", help="Cut file to apply")
+parser.add_option("-C", "--cut",  dest="cut", default=None, type="string", help="Cut to apply")
+parser.add_option("-T", "--type",  dest="type", default=None, type="string", help="Type of events to select")
+parser.add_option("-F", "--fudge",   dest="fudge",  default=False, action="store_true",  help="print -999 for missing variables")
+parser.add_option("-m", "--mc",     dest="ismc",  default=False, action="store_true",  help="print MC match info")
+parser.add_option("--mm", "--more-mc",     dest="moremc",  default=False, action="store_true",  help="print more MC match info")
+parser.add_option("--tau", dest="tau",  default=False, action="store_true",  help="print Taus")
+parser.add_option("-j", "--json",   dest="json",  default=None, type="string", help="JSON file to apply")
+parser.add_option("-n", "--maxEvents",  dest="maxEvents", default=-1, type="int", help="Max events")
+parser.add_option("-f", "--format",   dest="fmt",  default=None, type="string",  help="Print this format string")
+parser.add_option("-t", "--tree",          dest="tree", default='tree', help="Pattern for tree name");
+
+(options, args) = parser.parse_args(); sys.argv = []
+
+jsonmap = {}
+if options.json:
+    J = json.load(open(options.json, 'r'))
+    for r,l in J.iteritems():
+        jsonmap[long(r)] = l
+    stderr.write("Loaded JSON %s with %d runs\n" % (options.json, len(jsonmap)))
+
+def testJson(ev):
+    try:
+        lumilist = jsonmap[ev.run]
+        for (start,end) in lumilist:
+            if start <= ev.lumi and ev.lumi <= end:
+                return True
+        return False
+    except KeyError:
+        return False
+
+class BaseDumper(Module):
+    def __init__(self,name,options=None,booker=None):
+        Module.__init__(self,name,booker)
+        self.options = options
+    def preselect(self,ev):
+        return True
+    def makeVars(self,ev):
+        jets = Collection(ev,"Jet")
+        ev.Jet1_pt_zs = jets[0].pt if len(jets) > 0 else -1.0
+        ev.Jet2_pt_zs = jets[1].pt if len(jets) > 1 else -1.0
+    def analyze(self,ev):
+        try:
+            self.makeVars(ev)
+        except:
+            pass
+        if self.options.fmt: 
+            print string.Formatter().vformat(options.fmt.replace("\\t","\t"),[],ev)
+            return True
+        leps = Collection(ev,"Lep","nLep") 
+        jets = Collection(ev,"Jet")
+        print "run %6d lumi %4d event %11d " % (ev.run, ev.lumi, ev.evt)
+        for i,l in enumerate(leps):
+            print "    lepton %d: id %+2d pt %5.1f eta %+4.2f phi %+4.2f    relIso %5.3f sip3d %5.2f dxy %+4.3f dz %+4.3f " % (
+                    i+1, l.pdgId,l.pt,l.eta,l.phi, l.relIso04, l.sip3d, l.dxy, l.dz),
+            if self.options.ismc:
+                print "   mcMatch id %+3d, any %+2d" % (l.mcMatchId, l.mcMatchAny)
+        for i,j in enumerate(jets):
+            if self.options.ismc:
+                print "    jet %d:  pt %5.1f uncorrected pt %5.1f eta %+4.2f phi %+4.2f  btag %4.3f mcMatch %2d mcFlavour %d mcPt %5.1f" % (i, j.pt, j.rawPt, j.eta, j.phi, min(1.,max(0.,j.btagCSV)), j.mcMatchId, j.mcFlavour, j.mcPt)
+            else:
+                print "    jet %d:  pt %5.1f uncorrected pt %5.1f eta %+4.2f phi %+4.2f  btag %4.3f" % (i+1, j.pt, j.rawPt, j.eta, j.phi, min(1.,max(0.,j.btagCSV)))
+ 
+        print "    met %6.2f (phi %+4.2f)" % (ev.met_pt, ev.met_phi)
+        if self.options.ismc:
+            print "    vertices %d" % (ev.nVert)
+
+cut = None
+if options.cut:
+    cut = options.cut
+ 
+file = ROOT.TFile.Open(args[0])
+tree = file.Get(options.tree)
+tree.vectorTree = False
+dumper = BaseDumper("dump", options)
+el = EventLoop([dumper])
+el.loop(tree,options.maxEvents,cut=cut)
+

--- a/CMGTools/HToZZ4L/python/scripts/eventDumper.py
+++ b/CMGTools/HToZZ4L/python/scripts/eventDumper.py
@@ -61,13 +61,14 @@ class BaseDumper(Module):
         jets = Collection(ev,"Jet")
         print "run %6d lumi %4d event %11d " % (ev.run, ev.lumi, ev.evt)
         for i,l in enumerate(leps):
-            print "    lepton %d: id %+2d pt %5.1f eta %+4.2f phi %+4.2f    relIso %5.3f sip3d %5.2f dxy %+4.3f dz %+4.3f " % (
-                    i+1, l.pdgId,l.pt,l.eta,l.phi, l.relIso04, l.sip3d, l.dxy, l.dz),
+            print "    lepton %d: id %+2d pt %5.1f eta %+4.2f phi %+4.2f   tightId %d relIso %5.3f sip3d %5.2f dxy %+4.3f dz %+4.3f " % (
+                    i+1, l.pdgId,l.pt,l.eta,l.phi, l.tightId, l.relIso04, l.sip3d, l.dxy, l.dz),
             if self.options.ismc:
-                print "   mcMatch id %+3d, any %+2d" % (l.mcMatchId, l.mcMatchAny)
+                print "   mcMatch id %+3d, any %+2d" % (l.mcMatchId, l.mcMatchAny),
+            print ""
         for i,j in enumerate(jets):
             if self.options.ismc:
-                print "    jet %d:  pt %5.1f uncorrected pt %5.1f eta %+4.2f phi %+4.2f  btag %4.3f mcMatch %2d mcFlavour %d mcPt %5.1f" % (i, j.pt, j.rawPt, j.eta, j.phi, min(1.,max(0.,j.btagCSV)), j.mcMatchId, j.mcFlavour, j.mcPt)
+                print "    jet %d:  pt %5.1f uncorrected pt %5.1f eta %+4.2f phi %+4.2f  btag %4.3f mcMatch %2d mcFlavour %2d mcPt %5.1f" % (i, j.pt, j.rawPt, j.eta, j.phi, min(1.,max(0.,j.btagCSV)), j.mcMatchId, j.mcFlavour, j.mcPt)
             else:
                 print "    jet %d:  pt %5.1f uncorrected pt %5.1f eta %+4.2f phi %+4.2f  btag %4.3f" % (i+1, j.pt, j.rawPt, j.eta, j.phi, min(1.,max(0.,j.btagCSV)))
  

--- a/CMGTools/HToZZ4L/python/scripts/eventDumper.py
+++ b/CMGTools/HToZZ4L/python/scripts/eventDumper.py
@@ -65,7 +65,7 @@ class BaseDumper(Module):
             return True
         leps = Collection(ev,"Lep","nLep") 
         jets = Collection(ev,"Jet")
-        print "run %6d lumi %4d event %11d " % (ev.run, ev.lumi, ev.evt)
+        print "run %6d lumi %4d event %11d (id: %d:%d:%d) " % (ev.run, ev.lumi, ev.evt, ev.run, ev.lumi, ev.evt)
         for i,l in enumerate(leps):
             print "    lepton %d: id %+2d pt %5.1f eta %+4.2f phi %+4.2f   tightId %d relIso %5.3f sip3d %5.2f dxy %+4.3f dz %+4.3f bdt %+5.3f lostHits %1d" % (
                     i+1, l.pdgId,l.pt,l.eta,l.phi, l.tightId, l.relIso04, l.sip3d, l.dxy, l.dz, l.mvaIdPhys14, l.lostHits),
@@ -81,8 +81,8 @@ class BaseDumper(Module):
                 print "    jet %d:  pt %5.1f uncorrected pt %5.1f eta %+4.2f phi %+4.2f  btag %4.3f" % (i+1, j.pt, j.rawPt, j.eta, j.phi, min(1.,max(0.,j.btagCSV)))
         fsr = Collection(ev, "FSR")
         for i,g in enumerate(fsr):
-            print "    fsr %2d:  pt %5.1f eta %+4.2f phi %+4.2f  reliso% 6.3f (ch %5.1f nh %5.1f pu %5.1f), closest lepton id %+2d pt %5.1f eta %+4.2f phi %+4.2f dr %.4f " % (i+1, 
-                        g.pt, g.eta, g.phi, g.relIso, g.chargedHadIso, g.neutralHadIso, g.puChargedHadIso, g.closestLepton_pdgId, g.closestLepton_pt, g.closestLepton_eta, g.closestLepton_phi, g.closestLeptonDR)
+            print "    fsr %2d:  pt %5.1f eta %+4.2f phi %+4.2f  reliso% 6.3f (ch %5.1f nh %5.1f ph %5.1f pu %5.1f), closest lepton id %+2d pt %5.1f eta %+4.2f phi %+4.2f dr %.4f " % (i+1, 
+                        g.pt, g.eta, g.phi, g.relIso, g.chargedHadIso, g.neutralHadIso, g.photonIso, g.puChargedHadIso, g.closestLepton_pdgId, g.closestLepton_pt, g.closestLepton_eta, g.closestLepton_phi, g.closestLeptonDR)
 
         for type in "zz", "zz2P2F", "zz3P1F", "zzSS":
             zzs = Collection(ev,type)
@@ -93,8 +93,10 @@ class BaseDumper(Module):
                         findLepIndex(leps, zz.z1_l2_pt, zz.z1_l2_eta),
                         findLepIndex(leps, zz.z2_l1_pt, zz.z2_l1_eta),
                         findLepIndex(leps, zz.z2_l2_pt, zz.z2_l2_eta) ]
+                ifsr1 = findLepIndex(fsr, zz.z1_pho_pt, zz.z1_pho_eta) if zz.z1_hasFSR else -1
+                ifsr2 = findLepIndex(fsr, zz.z2_pho_pt, zz.z2_pho_eta) if zz.z2_hasFSR else -1
                 print "      candidate %1d: leptons %d %d %d %d, mass %6.3f mz1 %6.3f mz2 %6.3f , Z1 FSR %d Z2 FSR %d " % (
-                        izz, ils[0]+1,ils[1]+1,ils[2]+1,ils[3]+1, zz.mass, zz.z1_mass, zz.z2_mass, zz.z1_hasFSR, zz.z2_hasFSR )
+                        izz, ils[0]+1,ils[1]+1,ils[2]+1,ils[3]+1, zz.mass, zz.z1_mass, zz.z2_mass, ifsr1+1, ifsr2+1 )
                 print "                   m12 %6.3f  m13 %6.3f  m14 %6.3f  m23 %6.3f  m24 %6.3f  m34 %6.3f" % (
                          zz.mll_12, zz.mll_13, zz.mll_14, zz.mll_23, zz.mll_24, zz.mll_34)
         print "    met %6.2f (phi %+4.2f)" % (ev.met_pt, ev.met_phi)

--- a/CMGTools/HToZZ4L/python/scripts/eventDumper.py
+++ b/CMGTools/HToZZ4L/python/scripts/eventDumper.py
@@ -13,6 +13,7 @@ parser.add_option("-C", "--cut",  dest="cut", default=None, type="string", help=
 parser.add_option("-T", "--type",  dest="type", default=None, type="string", help="Type of events to select")
 parser.add_option("-F", "--fudge",   dest="fudge",  default=False, action="store_true",  help="print -999 for missing variables")
 parser.add_option("-m", "--mc",     dest="ismc",  default=False, action="store_true",  help="print MC match info")
+parser.add_option("-M", "--more",     dest="ismore",  default=False, action="store_true",  help="print more info")
 parser.add_option("--mm", "--more-mc",     dest="moremc",  default=False, action="store_true",  help="print more MC match info")
 parser.add_option("--tau", dest="tau",  default=False, action="store_true",  help="print Taus")
 parser.add_option("-j", "--json",   dest="json",  default=None, type="string", help="JSON file to apply")
@@ -71,11 +72,17 @@ class BaseDumper(Module):
             if self.options.ismc:
                 print "   mcMatch id %+3d, any %+2d" % (l.mcMatchId, l.mcMatchAny),
             print ""
+            if self.options.ismore:
+                print "              charged iso %.3f nh iso %.3f  pho iso %.3f   pu %.3f  rho %.3f  ea %.3f " % ( l.chargedHadIso04, l.neutralHadIso04, l.photonIso04, l.puChargedHadIso04, l.rho, l.EffectiveArea04 )
         for i,j in enumerate(jets):
             if self.options.ismc:
                 print "    jet %d:  pt %5.1f uncorrected pt %5.1f eta %+4.2f phi %+4.2f  btag %4.3f mcMatch %2d mcFlavour %2d mcPt %5.1f" % (i, j.pt, j.rawPt, j.eta, j.phi, min(1.,max(0.,j.btagCSV)), j.mcMatchId, j.mcFlavour, j.mcPt)
             else:
                 print "    jet %d:  pt %5.1f uncorrected pt %5.1f eta %+4.2f phi %+4.2f  btag %4.3f" % (i+1, j.pt, j.rawPt, j.eta, j.phi, min(1.,max(0.,j.btagCSV)))
+        fsr = Collection(ev, "FSR")
+        for i,g in enumerate(fsr):
+            print "    fsr %2d:  pt %5.1f eta %+4.2f phi %+4.2f  reliso% 6.3f (ch %5.1f nh %5.1f pu %5.1f), closest lepton id %+2d pt %5.1f eta %+4.2f phi %+4.2f dr %.4f " % (i+1, 
+                        g.pt, g.eta, g.phi, g.relIso, g.chargedHadIso, g.neutralHadIso, g.puChargedHadIso, g.closestLepton_pdgId, g.closestLepton_pt, g.closestLepton_eta, g.closestLepton_phi, g.closestLeptonDR)
 
         for type in "zz", "zz2P2F", "zz3P1F", "zzSS":
             zzs = Collection(ev,type)
@@ -86,13 +93,14 @@ class BaseDumper(Module):
                         findLepIndex(leps, zz.z1_l2_pt, zz.z1_l2_eta),
                         findLepIndex(leps, zz.z2_l1_pt, zz.z2_l1_eta),
                         findLepIndex(leps, zz.z2_l2_pt, zz.z2_l2_eta) ]
-                print "      candidate %1d: leptons %d %d %d %d, mass %6.3f mz1 %6.3f mz2 %6.3f  " % (
-                        izz, ils[0]+1,ils[1]+1,ils[2]+1,ils[3]+1, zz.mass, zz.z1_mass, zz.z2_mass, )
+                print "      candidate %1d: leptons %d %d %d %d, mass %6.3f mz1 %6.3f mz2 %6.3f , Z1 FSR %d Z2 FSR %d " % (
+                        izz, ils[0]+1,ils[1]+1,ils[2]+1,ils[3]+1, zz.mass, zz.z1_mass, zz.z2_mass, zz.z1_hasFSR, zz.z2_hasFSR )
                 print "                   m12 %6.3f  m13 %6.3f  m14 %6.3f  m23 %6.3f  m24 %6.3f  m34 %6.3f" % (
                          zz.mll_12, zz.mll_13, zz.mll_14, zz.mll_23, zz.mll_24, zz.mll_34)
         print "    met %6.2f (phi %+4.2f)" % (ev.met_pt, ev.met_phi)
         print "    vertices %d" % (ev.nVert)
         print "    HLT: ", " ".join([t for t in "DoubleMu DoubleEl TripleEl MuEG".split() if getattr(ev,"HLT_"+t)])
+        print ""
 
 cut = None
 if options.cut:

--- a/CMGTools/HToZZ4L/python/scripts/eventDumper.py
+++ b/CMGTools/HToZZ4L/python/scripts/eventDumper.py
@@ -91,8 +91,8 @@ class BaseDumper(Module):
                 print "                   m12 %6.3f  m13 %6.3f  m14 %6.3f  m23 %6.3f  m24 %6.3f  m34 %6.3f" % (
                          zz.mll_12, zz.mll_13, zz.mll_14, zz.mll_23, zz.mll_24, zz.mll_34)
         print "    met %6.2f (phi %+4.2f)" % (ev.met_pt, ev.met_phi)
-        if self.options.ismc:
-            print "    vertices %d" % (ev.nVert)
+        print "    vertices %d" % (ev.nVert)
+        print "    HLT: ", " ".join([t for t in "DoubleMu DoubleEl TripleEl MuEG".split() if getattr(ev,"HLT_"+t)])
 
 cut = None
 if options.cut:

--- a/CMGTools/HToZZ4L/python/tools/CutFlowMaker.py
+++ b/CMGTools/HToZZ4L/python/tools/CutFlowMaker.py
@@ -1,0 +1,77 @@
+
+class CutFlowMaker():
+    def __init__(self,counter,event,src1,src2 = None):
+        self.counter=counter
+        self.obj1=src1
+        self.obj2=src2
+        self.event=event
+        
+    def setSource1(self,src1):
+        self.obj1=src1
+        
+    def setSource2(self,src2):
+        self.obj2=src2
+    
+    def mergeResults(self,name=None):
+        tmp = set(self.obj1)
+        tmp.update(self.obj2)
+        self.obj1=tmp
+        self.obj2=None
+        if name is not None:
+            setattr(self.event,name,tmp)
+
+    def applyCut(self,cut,text = '',minN = 1,name=None):
+        selectedObjects=filter(cut,self.obj1)
+        if self.counter is not None:
+            if text not in self.counter.dico:
+                self.counter.register(text)
+
+        if len(selectedObjects)>=minN:
+            if self.counter is not None: 
+                self.counter.inc(text)
+            self.obj1=selectedObjects
+
+            if name is not None:
+                 setattr(self.event,name,self.obj1)
+	    return True
+        else:
+            self.obj1=selectedObjects
+            if name is not None:
+                setattr(self.event,name,self.obj1)
+            return False
+
+    def applyDoubleCut(self,cut1,cut2,text = '',minN = 1,name1 = None, name2 = None,minN1=-1,minN2=-1):
+        selectedObjects1=filter(cut1,self.obj1)
+        selectedObjects2=filter(cut2,self.obj2)
+   
+        merged=set(selectedObjects1)
+        merged.update(selectedObjects2)
+
+        isOK = (len(merged)>=minN) and \
+               (len(selectedObjects1)>=minN1) and \
+               (len(selectedObjects2)>=minN2)
+        if self.counter is not None:
+            if text not in self.counter.dico:
+                self.counter.register(text)
+
+        if isOK:
+            if self.counter is not None:
+                self.counter.inc(text)
+            self.obj1=selectedObjects1
+            self.obj2=selectedObjects2
+            if name1 is not None:
+                setattr(self.event,name1,selectedObjects1)
+            if name2 is not None:
+                setattr(self.event,name2,selectedObjects2)
+
+            return True
+        else:
+            self.obj1=selectedObjects1
+            self.obj2=selectedObjects2
+            if name1 is not None:
+                setattr(self.event,name1,selectedObjects1)
+            if name2 is not None:
+                setattr(self.event,name2,selectedObjects2)
+
+        return False
+   

--- a/CMGTools/HToZZ4L/python/tools/DiObject.py
+++ b/CMGTools/HToZZ4L/python/tools/DiObject.py
@@ -1,0 +1,142 @@
+from ROOT import TLorentzVector
+from math import pi,acos,asin
+from PhysicsTools.HeppyCore.utils.deltar import deltaR, deltaPhi
+
+class DiObject( TLorentzVector ):
+    '''Class used for Zs, and also for Higgs candidates'''
+    def __init__(self, leg1, leg2,doSort = True):
+        if (leg2.pt() > leg1.pt()) and doSort:
+            leg2, leg1 = leg1, leg2
+        lv1 = TLorentzVector( leg1.px(), leg1.py(), leg1.pz(), leg1.energy() )
+        lv2 = TLorentzVector( leg2.px(), leg2.py(), leg2.pz(), leg2.energy() )
+        lv1 += lv2 
+        super( DiObject, self).__init__( lv1 )
+        self.leg1 = leg1
+        self.leg2 = leg2
+
+
+
+
+    def px(self):
+         return self.Px()
+    def py(self):
+         return self.Py()
+    def pz(self):
+         return self.Pz()
+    def energy(self):
+         return self.Energy()
+
+    def eta(self):
+         return self.Eta()
+    def phi(self):
+         return self.Phi()
+
+    def pt(self):
+         return self.Pt()
+
+    def mass(self):
+         return self.M()
+
+
+
+#    def __getattr__(self, name):
+#        '''Trick to preserve the interface in use in CMSSW.'''
+#        if name.lower() == 'mass':
+#            name = 'M'
+        # changing the first letter of the function name to upper case. 
+#        capName = ''.join( [name[0].capitalize(), name[1:]] ) 
+#        return getattr( self, capName )
+
+    def PdgId(self):
+        '''Dummy, needed to fill the tree'''
+        return 23
+
+    def Sip3D(self):
+        '''Dummy, needed to fill the tree'''
+        return -1
+
+    def RelIso(self, dBetaCor):
+        '''Sum of the relative isolation (dbeta corrected) of the 2 legs'''
+        return self.leg1.relIso( dBetaCor ) + self.leg2.relIso(dBetaCor )
+
+        
+    def charge(self):
+        return self.leg1.charge() + self.leg2.charge()
+        
+    def __str__(self):
+        return ', '.join( ['DiObject:', str(self.leg1), str(self.leg2)] )
+
+    def daughterLeptons(self):
+        return [self.leg1,self.leg2]
+
+    def daughterPhotons(self):
+        if hasattr(self,'fsrPhoton'):
+            return [self.fsrPhoton]
+        else:
+            return []
+    
+
+
+
+############FSR variables
+    def fsrUncorrected(self):
+        if not hasattr(self,'fsrPhoton'):
+            return self
+        else:
+            gamma = TLorentzVector( self.fsrPhoton.px(), self.fsrPhoton.py(), self.fsrPhoton.pz(), self.fsrPhoton.energy() )
+            return self-gamma
+    
+    def setFSR(self,photon):
+        self.fsrPhoton=photon
+        gamma = TLorentzVector( photon.px(), photon.py(), photon.pz(), photon.energy() )
+        z     = TLorentzVector(self.Px(),self.Py(),self.Pz(),self.Energy())
+        new=gamma+z
+        self.SetPxPyPzE(new.Px(),new.Py(),new.Pz(),new.Energy())
+        
+
+    def hasFSR(self):
+        return hasattr(self,'fsrPhoton')
+
+    def fsrTheta1(self):
+        if hasattr(self,'fsrPhoton'):
+            photon=self.fsrPhoton
+            return acos(round(self.leg1.p4().Vect().Dot(photon.p4().Vect())/(self.leg1.p4().P()*photon.p4().P()),5))*180/pi
+        else:
+            return -99
+
+
+    def fsrTheta2(self):
+        if hasattr(self,'fsrPhoton'):
+            photon=self.fsrPhoton
+            return acos(round(self.leg2.p4().Vect().Dot(photon.p4().Vect())/(self.leg2.p4().P()*photon.p4().P()),5))*180/pi
+        else:
+            return -99
+
+    def fsrDR1(self):
+        if hasattr(self,'fsrPhoton'):
+            photon=self.fsrPhoton
+            return deltaR(self.leg1.eta(),self.leg1.phi(),photon.eta(),photon.phi())
+
+    def fsrDR2(self):
+        if hasattr(self,'fsrPhoton'):
+            photon=self.fsrPhoton
+            return deltaR(self.leg2.eta(),self.leg2.phi(),photon.eta(),photon.phi())
+
+
+    def fsrThetaStar(self):
+        if hasattr(self,'fsrPhoton'):
+            photon=self.fsrPhoton
+            plane = (self.leg1.p4().Vect().Cross(self.leg2.p4().Vect())).unit()
+            angle = asin(round(plane.Dot(photon.p4().Vect())/(photon.p4().P()),5))*180/pi
+            return abs(angle)
+
+    def fsrDRStar(self):
+        if hasattr(self,'fsrPhoton'):
+            photon=self.fsrPhoton
+            plane = self.leg1.p4().Vect().Cross(self.leg2.p4().Vect()).unit()
+            return deltaR(plane.eta(),plane.phi(),photon.eta(),photon.phi())
+
+
+        
+
+        

--- a/CMGTools/HToZZ4L/python/tools/DiObjectPair.py
+++ b/CMGTools/HToZZ4L/python/tools/DiObjectPair.py
@@ -1,0 +1,115 @@
+from ROOT import TLorentzVector
+from CMGTools.HToZZ4L.tools.DiObject import DiObject
+class DiObjectPair( TLorentzVector ):
+    '''Class used for A->VV'''
+    def __init__(self, leg1, leg2,leg3,leg4):
+
+        a=DiObject(leg1,leg2)
+        b=DiObject(leg3,leg4)
+        lv=a+b
+        super( DiObjectPair, self).__init__(lv)
+        self.leg1=a
+        self.leg2=b
+
+
+    def px(self):
+         return self.Px()
+    def py(self):
+         return self.Py()
+    def pz(self):
+         return self.Pz()
+    def energy(self):
+         return self.Energy()
+
+    def eta(self):
+         return self.Eta()
+    def phi(self):
+         return self.Phi()
+
+    def pt(self):
+         return self.Pt()
+
+    def mass(self):
+         return self.M()
+
+
+
+    def sortedPtLeg(self,N):
+        ''' Gives the Nth highest pt lepton. 0 is the highest'''
+        leptons=sorted([self.leg1.leg1, \
+                        self.leg1.leg2, \
+                        self.leg2.leg1, \
+                        self.leg2.leg2], \
+                       key=lambda x: x.pt(), \
+                       reverse=True)
+        return leptons[N]
+        
+
+    def charge(self):
+        return self.leg1.charge() + self.leg2.charge()
+
+    def PdgId(self):
+        '''Dummy, needed to fill the tree'''
+        return 24
+
+
+
+    def sortedMassPairs(self,onlyOS = False):
+        pairs=[DiObject(self.leg1.leg1,self.leg1.leg2),
+               DiObject(self.leg2.leg1,self.leg2.leg2),
+               DiObject(self.leg1.leg1,self.leg2.leg1),
+               DiObject(self.leg1.leg1,self.leg2.leg2),
+               DiObject(self.leg1.leg2,self.leg2.leg1),
+               DiObject(self.leg1.leg2,self.leg2.leg2)]
+
+        if onlyOS:
+            pairs=filter(lambda x: x.charge()==0,pairs)
+
+        pairs=sorted(pairs,key=lambda x: x.mass())
+        return pairs
+
+    def minPairMass(self):
+        sortedPairs=self.sortedMassPairs()
+        return sortedPairs[0].mass()
+
+    def minOSPairMass(self):
+        sortedPairs=self.sortedMassPairs(True)
+        if len(sortedPairs)>0:
+            return sortedPairs[0].mass()
+        else:
+            return 999.
+
+    def __str__(self):
+        return ', '.join( ['DiObjectPair:', str(self.leg1), str(self.leg2)] )
+
+
+    def fsrUncorrected(self):
+        return self.leg1.fsrUncorrected()+self.leg2.fsrUncorrected()
+
+    def hasFSR(self):
+        return self.leg1.hasFSR() or self.leg2.hasFSR()
+
+
+    def updateP4(self):
+        
+        z1     = TLorentzVector(self.leg1.Px(),self.leg1.Py(),self.leg1.Pz(),self.leg1.Energy())
+        z2     = TLorentzVector(self.leg2.Px(),self.leg2.Py(),self.leg2.Pz(),self.leg2.Energy())
+        new=z1+z2
+        self.SetPxPyPzE(new.Px(),new.Py(),new.Pz(),new.Energy())
+
+
+
+    def daughterLeptons(self):
+        return [self.leg1.leg1,self.leg1.leg2,self.leg2.leg1,self.leg2.leg2]
+
+    def daughterPhotons(self):
+        return self.leg1.daughterPhotons()+self.leg2.daughterPhotons()
+
+
+
+        ###MELA#########################################
+
+
+        ###MELA#########################################
+
+        

--- a/CMGTools/HToZZ4L/python/tools/DiObjectPair.py
+++ b/CMGTools/HToZZ4L/python/tools/DiObjectPair.py
@@ -4,8 +4,8 @@ class DiObjectPair( TLorentzVector ):
     '''Class used for A->VV'''
     def __init__(self, leg1, leg2,leg3,leg4):
 
-        a=DiObject(leg1,leg2)
-        b=DiObject(leg3,leg4)
+        a=DiObject(leg1,leg2, doSort=False)
+        b=DiObject(leg3,leg4, doSort=False)
         lv=a+b
         super( DiObjectPair, self).__init__(lv)
         self.leg1=a

--- a/CMGTools/HToZZ4L/python/tools/OverlapCleaner.py
+++ b/CMGTools/HToZZ4L/python/tools/OverlapCleaner.py
@@ -1,0 +1,27 @@
+from CMGTools.RootTools.utils.DeltaR import deltaR
+
+
+class OverlapCleaner(object):
+    def __init__(self,collection,dr,sourcePdgId,targetPdgId,targetID):
+        self.collection=collection
+        self.dr = dr
+        self.sourcePdgId=sourcePdgId
+        self.targetPdgId=targetPdgId
+        self.targetID = targetID
+
+    def __call__(self,object):
+        hasOverlap=False
+        if abs(object.pdgId()) ==self.sourcePdgId:
+            for p in self.collection:
+                if abs(p.pdgId()) ==self.targetPdgId:
+                    if self.targetID(p)==True:
+                        if deltaR(object.eta(),object.phi(),p.eta(),p.phi())<self.dr:
+                            hasOverlap=True
+
+        if hasOverlap:
+            return False                 
+        else:
+            return True
+
+                          
+                

--- a/PhysicsTools/Heppy/python/analyzers/core/EventSelector.py
+++ b/PhysicsTools/Heppy/python/analyzers/core/EventSelector.py
@@ -7,13 +7,24 @@ class EventSelector( Analyzer ):
     Example:
 
     eventSelector = cfg.Analyzer(
-    'EventSelector',
-    toSelect = [
-    1239742,
-    38001,
-    159832
-    ]
+        'EventSelector',
+        toSelect = [
+            1239742, 
+            38001,
+            159832
+        ]
     )
+
+    it can also be used with (run,lumi,event) tuples:
+
+    eventSelector = cfg.Analyzer(
+        'EventSelector',
+        toSelect = [
+            (1,40,1239742),
+            (1,38,38001),
+        ]
+    )
+
 
     The process function of this analyzer returns False if the event number
     is not in the toSelect list.
@@ -38,7 +49,7 @@ class EventSelector( Analyzer ):
         run = event.input.eventAuxiliary().id().run()
         lumi = event.input.eventAuxiliary().id().luminosityBlock()
         eId = event.input.eventAuxiliary().id().event()
-        if eId in self.cfg_ana.toSelect:
+        if eId in self.cfg_ana.toSelect or (run, lumi, eId) in self.cfg_ana.toSelect:
             # raise ValueError('found')
             print 'Selecting', run, lumi, eId
             return True 

--- a/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
@@ -63,6 +63,7 @@ class JetAnalyzer( Analyzer ):
         self.jetLepDR = getattr(self.cfg_ana, 'jetLepDR', 0.4)
         self.jetLepArbitration = getattr(self.cfg_ana, 'jetLepArbitration', lambda jet,lepton: lepton) 
         self.lepPtMin = getattr(self.cfg_ana, 'minLepPt', -1)
+        self.lepSelCut = getattr(self.cfg_ana, 'lepSelCut', lambda lep : True)
         self.jetGammaDR =  getattr(self.cfg_ana, 'jetGammaDR', 0.4)
         if(self.cfg_ana.doQG):
             self.qglcalc = QGLikelihoodCalculator("/afs/cern.ch/user/t/tomc/public/qgTagger/QGLikelihoodDBFiles/QGL_v1a/pdfQG_AK4chs_antib_13TeV_v1.root")
@@ -125,7 +126,7 @@ class JetAnalyzer( Analyzer ):
         ## Clean Jets from leptons
         leptons = []
         if hasattr(event, 'selectedLeptons'):
-            leptons = [ l for l in event.selectedLeptons if l.pt() > self.lepPtMin ]
+            leptons = [ l for l in event.selectedLeptons if l.pt() > self.lepPtMin and self.lepSelCut(l) ]
         if self.cfg_ana.cleanJetsFromTaus and hasattr(event, 'selectedTaus'):
             leptons = leptons[:] + event.selectedTaus
         if self.cfg_ana.cleanJetsFromIsoTracks and hasattr(event, 'selectedIsoCleanTrack'):
@@ -366,6 +367,7 @@ setattr(JetAnalyzer,"defaultConfig", cfg.Analyzer(
     jetLepDR = 0.4,
     jetLepArbitration = (lambda jet,lepton : lepton), # you can decide which to keep in case of overlaps; e.g. if the jet is b-tagged you might want to keep the jet
     minLepPt = 10,
+    lepSelCut = lambda lep : True,
     relaxJetId = False,  
     doPuId = False, # Not commissioned in 7.0.X
     doQG = False, 

--- a/PhysicsTools/Heppy/python/analyzers/objects/LeptonAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/LeptonAnalyzer.py
@@ -236,6 +236,11 @@ class LeptonAnalyzer( Analyzer ):
         for mu in allmuons:
             mu.associatedVertex = event.goodVertices[0] if len(event.goodVertices)>0 else event.vertices[0]
 
+        # Set tight id if specified
+        if hasattr(self.cfg_ana, "mu_tightId"):
+            for mu in allmuons:
+               mu.tightIdResult = mu.muonID(self.cfg_ana.mu_tightId)
+ 
         # Compute relIso in 0.3 and 0.4 cones
         for mu in allmuons:
             if self.cfg_ana.mu_isoCorr=="rhoArea" :
@@ -330,7 +335,10 @@ class LeptonAnalyzer( Analyzer ):
             elif self.cfg_ana.ele_tightId=="Cuts_2012" :
                  ele.tightIdResult = -1 + 1*ele.electronID("POG_Cuts_ID_2012_Veto_full5x5") + 1*ele.electronID("POG_Cuts_ID_2012_Loose_full5x5") + 1*ele.electronID("POG_Cuts_ID_2012_Medium_full5x5") + 1*ele.electronID("POG_Cuts_ID_2012_Tight_full5x5")
             else :
-                 raise RuntimeError, "Unsupported ele_tightId name '" + str(self.cfg_ana.ele_tightId) +  "'! For now only 'MVA' and 'Cuts_2012' are supported."
+                 try:
+                     ele.tightIdResult = ele.electronID(self.cfg_ana.ele_tightId)
+                 except RuntimeError:
+                     raise RuntimeError, "Unsupported ele_tightId name '" + str(self.cfg_ana.ele_tightId) +  "'! For now only 'MVA' and 'Cuts_2012' are supported, in addition to what provided in Electron.py."
 
         
         return allelectrons 
@@ -481,6 +489,7 @@ setattr(LeptonAnalyzer,"defaultConfig",cfg.Analyzer(
     # muon isolation correction method (can be "rhoArea" or "deltaBeta")
     mu_isoCorr = "rhoArea" ,
     mu_effectiveAreas = "Phys14_25ns_v1", #(can be 'Data2012' or 'Phys14_25ns_v1')
+    mu_tightId = "POG_ID_Tight" ,
     # electron isolation correction method (can be "rhoArea" or "deltaBeta")
     ele_isoCorr = "rhoArea" ,
     el_effectiveAreas = "Phys14_25ns_v1" , #(can be 'Data2012' or 'Phys14_25ns_v1')

--- a/PhysicsTools/Heppy/python/physicsobjects/Electron.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Electron.py
@@ -30,6 +30,7 @@ class Electron( Lepton ):
         elif id == "POG_MVA_ID_Trig_full5x5":     return self.mvaIDTight(full5x5=True)
         elif id == "POG_MVA_ID_Run2_NonTrig_Loose":    return self.mvaIDRun2("NonTrigPhys14","Loose")
         elif id == "POG_MVA_ID_Run2_NonTrig_Tight":    return self.mvaIDRun2("NonTrigPhys14","Tight")
+        elif id == "POG_MVA_ID_Run2_NonTrig_HZZ":          return self.mvaIDRun2("NonTrigPhys14","HZZ")
         elif id.startswith("POG_Cuts_ID_"):
                 return self.cutBasedId(id.replace("POG_Cuts_ID_","POG_"))
         for ID in self.electronIDs():
@@ -181,12 +182,19 @@ class Electron( Lepton ):
                     if   (eta < 0.8)  : return self.mvaRun2(name) > 0.73;
                     elif (eta < 1.479): return self.mvaRun2(name) > 0.57;
                     else              : return self.mvaRun2(name) > 0.05;
+                elif wp=="HZZ":
+                    if self.pt() <= 10:
+                        if   (eta < 0.8)  : return self.mvaRun2(name) > -0.202;
+                        elif (eta < 1.479): return self.mvaRun2(name) > -0.444;
+                        else              : return self.mvaRun2(name) > +0.264;
+                    else:
+                        if   (eta < 0.8)  : return self.mvaRun2(name) > -0.110;
+                        elif (eta < 1.479): return self.mvaRun2(name) > -0.284;
+                        else              : return self.mvaRun2(name) > -0.212;
                 else: raise RuntimeError, "Ele MVA ID Working point not found"
             else: raise RuntimeError, "Ele MVA ID type not found"
 
 
-    def mvaIDZZ(self):
-        return self.mvaIDLoose() and (self.gsfTrack().trackerExpectedHitsInner().numberOfLostHits()<=1)
 
     def chargedHadronIsoR(self,R=0.4):
         if   R == 0.3: return self.physObj.pfIsolationVariables().sumChargedHadronPt

--- a/PhysicsTools/Heppy/python/physicsobjects/Lepton.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Lepton.py
@@ -11,7 +11,7 @@ class Lepton( PhysicsObject):
         '''3D impact parameter significance.'''
         return abs(self.dB(self.PV3D) / self.edB(self.PV3D))
 
-    def absIsoFromEA(self,rho,eta,effectiveArea1 = None,effectiveArea2 = None):
+    def absIsoFromEA(self,area = "04"):
         '''
         Calculate Isolation using the effective area approach. If fsrPhotons is set
         the list of photons is subtracted from the isolation cone. It works with one or
@@ -20,25 +20,10 @@ class Lepton( PhysicsObject):
         photonIso = self.photonIso()
         if hasattr(self,'fsrPhotons'):
             for gamma in self.fsrPhotons:
-                photonIso=photonIso-gamma.pt()                
-        ea1 = rho
-        ea2 = rho
-        if effectiveArea1 is not None:
-            for element in effectiveArea1:
-                if abs(eta)>= element['etaMin'] and \
-                   abs(eta)< element['etaMax']:
-                    ea1 = ea1 * element['area']
-                    break
-        else:
-            return self.chargedHadronIso()+max(0.,photonIso+self.neutralHadronIso()-ea1)
-        if effectiveArea2 is not None:
-            for element in effectiveArea2:
-                if abs(eta)>= element['etaMin'] and \
-                   abs(eta)< element['etaMax']:
-                    ea2 = ea2 * element['area']
-            return self.chargedHadronIso()+max(0.,photonIso-ea1)+max(0.,self.neutralHadronIso()-ea2)
-        else:
-            return self.chargedHadronIso()+max(0.,photonIso+self.neutralHadronIso()-ea1)
+                photonIso=max(photonIso-gamma.pt(),0.0)                
+
+        offset = self.rho*getattr(self,"EffectiveArea"+area)
+        return self.chargedHadronIso()+max(0.,photonIso+self.neutralHadronIso()-offset)            
 
 
     def absIso(self, dBetaFactor=0, allCharged=0):

--- a/PhysicsTools/Heppy/python/physicsobjects/Muon.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Muon.py
@@ -7,8 +7,8 @@ class Muon( Lepton ):
         return self.physObj.isLooseMuon()
 
     def tightId( self ):
-        '''Tight ID as recommended by mu POG.'''
-        return self.muonID("POG_ID_Tight")
+        '''Tight ID as recommended by mu POG (unless redefined in the lepton analyzer).'''
+        return getattr(self,"tightIdResult",self.muonID("POG_ID_Tight"))
 
     def muonID(self, name, vertex=None):
         if name == "" or name is None: 
@@ -31,6 +31,8 @@ class Muon( Lepton ):
                 if not self.looseId(): return False
                 goodGlb = self.physObj.isGlobalMuon() and self.physObj.globalTrack().normalizedChi2() < 3 and self.physObj.combinedQuality().chi2LocalPosition < 12 and self.physObj.combinedQuality().trkKink < 20;
                 return self.physObj.innerTrack().validFraction() >= 0.8 and self.physObj.segmentCompatibility() >= (0.303 if goodGlb else 0.451)
+            if name == "POG_Global_OR_TMArbitrated":
+                return self.physObj.isGlobalMuon() or (self.physObj.isTrackerMuon() and self.physObj.numberOfMatchedStations() > 0)
         return self.physObj.muonID(name)
             
     def mvaId(self):


### PR DESCRIPTION
Code for the H &rarr;  ZZ &rarr; 4l analysis, plus some Heppy improvements, all transparent:
- in the event selector, allow passing `(run,lumi,event)` tuples instead of bare events
- allow setting the electron tight id also to anything recognized by the `electronID` method, and same also for the muon
- add an optional `lepCut` parameter to the jet cleaner to apply a preselection to the leptons used in jet cleaning (e.g. for applying a tighter id)
- support for sub-objects in an object type (see e.g. a7c917d7e40fab1fefe7920306180529cdbcb694)
