### PR TITLE
H2TauTau: SVfit updates, added QCD to samples

### DIFF
--- a/CMGTools/H2TauTau/python/proto/samples/phys14/connector.py
+++ b/CMGTools/H2TauTau/python/proto/samples/phys14/connector.py
@@ -8,6 +8,7 @@ from CMGTools.RootTools.utils.splitFactor                   import splitFactor
 from CMGTools.H2TauTau.proto.samples.phys14.higgs           import mc_higgs
 from CMGTools.H2TauTau.proto.samples.phys14.ewk             import mc_ewk
 from CMGTools.H2TauTau.proto.samples.phys14.diboson         import mc_diboson
+from CMGTools.H2TauTau.proto.samples.phys14.qcd             import mc_qcd
 from CMGTools.H2TauTau.proto.samples.phys14.triggers_tauMu  import mc_triggers as mc_triggers_mt
 from CMGTools.H2TauTau.proto.samples.phys14.triggers_tauEle import mc_triggers as mc_triggers_et
 from CMGTools.H2TauTau.proto.samples.phys14.triggers_tauTau import mc_triggers as mc_triggers_tt
@@ -34,24 +35,30 @@ class httConnector(object):
         self.homedir         = os.getenv('HOME')
         self.mc_dict         = {}
         self.MC_list         = []
