### PR TITLE
fix a crash in the Photon fiducial regions

### DIFF
--- a/PhysicsTools/Heppy/python/physicsobjects/Photon.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Photon.py
@@ -74,7 +74,7 @@ class Photon(PhysicsObject ):
         #return 0 if the photon is in barrel and 1 if in endcap
         if abs(self.physObj.eta())<1.479 :
             idForBarrel = 0
-        elif abs(self.physObj.eta())< 2.5: 
+        else:
             idForBarrel = 1
         return idForBarrel
 

--- a/PhysicsTools/Heppy/python/physicsobjects/Photon.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Photon.py
@@ -7,10 +7,7 @@ class Photon(PhysicsObject ):
     '''                                                                                                                                                                                                                                                                return object from the photon 
     '''
     def hOVERe(self):
-        #return self.physObj.hadronicOverEm() 
-        hadTowDepth1O = self.physObj.hadTowDepth1OverEm() * (self.physObj.superCluster().energy()/self.physObj.full5x5_e5x5() if self.physObj.full5x5_e5x5() else 1)
-        hadTowDepth2O = self.physObj.hadTowDepth2OverEm() * (self.physObj.superCluster().energy()/self.physObj.full5x5_e5x5() if self.physObj.full5x5_e5x5() else 1)
-        return hadTowDepth1O + hadTowDepth2O
+        return self.physObj.hadTowOverEm() 
 
     def r9(self):
         return self.physObj.r9()


### PR DESCRIPTION
the baricenter of the cluster of a photon can be at |eta|>2.5 (EE arrives at eta=3.0).
The PhotonAnalyzer was crashing because of that sometimes.
