### PR TITLE
bug fix in HeppyCore & use uint64 for 'evt' variable

### DIFF
--- a/PhysicsTools/Heppy/python/analyzers/core/AutoFillTreeProducer.py
+++ b/PhysicsTools/Heppy/python/analyzers/core/AutoFillTreeProducer.py
@@ -46,7 +46,7 @@ class AutoFillTreeProducer( TreeAnalyzerNumpy ):
         """Here we declare the variables that we always want and that are hard-coded"""
         tr.var('run', int, storageType="i")
         tr.var('lumi', int, storageType="i")
-        tr.var('evt', int, storageType="i")
+        tr.var('evt', int, storageType="l")
         tr.var('isData', int)
 
  #       self.triggerBitCheckers = []

--- a/PhysicsTools/HeppyCore/python/statistics/tree.py
+++ b/PhysicsTools/HeppyCore/python/statistics/tree.py
@@ -57,7 +57,7 @@ class Tree(object):
             if storageType not in dtypes: 
                 raise RuntimeError, 'Unknown storage type %s for branch %s' % (storageType, varName)
             selfmap[varName]=numpy.zeros(len,dtypes[storageType])
-            self.tree.Branch(varName,selfmap[varName],varName+postfix+'/I')
+            self.tree.Branch(varName,selfmap[varName],varName+postfix+'/'+storageType)
         else:
             raise RuntimeError, 'Unknown type %s for branch %s' % (type, varName)
         if title:


### PR DESCRIPTION
- fix bug in tree.py: there was no distinction between long, signed, unsigend, etc...types of integer
- use uint64 for event number variable 'evt' because uint32 this year is not enough:
  https://hypernews.cern.ch/HyperNews/CMS/get/edmFramework/3408/1/2/1/1.html

This follows PR #400 for Heppy