-        self.aliases         = aliases = {
-                                          '/GluGluToHToTauTau.*Phys14DR.*' : 'HiggsGGH'         ,
-                                          '/VBF_HToTauTau.*Phys14DR.*'     : 'HiggsVBF'         ,
-                                          '/DYJetsToLL.*Phys14DR.*'        : 'DYJets'           ,
-                                          '/TTJets.*Phys14DR.*'            : 'TTJets'           ,
-                                          '/T_tW.*Phys14DR.*'              : 'T_tW'             ,
-                                          '/Tbar_tW.*Phys14DR.*'           : 'Tbar_tW'          ,
-                                          '/WZJetsTo3LNu.*Phys14DR.*'      : 'WZJetsTo3LNu'     ,
-                                          '/TTbarH.*Phys14DR.*'            : 'HiggsTTHInclusive',
-                                          '/WJetsToLNu.*Phys14DR.*'        : 'WJets'            ,
+        self.aliases         = aliases =  {
+                                          '/GluGluToHToTauTau.*Phys14DR.*'            : 'HiggsGGH'         ,
+                                          '/VBF_HToTauTau.*Phys14DR.*'                : 'HiggsVBF'         ,
+                                          '/DYJetsToLL.*Phys14DR.*'                   : 'DYJets'           ,
+                                          '/TTJets.*Phys14DR.*'                       : 'TTJets'           ,
+                                          '/T_tW.*Phys14DR.*'                         : 'T_tW'             ,
+                                          '/Tbar_tW.*Phys14DR.*'                      : 'Tbar_tW'          ,
+                                          '/WZJetsTo3LNu.*Phys14DR.*'                 : 'WZJetsTo3LNu'     ,
+                                          '/TTbarH.*Phys14DR.*'                       : 'HiggsTTHInclusive',
+                                          '/WJetsToLNu.*Phys14DR.*'                   : 'WJets'            ,
+                                          '/QCD_Pt-10to20_EMEnriched.*Phys14DR.*'     : 'QCDEM10to20'      ,
+                                          '/QCD_Pt-20to30_EMEnriched.*Phys14DR.*'     : 'QCDEM20to30'      ,
+                                          '/QCD_Pt-30to80_EMEnriched.*Phys14DR.*'     : 'QCDEM30to80'      ,
+                                          '/QCD_Pt-80to170_EMEnriched.*Phys14DR.*'    : 'QCDEM80to170'     ,
+                                          '/QCD_Pt-30to50_MuEnrichedPt5.*Phys14DR.*'  : 'QCDMu30to50'      ,
+                                          '/QCD_Pt-50to80_MuEnrichedPt5.*Phys14DR.*'  : 'QCDMu50to80'      ,
+                                          '/QCD_Pt-80to120_MuEnrichedPt5.*Phys14DR.*' : 'QCDMu80to120'     ,
                                          }
-
         self.dictionarize_()
         self.listify_()
 
     def dictionarize_(self):
         ''' '''
-        for s in mc_higgs + mc_ewk + mc_diboson:
+        for s in mc_higgs + mc_ewk + mc_diboson + mc_qcd:
             self.mc_dict[s.name] = s
 
     def listify_(self):
@@ -108,7 +115,7 @@ class httConnector(object):
 
         for alias_k, alias_v in self.mc_dict.items():
             m = regex.match(alias_k)
-            if m:
+            if m and 'QCD' not in alias_k:
                 alias_k = m.group('sample')
             if alias_k not in self.aliases.values():
                 continue
@@ -138,3 +145,20 @@ class httConnector(object):
 
     def pruneSampleList_(self):
         self.MC_list = [m for m in self.MC_list if m.files]
+
+if __name__ == '__main__':
+
+    from optparse import OptionParser
+    parser = OptionParser()
+    parser.usage = ''' To be written '''
+
+    parser.add_option('-T', '--tier'      , dest = 'tier'      ,  help = 'Tier. Search samples on eos that end with this tier'                                            )
+    parser.add_option('-U', '--user'      , dest = 'user'      ,  help = 'User. User or group that owns the samples. Default htautau_group'    , default = 'htautau_group')
+    parser.add_option('-P', '--pattern'   , dest = 'pattern'   ,  help = 'Pattern. Connect only files that match this pattern. Default .*root' , default = '.*root'       )
+    parser.add_option('-C', '--channel'   , dest = 'channel'   ,  help = 'Channel. Choose [mt, et, tt, em]. Default mt'                        , default = 'mt'           )
+    parser.add_option('-p', '--production', dest = 'production',  help = 'Production. Check the cache first. Default False'                    , default = False          )
+
+    (options,args) = parser.parse_args()
+
+    my_connect = httConnector(options.tier, options.user, options.pattern, options.channel, options.production)
+    my_connect.connect()

--- a/CMGTools/H2TauTau/python/proto/samples/phys14/qcd.py
+++ b/CMGTools/H2TauTau/python/proto/samples/phys14/qcd.py
@@ -1,0 +1,82 @@
+import CMGTools.RootTools.fwlite.Config as cfg
+
+QCDEM10to20 = cfg.MCComponent(
+    name          = 'QCDEM10to20',
+    files         = []           ,
+    xSection      = 1.           ,
+    nGenEvents    = 1            ,
+    triggers      = []           ,
+    effCorrFactor = 1
+    )
+
+QCDEM20to30 = cfg.MCComponent(
+    name          = 'QCDEM20to30',
+    files         = []           ,
+    xSection      = 1.           ,
+    nGenEvents    = 1            ,
+    triggers      = []           ,
+    effCorrFactor = 1
+    )
+
+QCDEM30to80 = cfg.MCComponent(
+    name          = 'QCDEM30to80',
+    files         = []           ,
+    xSection      = 1.           ,
+    nGenEvents    = 1            ,
+    triggers      = []           ,
+    effCorrFactor = 1
+    )
+
+QCDEM80to170 = cfg.MCComponent(
+    name          = 'QCDEM80to170',
+    files         = []            ,
+    xSection      = 1.            ,
+    nGenEvents    = 1             ,
+    triggers      = []            ,
+    effCorrFactor = 1
+    )
+
+QCDMu30to50 = cfg.MCComponent(
+    name          = 'QCDMu30to50',
+    files         = []           ,
+    xSection      = 1.           ,
+    nGenEvents    = 1            ,
+    triggers      = []           ,
+    effCorrFactor = 1
+    )
+
+QCDMu50to80 = cfg.MCComponent(
+    name          = 'QCDMu50to80',
+    files         = []           ,
+    xSection      = 1.           ,
+    nGenEvents    = 1            ,
+    triggers      = []           ,
+    effCorrFactor = 1
+    )
+
+QCDMu80to120 = cfg.MCComponent(
+    name          = 'QCDMu80to120',
+    files         = []            ,
+    xSection      = 1.            ,
+    nGenEvents    = 1             ,
+    triggers      = []            ,
+    effCorrFactor = 1
+    )
+
+mc_qcd_em = [
+    QCDEM10to20 ,
+    QCDEM20to30 ,
+    QCDEM30to80 ,
+    QCDEM80to170,
+    ]
+
+mc_qcd_mu = [
+    QCDMu30to50 ,
+    QCDMu50to80 ,
+    QCDMu80to120,
+    ]
+
+mc_qcd = []
+mc_qcd += mc_qcd_em
+mc_qcd += mc_qcd_mu
+

--- a/TauAnalysis/SVfitStandalone/bin/BuildFile.xml
+++ b/TauAnalysis/SVfitStandalone/bin/BuildFile.xml
@@ -1,4 +1,5 @@
 <bin   file="testSVfitStandalone.cc" name="testSVfitStandalone">
+  <use name="FWCore/ParameterSet"/>
   <use name="TauAnalysis/SVfitStandalone"/>
   <use name="rootcintex"/>
   <use name="root"/>

--- a/TauAnalysis/SVfitStandalone/bin/testSVfitStandalone.cc
+++ b/TauAnalysis/SVfitStandalone/bin/testSVfitStandalone.cc
@@ -7,10 +7,13 @@
    from a flat n-tuple or single event.
 */
 
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+
 #include "TauAnalysis/SVfitStandalone/interface/SVfitStandaloneAlgorithm.h"
 
-#include "TTree.h"
 #include "TFile.h"
+#include "TTree.h"
+#include "TH1.h"
 
 void singleEvent()
 {
@@ -29,28 +32,33 @@ void singleEvent()
   // define lepton four vectors
   std::vector<svFitStandalone::MeasuredTauLepton> measuredTauLeptons;
   measuredTauLeptons.push_back(svFitStandalone::MeasuredTauLepton(svFitStandalone::kTauToElecDecay, 33.7393, 0.9409,  -0.541458, 0.51100e-3)); // tau -> electron decay (Pt, eta, phi, mass)
-  measuredTauLeptons.push_back(svFitStandalone::MeasuredTauLepton(svFitStandalone::kTauToHadDecay,  25.7322, 0.618228, 2.79362,  0.13957));    // tau -> hadron decay   (Pt, eta, phi, mass)
+  measuredTauLeptons.push_back(svFitStandalone::MeasuredTauLepton(svFitStandalone::kTauToHadDecay,  25.7322, 0.618228, 2.79362,  0.13957, 0)); // tau -> 1prong0pi0 hadronic decay (Pt, eta, phi, mass)
   // define algorithm (set the debug level to 3 for testing)
   unsigned verbosity = 2;
   SVfitStandaloneAlgorithm algo(measuredTauLeptons, measuredMETx, measuredMETy, covMET, verbosity);
-  algo.addLogM(false);
+  algo.addLogM(false);  
+  edm::FileInPath inputFileName_visPtResolution("TauAnalysis/SVfitStandalone/data/svFitVisMassAndPtResolutionPDF.root");
+  TH1::AddDirectory(false);  
+  TFile* inputFile_visPtResolution = new TFile(inputFileName_visPtResolution.fullPath().data());
+  algo.shiftVisPt(true, inputFile_visPtResolution);
   /* 
      the following lines show how to use the different methods on a single event
   */
   // minuit fit method
   //algo.fit();
   // integration by VEGAS (same as function algo.integrate() that has been in use when markov chain integration had not yet been implemented)
-  algo.integrateVEGAS();
+  //algo.integrateVEGAS();
   // integration by markov chain MC
-  //algo.integrateMarkovChain();
+  algo.integrateMarkovChain();
 
   double mass = algo.getMass(); // return value is in units of GeV
   if ( algo.isValidSolution() ) {
-    std::cout << "found mass = " << mass << " (expected value = 123.126)" << std::endl;
+    std::cout << "found mass = " << mass << " (expected value = 118.64)" << std::endl;
   } else {
     std::cout << "sorry -- status of NLL is not valid [" << algo.isValidSolution() << "]" << std::endl;
   }
-  return;
+
+  delete inputFile_visPtResolution;
 }
 
 void eventsFromTree(int argc, char* argv[]) 

--- a/TauAnalysis/SVfitStandalone/src/SVfitStandaloneAlgorithm.cc
+++ b/TauAnalysis/SVfitStandalone/src/SVfitStandaloneAlgorithm.cc
@@ -200,7 +200,7 @@ SVfitStandaloneAlgorithm::SVfitStandaloneAlgorithm(const std::vector<svFitStanda
     integrator2_(0),
     integrator2_nDim_(0),
     isInitialized2_(false),
-    maxObjFunctionCalls2_(250000),
+    maxObjFunctionCalls2_(100000),
     marginalizeVisMass_(false),
     lutVisMassAllDMs_(0),
     shiftVisMass_(false),
@@ -244,6 +244,8 @@ SVfitStandaloneAlgorithm::~SVfitStandaloneAlgorithm()
   //delete lutVisPtResDM0_;
   //delete lutVisPtResDM1_;
   //delete lutVisPtResDM10_;
+
+  delete clock_;
 }
 
 namespace
@@ -313,20 +315,20 @@ SVfitStandaloneAlgorithm::setup()
 {
   using namespace svFitStandalone;
 
-  if ( verbose_ >= 1 ) {
-    std::cout << "<SVfitStandaloneAlgorithm::setup()>:" << std::endl;
-  }
+  //if ( verbose_ >= 1 ) {
+  //  std::cout << "<SVfitStandaloneAlgorithm::setup()>:" << std::endl;
+  //}
   for ( size_t idx = 0; idx < nll_->measuredTauLeptons().size(); ++idx ) {
     const MeasuredTauLepton& measuredTauLepton = nll_->measuredTauLeptons()[idx];
-    if ( verbose_ >= 1 ) {
-      std::cout << " --> upper limit of leg1::mNuNu will be set to "; 
-      if ( measuredTauLepton.type() == kTauToHadDecay ) { 
-	std::cout << "0";
-      } else {
-	std::cout << (svFitStandalone::tauLeptonMass - TMath::Min(measuredTauLepton.mass(), 1.5));
-      } 
-      std::cout << std::endl;
-    }
+    //if ( verbose_ >= 1 ) {
+    //  std::cout << " --> upper limit of leg1::mNuNu will be set to "; 
+    //  if ( measuredTauLepton.type() == kTauToHadDecay ) { 
+    //	  std::cout << "0";
+    //  } else {
+    //	  std::cout << (svFitStandalone::tauLeptonMass - TMath::Min(measuredTauLepton.mass(), 1.5));
+    //  } 
+    //  std::cout << std::endl;
+    //}
     // start values for xFrac
     minimizer_->SetLimitedVariable(
       idx*kMaxFitParams + kXFrac, 
@@ -378,11 +380,11 @@ SVfitStandaloneAlgorithm::setup()
 void
 SVfitStandaloneAlgorithm::fit()
 {
-  if ( verbose_ >= 1 ) {
-    std::cout << "<SVfitStandaloneAlgorithm::fit()>" << std::endl
-	      << " dimension of fit    : " << nll_->measuredTauLeptons().size()*svFitStandalone::kMaxFitParams << std::endl
-	      << " maxObjFunctionCalls : " << maxObjFunctionCalls_ << std::endl; 
-  }
+  //if ( verbose_ >= 1 ) {
+  //  std::cout << "<SVfitStandaloneAlgorithm::fit()>" << std::endl
+  //	        << " dimension of fit    : " << nll_->measuredTauLeptons().size()*svFitStandalone::kMaxFitParams << std::endl
+  //	        << " maxObjFunctionCalls : " << maxObjFunctionCalls_ << std::endl; 
+  //}
   // clear minimizer
   minimizer_->Clear();
   // set verbosity level of minimizer
@@ -398,19 +400,19 @@ SVfitStandaloneAlgorithm::fit()
   // compute uncertainties for increase of objective function by 0.5 wrt. 
   // minimum (objective function is log-likelihood function)
   minimizer_->SetErrorDef(0.5);
-  if ( verbose_ >= 1 ) {
-    std::cout << "starting ROOT::Math::Minimizer::Minimize..." << std::endl;
-    std::cout << " #freeParameters = " << minimizer_->NFree() << ","
-  	      << " #constrainedParameters = " << (minimizer_->NDim() - minimizer_->NFree()) << std::endl;
-  }
+  //if ( verbose_ >= 1 ) {
+  //  std::cout << "starting ROOT::Math::Minimizer::Minimize..." << std::endl;
+  //  std::cout << " #freeParameters = " << minimizer_->NFree() << ","
+  //	        << " #constrainedParameters = " << (minimizer_->NDim() - minimizer_->NFree()) << std::endl;
+  //}
   // do the minimization
   nll_->addDelta(false);
   nll_->addSinTheta(true);
   nll_->requirePhysicalSolution(false);
   minimizer_->Minimize();
-  if ( verbose_ >= 2 ) { 
-    minimizer_->PrintResults(); 
-  };
+  //if ( verbose_ >= 2 ) { 
+  //  minimizer_->PrintResults(); 
+  //};
   /* get Minimizer status code, check if solution is valid:
     
      0: Valid solution
@@ -421,9 +423,9 @@ SVfitStandaloneAlgorithm::fit()
      5: Any other failure
   */
   fitStatus_ = minimizer_->Status();
-  if ( verbose_ >=1 ) { 
-    std::cout << "--> fitStatus = " << fitStatus_ << std::endl; 
-  }
+  //if ( verbose_ >=1 ) { 
+  //  std::cout << "--> fitStatus = " << fitStatus_ << std::endl; 
+  //}
   
   // and write out the result
   using svFitStandalone::kXFrac;
@@ -439,31 +441,31 @@ SVfitStandaloneAlgorithm::fit()
   fittedDiTauSystem_ = fittedTauLeptons_[0] + fittedTauLeptons_[1];
   mass_ = fittedDiTauSystem().mass();
   massUncert_ = TMath::Sqrt(0.25*x1RelErr*x1RelErr + 0.25*x2RelErr*x2RelErr)*fittedDiTauSystem().mass();
-  if ( verbose_ >= 2 ) {
-    std::cout << ">> -------------------------------------------------------------" << std::endl;
-    std::cout << ">> Resonance Record: " << std::endl;
-    std::cout << ">> -------------------------------------------------------------" << std::endl;
-    std::cout << ">> pt  (di-tau)    = " << fittedDiTauSystem().pt  () << std::endl;
-    std::cout << ">> eta (di-tau)    = " << fittedDiTauSystem().eta () << std::endl;
-    std::cout << ">> phi (di-tau)    = " << fittedDiTauSystem().phi () << std::endl;
-    std::cout << ">> mass(di-tau)    = " << fittedDiTauSystem().mass() << std::endl;  
-    std::cout << ">> massUncert      = " << massUncert_ << std::endl
-	      << "   error[xFrac1]   = " << minimizer_->Errors()[svFitStandalone::kXFrac] << std::endl
-	      << "   value[xFrac1]   = " << minimizer_->X()[svFitStandalone::kXFrac]      << std::endl
-	      << "   error[xFrac2]   = " << minimizer_->Errors()[svFitStandalone::kMaxFitParams+kXFrac] << std::endl
-	      << "   value[xFrac2]   = " << minimizer_->X()[svFitStandalone::kMaxFitParams+kXFrac]      << std::endl;
-    for ( size_t leg = 0; leg < 2 ; ++leg ) {
-      std::cout << ">> -------------------------------------------------------------" << std::endl;
-      std::cout << ">> Leg " << leg+1 << " Record: " << std::endl;
-      std::cout << ">> -------------------------------------------------------------" << std::endl;
-      std::cout << ">> pt  (meas)      = " << nll_->measuredTauLeptons()[leg].p4().pt () << std::endl;
-      std::cout << ">> eta (meas)      = " << nll_->measuredTauLeptons()[leg].p4().eta() << std::endl;
-      std::cout << ">> phi (meas)      = " << nll_->measuredTauLeptons()[leg].p4().phi() << std::endl; 
-      std::cout << ">> pt  (fit )      = " << fittedTauLeptons()[leg].pt () << std::endl;
-      std::cout << ">> eta (fit )      = " << fittedTauLeptons()[leg].eta() << std::endl;
-      std::cout << ">> phi (fit )      = " << fittedTauLeptons()[leg].phi() << std::endl; 
-    }
-  }
+  //if ( verbose_ >= 2 ) {
+  //  std::cout << ">> -------------------------------------------------------------" << std::endl;
+  //  std::cout << ">> Resonance Record: " << std::endl;
+  //  std::cout << ">> -------------------------------------------------------------" << std::endl;
+  //  std::cout << ">> pt  (di-tau)    = " << fittedDiTauSystem().pt  () << std::endl;
+  //  std::cout << ">> eta (di-tau)    = " << fittedDiTauSystem().eta () << std::endl;
+  //  std::cout << ">> phi (di-tau)    = " << fittedDiTauSystem().phi () << std::endl;
+  //  std::cout << ">> mass(di-tau)    = " << fittedDiTauSystem().mass() << std::endl;  
+  //  std::cout << ">> massUncert      = " << massUncert_ << std::endl
+  //	        << "   error[xFrac1]   = " << minimizer_->Errors()[svFitStandalone::kXFrac] << std::endl
+  //	        << "   value[xFrac1]   = " << minimizer_->X()[svFitStandalone::kXFrac]      << std::endl
+  //	        << "   error[xFrac2]   = " << minimizer_->Errors()[svFitStandalone::kMaxFitParams+kXFrac] << std::endl
+  //	        << "   value[xFrac2]   = " << minimizer_->X()[svFitStandalone::kMaxFitParams+kXFrac]      << std::endl;
+  //  for ( size_t leg = 0; leg < 2 ; ++leg ) {
+  //    std::cout << ">> -------------------------------------------------------------" << std::endl;
+  //    std::cout << ">> Leg " << leg+1 << " Record: " << std::endl;
+  //    std::cout << ">> -------------------------------------------------------------" << std::endl;
+  //    std::cout << ">> pt  (meas)      = " << nll_->measuredTauLeptons()[leg].p4().pt () << std::endl;
+  //    std::cout << ">> eta (meas)      = " << nll_->measuredTauLeptons()[leg].p4().eta() << std::endl;
+  //    std::cout << ">> phi (meas)      = " << nll_->measuredTauLeptons()[leg].p4().phi() << std::endl; 
+  //    std::cout << ">> pt  (fit )      = " << fittedTauLeptons()[leg].pt () << std::endl;
+  //    std::cout << ">> eta (fit )      = " << fittedTauLeptons()[leg].eta() << std::endl;
+  //    std::cout << ">> phi (fit )      = " << fittedTauLeptons()[leg].phi() << std::endl; 
+  //  }
+  //}
 }
 
 void
@@ -744,9 +746,9 @@ SVfitStandaloneAlgorithm::integrateVEGAS(const std::string& likelihoodFileName)
     delete likelihoodGraph;
   }
 
-  delete x0;
-  delete xl;
-  delete xh;
+  delete[] x0;
+  delete[] xl;
+  delete[] xh;
 
   if ( verbose_ >= 1 ) {
     clock_->Show("<SVfitStandaloneAlgorithm::integrateVEGAS>");

--- a/TauAnalysis/SVfitStandalone/src/SVfitStandaloneLikelihood.cc
+++ b/TauAnalysis/SVfitStandalone/src/SVfitStandaloneLikelihood.cc
@@ -32,9 +32,9 @@ SVfitStandaloneLikelihood::SVfitStandaloneLikelihood(const std::vector<MeasuredT
     l1lutVisPtRes_(0),
     l2lutVisPtRes_(0)
 {
-  if ( verbose_ ) {
-    std::cout << "<SVfitStandaloneLikelihood::SVfitStandaloneLikelihood>:" << std::endl;
-  }
+  //if ( verbose_ ) {
+  //  std::cout << "<SVfitStandaloneLikelihood::SVfitStandaloneLikelihood>:" << std::endl;
+  //}
   measuredMET_ = measuredMET;
   // for integration mode the order of lepton or tau matters due to the choice of order in which 
   // way the integration boundaries are defined. In this case the lepton should always go before
@@ -95,9 +95,9 @@ SVfitStandaloneLikelihood::shiftVisPt(bool value, const TH1* l1lutVisPtRes, cons
 const double*
 SVfitStandaloneLikelihood::transform(double* xPrime, const double* x, bool fixToMtest, double mtest) const
 {
-  if ( verbose_ ) {
-    std::cout << "<SVfitStandaloneLikelihood:transform(double*, const double*)>:" << std::endl;
-  }
+  //if ( verbose_ ) {
+  //  std::cout << "<SVfitStandaloneLikelihood:transform(double*, const double*)>:" << std::endl;
+  //}
   LorentzVector fittedDiTauSystem;
   for ( size_t idx = 0; idx < measuredTauLeptons_.size(); ++idx ) {
     const MeasuredTauLepton& measuredTauLepton = measuredTauLeptons_[idx];
@@ -176,27 +176,27 @@ SVfitStandaloneLikelihood::transform(double* xPrime, const double* x, bool fixTo
   if ( fixToMtest ) xPrime[ kMTauTau ] = mtest;       // CV: evaluate delta-function derrivate in case of VEGAS integration for nominal test mass,
   else xPrime[ kMTauTau ] = fittedDiTauSystem.mass(); //     not for fitted mass, to improve numerical stability of integration (this is what the SVfit plugin version does)
 
-  if ( verbose_ && FIRST ) {
-    std::cout << " >> input values for transformed variables: " << std::endl;
-    std::cout << "    MET[x] = " <<  fittedMET.x() << " (fitted)  " << measuredMET_.x() << " (measured) " << std::endl; 
-    std::cout << "    MET[y] = " <<  fittedMET.y() << " (fitted)  " << measuredMET_.y() << " (measured) " << std::endl; 
-    std::cout << "    fittedDiTauSystem: [" 
-	      << " px = " << fittedDiTauSystem.px() 
-	      << " py = " << fittedDiTauSystem.py() 
-	      << " pz = " << fittedDiTauSystem.pz() 
-	      << " En = " << fittedDiTauSystem.energy() 
-	      << " ]" << std::endl; 
-    std::cout << " >> nll parameters after transformation: " << std::endl;
-    std::cout << "    x[kNuNuMass1  ] = " << xPrime[kNuNuMass1  ] << std::endl;
-    std::cout << "    x[kVisMass1   ] = " << xPrime[kVisMass1   ] << std::endl;
-    std::cout << "    x[kDecayAngle1] = " << xPrime[kDecayAngle1] << std::endl;
-    std::cout << "    x[kNuNuMass2  ] = " << xPrime[kNuNuMass2  ] << std::endl;
-    std::cout << "    x[kVisMass2   ] = " << xPrime[kVisMass2   ] << std::endl;
-    std::cout << "    x[kDecayAngle2] = " << xPrime[kDecayAngle2] << std::endl;
-    std::cout << "    x[kDMETx      ] = " << xPrime[kDMETx      ] << std::endl;
-    std::cout << "    x[kDMETy      ] = " << xPrime[kDMETy      ] << std::endl;
-    std::cout << "    x[kMTauTau    ] = " << xPrime[kMTauTau    ] << std::endl;
-  }
+  //if ( verbose_ && FIRST ) {
+  //  std::cout << " >> input values for transformed variables: " << std::endl;
+  //  std::cout << "    MET[x] = " <<  fittedMET.x() << " (fitted)  " << measuredMET_.x() << " (measured) " << std::endl; 
+  //  std::cout << "    MET[y] = " <<  fittedMET.y() << " (fitted)  " << measuredMET_.y() << " (measured) " << std::endl; 
+  //  std::cout << "    fittedDiTauSystem: [" 
+  //	        << " px = " << fittedDiTauSystem.px() 
+  //	        << " py = " << fittedDiTauSystem.py() 
+  //	        << " pz = " << fittedDiTauSystem.pz() 
+  //	        << " En = " << fittedDiTauSystem.energy() 
+  //	        << " ]" << std::endl; 
+  //  std::cout << " >> nll parameters after transformation: " << std::endl;
+  //  std::cout << "    x[kNuNuMass1  ] = " << xPrime[kNuNuMass1  ] << std::endl;
+  //  std::cout << "    x[kVisMass1   ] = " << xPrime[kVisMass1   ] << std::endl;
+  //  std::cout << "    x[kDecayAngle1] = " << xPrime[kDecayAngle1] << std::endl;
+  //  std::cout << "    x[kNuNuMass2  ] = " << xPrime[kNuNuMass2  ] << std::endl;
+  //  std::cout << "    x[kVisMass2   ] = " << xPrime[kVisMass2   ] << std::endl;
+  //  std::cout << "    x[kDecayAngle2] = " << xPrime[kDecayAngle2] << std::endl;
+  //  std::cout << "    x[kDMETx      ] = " << xPrime[kDMETx      ] << std::endl;
+  //  std::cout << "    x[kDMETy      ] = " << xPrime[kDMETy      ] << std::endl;
+  //  std::cout << "    x[kMTauTau    ] = " << xPrime[kMTauTau    ] << std::endl;
+  //}
   return xPrime;
 }
 
@@ -207,13 +207,13 @@ SVfitStandaloneLikelihood::prob(const double* x, bool fixToMtest, double mtest) 
   if ( error() ) { 
     return 0.;
   }
-  if ( verbose_ ) {
-    std::cout << "<SVfitStandaloneLikelihood:prob(const double*)>:" << std::endl;
-  }
+  //if ( verbose_ ) {
+  //  std::cout << "<SVfitStandaloneLikelihood:prob(const double*)>:" << std::endl;
+  //}
   ++idxObjFunctionCall_;
-  if ( verbose_ && FIRST ) {
-    std::cout << " >> ixdObjFunctionCall : " << idxObjFunctionCall_ << std::endl;  
-  }
+  //if ( verbose_ && FIRST ) {
+  //  std::cout << " >> ixdObjFunctionCall : " << idxObjFunctionCall_ << std::endl;  
+  //}
   // prevent kPhi in the fit parameters (kFitParams) from trespassing the 
   // +/-pi boundaries
   double phiPenalty = 0.;
@@ -241,15 +241,15 @@ SVfitStandaloneLikelihood::prob(const double* x, bool fixToMtest, double mtest) 
 double 
 SVfitStandaloneLikelihood::prob(const double* xPrime, double phiPenalty) const
 {
-  if ( verbose_ && FIRST ) {
-    std::cout << "<SVfitStandaloneLikelihood:prob(const double*, double)>:" << std::endl;
-  }
+  //if ( verbose_ && FIRST ) {
+  //  std::cout << "<SVfitStandaloneLikelihood:prob(const double*, double)>:" << std::endl;
+  //}
   if ( requirePhysicalSolution_ && (xPrime[ kMaxNLLParams + 2 ] < 0.5 || xPrime[ kMaxNLLParams + 3 ] < 0.5) ) return 0.;
   // start the combined likelihood construction from MET
   double prob = probMET(xPrime[kDMETx], xPrime[kDMETy], covDet_, invCovMET_, metPower_, (verbose_&& FIRST));
-  if ( verbose_ && FIRST ) {
-    std::cout << "probMET         = " << prob << std::endl;
-  }
+  //if ( verbose_ && FIRST ) {
+  //  std::cout << "probMET         = " << prob << std::endl;
+  //}
   // add likelihoods for the decay branches
   for ( size_t idx = 0; idx < measuredTauLeptons_.size(); ++idx ) {
     switch ( measuredTauLeptons_[idx].type() ) {
@@ -280,9 +280,9 @@ SVfitStandaloneLikelihood::prob(const double* xPrime, double phiPenalty) const
 		  idx == 0 ? l1lutVisPtRes_ : l2lutVisPtRes_, 
 		  (verbose_&& FIRST));
       }
-      if ( verbose_ && FIRST ) {
-	std::cout << " *probTauToHad  = " << prob << std::endl;
-      }
+      //if ( verbose_ && FIRST ) {
+      //  std::cout << " *probTauToHad  = " << prob << std::endl;
+      //}
       break;
     case kTauToElecDecay :
     case kTauToMuDecay :
@@ -293,9 +293,9 @@ SVfitStandaloneLikelihood::prob(const double* xPrime, double phiPenalty) const
 		xPrime[idx == 0 ? kMaxNLLParams : (kMaxNLLParams + 1)], 
 		addSinTheta_, 
 		(verbose_&& FIRST));
-      if ( verbose_ && FIRST ) {
-	std::cout << " *probTauToLep  = " << prob << std::endl;
-      }
+      //if ( verbose_ && FIRST ) {
+      //  std::cout << " *probTauToLep  = " << prob << std::endl;
+      //}
       break;
     default :
       break;
@@ -306,23 +306,23 @@ SVfitStandaloneLikelihood::prob(const double* xPrime, double phiPenalty) const
     if ( xPrime[kMTauTau] > 0. ) {
       prob *= TMath::Power(1.0/xPrime[kMTauTau], powerLogM_);
     }
-    if ( verbose_ && FIRST ) {
-      std::cout << " *1/mtautau     = " << prob << std::endl;
-    }
+    //if ( verbose_ && FIRST ) {
+    //  std::cout << " *1/mtautau     = " << prob << std::endl;
+    //}
   }
   if ( addDelta_ ) {
     prob *= (2.*xPrime[kMaxNLLParams + 1]/xPrime[kMTauTau]);
-    if ( verbose_ && FIRST ) {
-      std::cout << " *deltaDeriv.   = " << prob << std::endl;
-    }
+    //if ( verbose_ && FIRST ) {
+    //  std::cout << " *deltaDeriv.   = " << prob << std::endl;
+    //}
   }
   // add additional phiPenalty in case kPhi in the fit parameters 
   // (kFitParams) trespassed the physical boundaries from +/-pi 
   if ( phiPenalty > 0. ) {
     prob *= TMath::Exp(-phiPenalty);
-    if ( verbose_ && FIRST ) {
-      std::cout << "* phiPenalty   = " << prob << std::endl;
-    }
+    //if ( verbose_ && FIRST ) {
+    //  std::cout << "* phiPenalty   = " << prob << std::endl;
+    //}
   }
   // set FIRST to false after the first complete evaluation of the likelihood 
   FIRST = false;
@@ -332,9 +332,9 @@ SVfitStandaloneLikelihood::prob(const double* xPrime, double phiPenalty) const
 void
 SVfitStandaloneLikelihood::results(std::vector<LorentzVector>& fittedTauLeptons, const double* x) const
 {
-  if ( verbose_ ) {
-    std::cout << "<SVfitStandaloneLikelihood:results(std::vector<LorentzVector>&, const double*)>:" << std::endl;
-  }
+  //if ( verbose_ ) {
+  //  std::cout << "<SVfitStandaloneLikelihood:results(std::vector<LorentzVector>&, const double*)>:" << std::endl;
+  //}
   for ( size_t idx = 0; idx < measuredTauLeptons_.size(); ++idx ) {
     const MeasuredTauLepton& measuredTauLepton = measuredTauLeptons_[idx];
 

--- a/TauAnalysis/SVfitStandalone/src/SVfitStandaloneMarkovChainIntegrator.cc
+++ b/TauAnalysis/SVfitStandalone/src/SVfitStandaloneMarkovChainIntegrator.cc
@@ -12,8 +12,6 @@ enum { kMetropolis };
 
 enum { kUniform, kGaus, kNone };
 
-#define SVFIT_DEBUG 1
-
 namespace
 {
   double square(double x)
@@ -205,12 +203,10 @@ void SVfitStandaloneMarkovChainIntegrator::registerCallBackFunction(const ROOT::
 void SVfitStandaloneMarkovChainIntegrator::integrate(const std::vector<double>& xMin, const std::vector<double>& xMax, 
 						     double& integral, double& integralErr, int& errorFlag)
 {
-#ifdef SVFIT_DEBUG 
   if ( verbose_ >= 2 ) {
     std::cout << "<SVfitStandaloneMarkovChainIntegrator::integrate>:" << std::endl;
     std::cout << " numDimensions = " << numDimensions_ << std::endl;
   }
-#endif
 
   if ( !integrand_ ) {
     std::cerr << "<SVfitStandaloneMarkovChainIntegrator>:"
@@ -227,11 +223,9 @@ void SVfitStandaloneMarkovChainIntegrator::integrate(const std::vector<double>& 
   for ( unsigned iDimension = 0; iDimension < numDimensions_; ++iDimension ) {
     xMin_[iDimension] = xMin[iDimension];
     xMax_[iDimension] = xMax[iDimension];
-#ifdef SVFIT_DEBUG 
     if ( verbose_ >= 2 ) {
       std::cout << "dimension #" << iDimension << ": min = " << xMin_[iDimension] << ", max = " << xMax_[iDimension] << std::endl;
     }
-#endif
   }
   
 //--- CV: set random number generator used to initialize starting-position
@@ -259,20 +253,16 @@ void SVfitStandaloneMarkovChainIntegrator::integrate(const std::vector<double>& 
 	if ( isWithinBounds ) {
 	  isValidStartPos = true;
 	} else {
-#ifdef SVFIT_DEBUG 
 	  if ( verbose_ >= 1 ) {
 	    std::cerr << "<SVfitStandaloneMarkovChainIntegrator>:"
 		      << "Warning: Requested start-position = " << format_vdouble(q_) << " not within interval ]0..1[ --> searching for valid alternative !!\n";
 	  }
-#endif
 	}
       } else {
-#ifdef SVFIT_DEBUG 
 	if ( verbose_ >= 1 ) {
 	  std::cerr << "<SVfitStandaloneMarkovChainIntegrator>:"
 		    << "Warning: Requested start-position = " << format_vdouble(q_) << " returned probability zero --> searching for valid alternative !!";
 	}
-#endif
       }
     }    
     unsigned iTry = 0;
@@ -302,9 +292,9 @@ void SVfitStandaloneMarkovChainIntegrator::integrate(const std::vector<double>& 
 
     for ( unsigned iMove = 0; iMove < numIterBurnin_; ++iMove ) {
 //--- propose Markov Chain transition to new, randomly chosen, point
-#ifdef SVFIT_DEBUG 
-      if ( verbose_ >= 2 ) std::cout << "burn-in move #" << iMove << ":" << std::endl;
-#endif
+
+      //if ( verbose_ >= 2 ) std::cout << "burn-in move #" << iMove << ":" << std::endl;
+
       bool isAccepted = false;
       bool isValid = true;
       do {
@@ -317,9 +307,9 @@ void SVfitStandaloneMarkovChainIntegrator::integrate(const std::vector<double>& 
     for ( unsigned iMove = 0; iMove < numIterSampling_; ++iMove ) {
 //--- propose Markov Chain transition to new, randomly chosen, point;
 //    evaluate "call-back" functions at this point
-#ifdef SVFIT_DEBUG 
-      if ( verbose_ >= 2 ) std::cout << "sampling move #" << iMove << ":" << std::endl;
-#endif
+
+      //if ( verbose_ >= 2 ) std::cout << "sampling move #" << iMove << ":" << std::endl;
+
       bool isAccepted = false;
       bool isValid = true;
       do {
@@ -346,10 +336,7 @@ void SVfitStandaloneMarkovChainIntegrator::integrate(const std::vector<double>& 
 
   for ( unsigned idxBatch = 0; idxBatch < probSum_.size(); ++idxBatch ) {  
     integral_[idxBatch] = probSum_[idxBatch]/m;
-    //if ( verbose_ >= 1 ) std::cout << "integral[" << idxBatch << "] = " << integral_[idxBatch] << std::endl;
   }
-
-  //if ( verbose_ >= 1 ) print(std::cout);
 
 //--- compute integral value and uncertainty
 //   (eqs. (6.39) and (6.40) in [1])   
@@ -383,11 +370,9 @@ void SVfitStandaloneMarkovChainIntegrator::print(std::ostream& stream) const
     double integral = 0.;
     for ( unsigned iBatch = 0; iBatch < numBatches_; ++iBatch ) {    
       double integral_i = integral_[iChain*numBatches_ + iBatch];
-      //std::cout << "batch #" << iBatch << ": integral = " << integral_i << std::endl;
       integral += integral_i;
     }
     integral /= numBatches_;
-    //std::cout << "<integral> = " << integral << std::endl;
     
     double integralErr = 0.;
     for ( unsigned iBatch = 0; iBatch < numBatches_; ++iBatch ) { 
@@ -445,12 +430,11 @@ void SVfitStandaloneMarkovChainIntegrator::initializeStartPosition_and_Momentum(
       }
     }
   }
-#ifdef SVFIT_DEBUG 
+
   if ( verbose_ >= 1 ) {
     std::cout << "<SVfitStandaloneMarkovChainIntegrator::initializeStartPosition_and_Momentum>:" << std::endl;
     std::cout << " q = " << format_vdouble(q_) << std::endl;
   }
-#endif
 }
 
 void SVfitStandaloneMarkovChainIntegrator::sampleSphericallyRandom()
@@ -478,24 +462,20 @@ void SVfitStandaloneMarkovChainIntegrator::makeStochasticMove(unsigned idxMove, 
 {
 //--- perform "stochastic" move
 //   (eq. 24 in [2])
-#ifdef SVFIT_DEBUG 
-  if ( verbose_ >= 2 ) {
-    std::cout << "<MarkovChainIntegrator::makeStochasticMove>:" << std::endl;
-    std::cout << " idx = " << idxMove << std::endl;
-    std::cout << " q = " << format_vdouble(q_) << std::endl;
-    std::cout << " prob = " << prob_ << std::endl;
-    //std::cout << " Ks = " << evalK(p_, 0, numDimensions_) << std::endl;
-  }
-  //if ( (idxMove % 1000) == 0 ) std::cout << "computing move #" << idxMove << "..." << std::endl;
-#endif
+
+  //if ( verbose_ >= 2 ) {
+  //  std::cout << "<MarkovChainIntegrator::makeStochasticMove>:" << std::endl;
+  //  std::cout << " idx = " << idxMove << std::endl;
+  //  std::cout << " q = " << format_vdouble(q_) << std::endl;
+  //  std::cout << " prob = " << prob_ << std::endl;
+  //}
+
 //--- perform random updates of momentum components
   if ( idxMove < numIterSimAnnealingPhase1_ ) {
-    //std::cout << "case 1" << std::endl;
     for ( unsigned iDimension = 0; iDimension < 2*numDimensions_; ++iDimension ) {
       p_[iDimension] = sqrtT0_*rnd_.Gaus(0., 1.);
     }
   } else if ( idxMove < numIterSimAnnealingPhase1plus2_ ) {
-    //std::cout << "case 2" << std::endl;
     double pMag2 = 0.;
     for ( unsigned iDimension = 0; iDimension < 2*numDimensions_; ++iDimension ) {
       double p_i = p_[iDimension];
@@ -512,13 +492,11 @@ void SVfitStandaloneMarkovChainIntegrator::makeStochasticMove(unsigned idxMove, 
       p_[iDimension] = rnd_.Gaus(0., 1.);
     }
   }
-#ifdef SVFIT_DEBUG 
-  if ( verbose_ >= 2 ) {
-    std::cout << "p(updated) = " << format_vdouble(p_) << std::endl;
-    //std::cout << " Ks = " << evalK(p_, 0, numDimensions_) << std::endl;
-    //std::cout << " Kd = " << evalK(p_, numDimensions_, 2*numDimensions_) << std::endl;
-  }
-#endif
+
+  //if ( verbose_ >= 2 ) {
+  //  std::cout << "p(updated) = " << format_vdouble(p_) << std::endl;
+  //}
+
 //--- choose random step size 
   double exp_nu_times_C = 0.;
   do {
@@ -529,9 +507,9 @@ void SVfitStandaloneMarkovChainIntegrator::makeStochasticMove(unsigned idxMove, 
   for ( unsigned iDimension = 0; iDimension < numDimensions_; ++iDimension ) {
     epsilon[iDimension] = epsilon0s_[iDimension]*exp_nu_times_C;
   }
-#ifdef SVFIT_DEBUG 
-  if ( verbose_ >= 2 ) std::cout << "epsilon = " << format_vdouble(epsilon) << std::endl;
-#endif
+
+  //if ( verbose_ >= 2 ) std::cout << "epsilon = " << format_vdouble(epsilon) << std::endl;
+
   if        ( moveMode_ == kMetropolis ) { // Metropolis algorithm: move according to eq. (27) in [2]
 //--- update position components
 //    by single step of chosen size in direction of the momentum components
@@ -539,9 +517,9 @@ void SVfitStandaloneMarkovChainIntegrator::makeStochasticMove(unsigned idxMove, 
       qProposal_[iDimension] = q_[iDimension] + epsilon[iDimension]*p_[iDimension];
     }
   } else assert(0);
-#ifdef SVFIT_DEBUG 
-  if ( verbose_ >= 2 ) std::cout << "q(proposed) = " << format_vdouble(qProposal_) << std::endl;
-#endif
+
+  //if ( verbose_ >= 2 ) std::cout << "q(proposed) = " << format_vdouble(qProposal_) << std::endl;
+
 //--- ensure that proposed new point is within integration region
 //   (take integration region to be "cyclic")
   for ( unsigned iDimension = 0; iDimension < numDimensions_; ++iDimension ) {         
@@ -555,9 +533,9 @@ void SVfitStandaloneMarkovChainIntegrator::makeStochasticMove(unsigned idxMove, 
 //    compute change in phase-space volume for "dummy" momentum components
 //   (eqs. 25 in [2])
   double probProposal = evalProb(qProposal_);
-#ifdef SVFIT_DEBUG 
-  if ( verbose_ >= 2 ) std::cout << "prob(proposed) = " << probProposal << std::endl;
-#endif
+
+  //if ( verbose_ >= 2 ) std::cout << "prob(proposed) = " << probProposal << std::endl;
+
   double deltaE = 0.;
   if      ( probProposal > 0. && prob_ > 0. ) deltaE = -TMath::Log(probProposal/prob_);
   else if ( probProposal > 0.               ) deltaE = -std::numeric_limits<double>::max();
@@ -566,33 +544,27 @@ void SVfitStandaloneMarkovChainIntegrator::makeStochasticMove(unsigned idxMove, 
 
   double pAccept = 0.;
   if        ( moveMode_ == kMetropolis ) { // Metropolis algorithm: move according to eq. (13) in [2]
-#ifdef SVFIT_DEBUG 
-    if ( verbose_ >= 2 ) std::cout << " deltaE = " << deltaE << std::endl;
-#endif
+
+    //if ( verbose_ >= 2 ) std::cout << " deltaE = " << deltaE << std::endl;
+
     pAccept = TMath::Exp(-deltaE);
   } else assert(0);
-#ifdef SVFIT_DEBUG 
-  if ( verbose_ >= 2 ) std::cout << "p(accept) = " << pAccept << std::endl;
-#endif
 
-   double u = rnd_.Uniform(0., 1.);
-#ifdef SVFIT_DEBUG 
-  if ( verbose_ >= 2 ) std::cout << "u = " << u << std::endl;
-#endif  
+  //if ( verbose_ >= 2 ) std::cout << "p(accept) = " << pAccept << std::endl;
+
+  double u = rnd_.Uniform(0., 1.);
+
+  //if ( verbose_ >= 2 ) std::cout << "u = " << u << std::endl;
   
   if ( u < pAccept ) {
-#ifdef SVFIT_DEBUG 
-    if ( verbose_ >= 2 ) std::cout << "move accepted." << std::endl;
-#endif
+    //if ( verbose_ >= 2 ) std::cout << "move accepted." << std::endl;
     for ( unsigned iDimension = 0; iDimension < numDimensions_; ++iDimension ) {    
       q_[iDimension] = qProposal_[iDimension];
     }
     prob_ = evalProb(q_);
     isAccepted = true;
   } else {
-#ifdef SVFIT_DEBUG 
-    if ( verbose_ >= 2 ) std::cout << "move rejected." << std::endl;
-#endif  
+    //if ( verbose_ >= 2 ) std::cout << "move rejected." << std::endl;
     isAccepted = false;
   }
 }
@@ -668,5 +640,4 @@ void SVfitStandaloneMarkovChainIntegrator::updateGradE(std::vector<double>& q)
   //  std::cout << "--> gradE = " << format_vdouble(gradE_) << std::endl;
   //}
 }
-
 


### PR DESCRIPTION
Implement latest changes to SVfit by Christian: reduce 250000 --> 100000 calls to evaluate likelihood in MarkovChain integration and disable redundant debug printouts.
Aligned to https://github.com/veelken/SVfit_standalone/tree/svFit_2015Apr03

Add QCD samples to qcd.py and connector.py under phys14.
