### PR TITLE
Heppy: Safe printing for particles that are directly put into the event

### DIFF
--- a/PhysicsTools/HeppyCore/python/framework/event.py
+++ b/PhysicsTools/HeppyCore/python/framework/event.py
@@ -37,6 +37,7 @@ class Event(object):
             if isinstance( value, collections.Iterable ) and \
                    not isinstance(value, (str,unicode)) and \
                    not isinstance(value, TChain) and \
+                   not hasattr(value, 'numberOfDaughters') and \
                    not recursive :
                 tmp = map(str, value)
 

--- a/PhysicsTools/HeppyCore/python/framework/event.py
+++ b/PhysicsTools/HeppyCore/python/framework/event.py
@@ -1,4 +1,3 @@
-import collections
 from ROOT import TChain
 
 class Event(object):
@@ -34,10 +33,9 @@ class Event(object):
             if hasattr(value, '__getitem__'):
                 if (len(value)>0 and value[0].__class__ == value.__class__):
                     recursive = True
-            if isinstance( value, collections.Iterable ) and \
+            if hasattr(value, '__contains__') and \
                    not isinstance(value, (str,unicode)) and \
                    not isinstance(value, TChain) and \
-                   not hasattr(value, 'numberOfDaughters') and \
                    not recursive :
                 tmp = map(str, value)
 


### PR DESCRIPTION
Fixes crash when particle is directly put into the event but daughters are not available (and it anyway makes more sense to not print the daughters)

Will be added to another PR for the CMG branch.
