### PR TITLE
RecoJet/JetProducers: remove declaration of  PileupJetIdentifier::computeIdVariables (backport of https://github.com/cms-sw/cmssw/pull/8656/)

### DIFF
--- a/RecoJets/JetProducers/interface/PileupJetIdAlgo.h
+++ b/RecoJets/JetProducers/interface/PileupJetIdAlgo.h
@@ -37,12 +37,6 @@ public:
 					       float jec, const reco::Vertex *, const reco::VertexCollection &,
 					       bool calculateMva=false);
 
-	PileupJetIdentifier computeIdVariables(const pat::Jet * jet,
-					       //					       const reco::Vertex *, 
-					       const edm::Ptr<reco::Vertex>,
-					       const std::map<edm::Ptr<reco::Vertex>,edm::PtrVector<pat::PackedCandidate> >&,
-					       bool calculateMva);
-	
 	void set(const PileupJetIdentifier &);
 	PileupJetIdentifier computeMva();
 	const std::string method() const { return tmvaMethod_; }


### PR DESCRIPTION
Remove method that is not implemented.
https://github.com/cms-sw/cmssw/pull/8656/commits
