### PR TITLE
Make muon track for dxy/dz configurable, use muonBestTrack as default

### DIFF
--- a/PhysicsTools/Heppy/python/analyzers/objects/LeptonAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/LeptonAnalyzer.py
@@ -235,6 +235,7 @@ class LeptonAnalyzer( Analyzer ):
         # Attach the vertex to them, for dxy/dz calculation
         for mu in allmuons:
             mu.associatedVertex = event.goodVertices[0] if len(event.goodVertices)>0 else event.vertices[0]
+            mu.setTrackForDxyDz(self.cfg_ana.muon_dxydz_track)
 
         # Set tight id if specified
         if hasattr(self.cfg_ana, "mu_tightId"):
@@ -464,6 +465,7 @@ setattr(LeptonAnalyzer,"defaultConfig",cfg.Analyzer(
     inclusive_muon_eta = 2.4,
     inclusive_muon_dxy = 0.5,
     inclusive_muon_dz  = 1.0,
+    muon_dxydz_track   = "muonBestTrack",
     # loose muon selection
     loose_muon_id     = "POG_ID_Loose",
     loose_muon_pt     = 5,

--- a/PhysicsTools/Heppy/python/analyzers/objects/autophobj.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/autophobj.py
@@ -44,7 +44,7 @@ leptonType = NTupleObjectType("lepton", baseObjectTypes = [ particleType ], vari
     NTupleVariable("dxy",   lambda x : x.dxy(), help="d_{xy} with respect to PV, in cm (with sign)"),
     NTupleVariable("dz",    lambda x : x.dz() , help="d_{z} with respect to PV, in cm (with sign)"),
     NTupleVariable("edxy",  lambda x : x.edB(), help="#sigma(d_{xy}) with respect to PV, in cm"),
-    NTupleVariable("edz",   lambda x : x.gsfTrack().dzError() if abs(x.pdgId())==11 else x.innerTrack().dzError() , help="#sigma(d_{z}) with respect to PV, in cm"),
+    NTupleVariable("edz",   lambda x : x.edz(), help="#sigma(d_{z}) with respect to PV, in cm"),
     NTupleVariable("ip3d",  lambda x : x.ip3D() , help="d_{3d} with respect to PV, in cm (absolute value)"),
     NTupleVariable("sip3d",  lambda x : x.sip3D(), help="S_{ip3d} with respect to PV (significance)"),
     # Conversion rejection

--- a/PhysicsTools/Heppy/python/physicsobjects/Electron.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Electron.py
@@ -198,6 +198,11 @@ class Electron( Lepton ):
         if vertex is None:
             vertex = self.associatedVertex
         return self.gsfTrack().dxy( vertex.position() )
+
+    def edxy(self):
+        '''returns the uncertainty on dxy (from gsf track)'''
+        return self.gsfTrack().dxyError()
+
     def p4(self):
 	 return ROOT.reco.Candidate.p4(self.physObj)
 
@@ -212,6 +217,11 @@ class Electron( Lepton ):
         if vertex is None:
             vertex = self.associatedVertex
         return self.gsfTrack().dz( vertex.position() )
+
+    def edz(self):
+        '''returns the uncertainty on dxz (from gsf track)'''
+        return self.gsfTrack().dzError()
+
 
     def lostInner(self) :
         if hasattr(self.gsfTrack(),"trackerExpectedHitsInner") :

--- a/PhysicsTools/Heppy/python/physicsobjects/Muon.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Muon.py
@@ -1,6 +1,14 @@
 from PhysicsTools.Heppy.physicsobjects.Lepton import Lepton
 
 class Muon( Lepton ):
+    def __init__(self, *args, **kwargs):
+        super(Muon, self).__init__(*args, **kwargs)
+        self._trackForDxyDz = "muonBestTrack"
+
+    def setTrackForDxyDz(self,what):
+        if not hasattr(self,what):
+            raise RuntimeError, "I don't have a track called "+what
+        self._trackForDxyDz = what
 
     def looseId( self ):
         '''Loose ID as recommended by mu POG.'''
@@ -53,7 +61,11 @@ class Muon( Lepton ):
         '''
         if vertex is None:
             vertex = self.associatedVertex
-        return self.innerTrack().dxy( vertex.position() )
+        return getattr(self,self._trackForDxyDz)().dxy( vertex.position() )
+
+    def edxy(self):
+        '''returns the uncertainty on dxy (from gsf track)'''
+        return getattr(self,self._trackForDxyDz)().dxyError()
  
 
     def dz(self, vertex=None):
@@ -63,7 +75,11 @@ class Muon( Lepton ):
         '''
         if vertex is None:
             vertex = self.associatedVertex
-        return self.innerTrack().dz( vertex.position() )
+        return getattr(self,self._trackForDxyDz)().dz( vertex.position() )
+
+    def edz(self):
+        '''returns the uncertainty on dxz (from gsf track)'''
+        return getattr(self,self._trackForDxyDz)().dzError()
 
     def chargedHadronIsoR(self,R=0.4):
         if   R == 0.3: return self.physObj.pfIsolationR03().sumChargedHadronPt 


### PR DESCRIPTION
Use muonBestTrack as default for dxy, dz (as suggested by POG, and for consistency with what is used for sip3D already)

In the CMGTools branch, the susy default will be left to innerTrack for backwards compatibility
