### PR TITLE
make cmsswPreprocessor work on crab

### DIFF
--- a/PhysicsTools/Heppy/python/utils/cmsswPreprocessor.py
+++ b/PhysicsTools/Heppy/python/utils/cmsswPreprocessor.py
@@ -11,7 +11,7 @@ class CmsswPreprocessor :
 		print wd,firstEvent,nEvents
 		if nEvents is None:
 			nEvents = -1
-		cmsswConfig = imp.load_source("cmsRunProcess",self.configFile)
+		cmsswConfig = imp.load_source("cmsRunProcess",os.path.expandvars(self.configFile))
 		inputfiles= []
 		for fn in component.files :
 			if not re.match("file:.*",fn) and not re.match("root:.*",fn) :


### PR DESCRIPTION
This way, local path to the preprocessor cfg is expanded at the worker when using crab.
