### PR TITLE
Parametric batch submission at IC, toggle for LHE reading and always clean jets from photons

### DIFF
--- a/CMGTools/TTHAnalysis/python/analyzers/susyCore_modules_cff.py
+++ b/CMGTools/TTHAnalysis/python/analyzers/susyCore_modules_cff.py
@@ -124,6 +124,7 @@ pdfwAna = cfg.Analyzer(
 from CMGTools.TTHAnalysis.analyzers.susyParameterScanAnalyzer import susyParameterScanAnalyzer
 susyScanAna = cfg.Analyzer(
     susyParameterScanAnalyzer, name="susyParameterScanAnalyzer",
+    doLHE=True,
     )
 
 # Lepton Analyzer (generic)
@@ -277,6 +278,7 @@ jetAna = cfg.Analyzer(
     shiftJEC = 0, # set to +1 or -1 to get +/-1 sigma shifts
     smearJets = False,
     shiftJER = 0, # set to +1 or -1 to get +/-1 sigma shifts  
+    alwaysCleanPhotons = False,
     cleanJetsFromFirstPhoton = False,
     cleanJetsFromTaus = False,
     cleanJetsFromIsoTracks = False,

--- a/CMGTools/TTHAnalysis/python/analyzers/susyParameterScanAnalyzer.py
+++ b/CMGTools/TTHAnalysis/python/analyzers/susyParameterScanAnalyzer.py
@@ -33,7 +33,8 @@ class susyParameterScanAnalyzer( Analyzer ):
         #mc information
         self.mchandles['genParticles'] = AutoHandle( 'prunedGenParticles',
                                                      'std::vector<reco::GenParticle>' )
-        self.mchandles['lhe'] = AutoHandle( 'source', 'LHEEventProduct', mayFail = True, lazy = False )
+        if self.cfg_ana.doLHE:
+            self.mchandles['lhe'] = AutoHandle( 'source', 'LHEEventProduct', mayFail = True, lazy = False )
         
     def beginLoop(self, setup):
         super(susyParameterScanAnalyzer,self).beginLoop(setup)
@@ -96,6 +97,7 @@ class susyParameterScanAnalyzer( Analyzer ):
         event.genSusyMScan4 = 0.0
 
         # do MC level analysis
-        self.readLHE(event)
+        if self.cfg_ana.doLHE:
+            self.readLHE(event)
         self.findSusyMasses(event)
         return True

--- a/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
@@ -158,6 +158,10 @@ class JetAnalyzer( Analyzer ):
         self.gamma_cleanJetsFwd = [j for j in self.gamma_cleanJetsAll if abs(j.eta()) >= self.cfg_ana.jetEtaCentral ]
         ###
 
+        if self.cfg_ana.alwaysCleanPhotons:
+            self.cleanJets = self.gamma_cleanJets
+            self.cleanJetsAll = self.gamma_cleanJetsAll
+            self.cleanJetsFwd = self.gamma_cleanJetsFwd
 
         ## Associate jets to leptons
         leptons = event.inclusiveLeptons if hasattr(event, 'inclusiveLeptons') else event.selectedLeptons
@@ -410,6 +414,7 @@ setattr(JetAnalyzer,"defaultConfig", cfg.Analyzer(
     cleanJetsFromFirstPhoton = False,
     cleanJetsFromTaus = False,
     cleanJetsFromIsoTracks = False,
+    alwaysCleanPhotons = False,
     jecPath = "",
     cleanGenJetsFromPhoton = False,
     collectionPostFix = ""

--- a/PhysicsTools/HeppyCore/scripts/heppy_batch.py
+++ b/PhysicsTools/HeppyCore/scripts/heppy_batch.py
@@ -211,7 +211,7 @@ echo 'running'
 python {cmssw}/src/PhysicsTools/HeppyCore/python/framework/looper.py pycfg.py config.pck
 echo
 echo 'sending the job directory back'
-cp -r Loop/* ./ && rm -r Loop
+mv Loop/* ./ && rm -r Loop
 """.format(jobdir = jobDir,cmssw = cmssw_release)
    return script
 

--- a/PhysicsTools/HeppyCore/scripts/heppy_batch.py
+++ b/PhysicsTools/HeppyCore/scripts/heppy_batch.py
@@ -211,7 +211,7 @@ echo 'running'
 python {cmssw}/src/PhysicsTools/HeppyCore/python/framework/looper.py pycfg.py config.pck
 echo
 echo 'sending the job directory back'
-mv Loop/* ./
+cp -r Loop/* ./ && rm -r Loop
 """.format(jobdir = jobDir,cmssw = cmssw_release)
    return script
 


### PR DESCRIPTION
- Implemented parametric batch submission at IC. This is to circumvent the hard 2000 individual job limit. A file with all the job directories is saved and the jobs are submitted separately in a parametric way.
- The non lazy LHE extra information event reading was found to significantly increase the timing of the susyParameterScanAnalyzer (and GenAnalyzer) (increasing the fraction of time they took by ~10%) . Added a toggle to switch it off for the susyParameterScanAnalyzer). 
- Added an option to define the cleanJets as ones that are cleaned from photons as well.
