### PR TITLE
Add the a component creator for data from private list of files

### DIFF
--- a/CMGTools/TTHAnalysis/python/samples/ComponentCreator.py
+++ b/CMGTools/TTHAnalysis/python/samples/ComponentCreator.py
@@ -35,6 +35,20 @@ class ComponentCreator(object):
 
          return component
     
+    def makePrivateDataComponent(self,name,dataset,files,json,xSec=1):
+         if len(files) == 0:
+            raise RuntimeError, "Trying to make a component %s with no files" % name
+         dprefix = dataset +"/" if files[0][0] != "/" else ""
+         component = cfg.DataComponent(
+             name = name,
+             files = ['root://eoscms.cern.ch//eos/cms%s%s' % (dprefix,f) for f in files],
+             intLumi=1,
+             triggers = [],
+             json=json
+         )
+
+         return component
+
     def makeMyPrivateMCComponent(self,name,dataset,user,pattern,dbsInstance, xSec=1,useAAA=False):
 
         component = cfg.MCComponent(


### PR DESCRIPTION
Useful for private data re-reco or for the B=0 2015A period when the MINIAOD are not centrally produced.
