### PR TITLE
Heppy: adapted to current PF JetID; medium WP removed

### DIFF
--- a/PhysicsTools/Heppy/python/physicsobjects/Jet.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Jet.py
@@ -60,10 +60,11 @@ class Jet(PhysicsObject):
         #    import pdb; pdb.set_trace()
         if name == "POG_PFID":  
             if   self.jetID("POG_PFID_Tight")  : return 3;
-            elif self.jetID("POG_PFID_Medium") : return 2;
+            #elif self.jetID("POG_PFID_Medium") : return 2;  commented this line because this working point doesn't exist anymore (as 12/05/15)
             elif self.jetID("POG_PFID_Loose")  : return 1;
             else                               : return 0;
         
+        # jetID from here: https://twiki.cern.ch/twiki/bin/view/CMS/JetID#Recommendations_for_8_TeV_data_a
         if name == "POG_PFID_Loose":    return (npr>1 and phf<0.99 and nhf<0.99 and muf < 0.8) and (eta>2.4 or (elf<0.99 and chf>0 and chm>0));
         if name == "POG_PFID_Medium":   return (npr>1 and phf<0.95 and nhf<0.95 and muf < 0.8) and (eta>2.4 or (elf<0.99 and chf>0 and chm>0));
         if name == "POG_PFID_Tight":    return (npr>1 and phf<0.90 and nhf<0.90 and muf < 0.8) and (eta>2.4 or (elf<0.90 and chf>0 and chm>0));


### PR DESCRIPTION
- Adapted to current PF JetID working points: medium WP doesn't exist anymore
- Kept jetID indexes as they were before for backward compatibility: tight=3, loose=1
- this PR goes together with PR #417 for CMGTools
