### PR TITLE
Spring15 QCD enriched and diboson samples + RA5 fake-rate studies configuration

### DIFF
--- a/CMGTools/RootTools/python/samples/samples_13TeV_74X.py
+++ b/CMGTools/RootTools/python/samples/samples_13TeV_74X.py
@@ -115,6 +115,41 @@ QCD_Mu5 = [ QCD_Pt15to20_Mu5, QCD_Pt20to30_Mu5, QCD_Pt30to50_Mu5, QCD_Pt50to80_M
             QCD_Pt470to600_Mu5, QCD_Pt600to800_Mu5, QCD_Pt800to1000_Mu5, QCD_Pt1000toInf_Mu5 ]
 QCD_MuX = [ QCD_Mu15 ] + QCD_Mu5
 
+# QCD EM-enriched + bcToE, 25 ns
+QCD_Pt15to20_EMEnriched   = kreator.makeMCComponent("QCD_Pt15to20_EMEnriched","/QCD_Pt-15to20_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM", "CMS", ".*root", 1273000000*0.0002)
+QCD_Pt20to30_EMEnriched   = kreator.makeMCComponent("QCD_Pt20to30_EMEnriched","/QCD_Pt-20to30_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM", "CMS", ".*root", 557600000*0.0096)
+QCD_Pt30to50_EMEnriched   = kreator.makeMCComponent("QCD_Pt30to50_EMEnriched","/QCD_Pt-30to50_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM", "CMS", ".*root", 136000000*0.073)
+QCD_Pt50to80_EMEnriched   = kreator.makeMCComponent("QCD_Pt50to80_EMEnriched","/QCD_Pt-50to80_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM", "CMS", ".*root", 19800000*0.146)
+QCD_Pt80to120_EMEnriched  = kreator.makeMCComponent("QCD_Pt80to120_EMEnriched","/QCD_Pt-80to120_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v3/MINIAODSIM", "CMS", ".*root", 2800000*0.125)
+QCD_Pt120to170_EMEnriched = kreator.makeMCComponent("QCD_Pt120to170_EMEnriched","/QCD_Pt-120to170_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM", "CMS", ".*root", 477000*0.132)
+QCD_Pt170to300_EMEnriched = kreator.makeMCComponent("QCD_Pt170to300_EMEnriched","/QCD_Pt-170to300_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM", "CMS", ".*root", 114000*0.165)
+QCD_Pt300toInf_EMEnriched = kreator.makeMCComponent("QCD_Pt300toInf_EMEnriched","/QCD_Pt-300toInf_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v2/MINIAODSIM", "CMS", ".*root", 9000*0.15)
+QCDPtEMEnriched = [
+QCD_Pt15to20_EMEnriched,
+QCD_Pt20to30_EMEnriched,
+QCD_Pt30to50_EMEnriched,
+QCD_Pt50to80_EMEnriched,
+QCD_Pt80to120_EMEnriched,
+QCD_Pt120to170_EMEnriched,
+QCD_Pt170to300_EMEnriched,
+QCD_Pt300toInf_EMEnriched
+]
+QCD_Pt_15to20_bcToE   = kreator.makeMCComponent("QCD_Pt_15to20_bcToE","/QCD_Pt_15to20_bcToE_TuneCUETP8M1_13TeV_pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM", "CMS", ".*root", 1272980000*0.0002)
+QCD_Pt_20to30_bcToE   = kreator.makeMCComponent("QCD_Pt_20to30_bcToE","/QCD_Pt_20to30_bcToE_TuneCUETP8M1_13TeV_pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM", "CMS", ".*root", 557627000*0.00059)
+QCD_Pt_30to80_bcToE   = kreator.makeMCComponent("QCD_Pt_30to80_bcToE","/QCD_Pt_30to80_bcToE_TuneCUETP8M1_13TeV_pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v2/MINIAODSIM", "CMS", ".*root", 159068000*0.00255)
+QCD_Pt_80to170_bcToE  = kreator.makeMCComponent("QCD_Pt_80to170_bcToE","/QCD_Pt_80to170_bcToE_TuneCUETP8M1_13TeV_pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v2/MINIAODSIM", "CMS", ".*root", 3221000*0.01183)
+QCD_Pt_170to250_bcToE = kreator.makeMCComponent("QCD_Pt_170to250_bcToE","/QCD_Pt_170to250_bcToE_TuneCUETP8M1_13TeV_pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM", "CMS", ".*root", 105771*0.02492)
+QCD_Pt_250toInf_bcToE = kreator.makeMCComponent("QCD_Pt_250toInf_bcToE","/QCD_Pt_250toInf_bcToE_TuneCUETP8M1_13TeV_pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v2/MINIAODSIM", "CMS", ".*root", 21094.1*0.03375)
+QCDPtbcToE = [
+QCD_Pt_15to20_bcToE,
+QCD_Pt_20to30_bcToE,
+QCD_Pt_30to80_bcToE,
+QCD_Pt_80to170_bcToE,
+QCD_Pt_170to250_bcToE,
+QCD_Pt_250toInf_bcToE
+]
+QCD_ElX = QCDPtEMEnriched + QCDPtbcToE
+
 # cross section from StandardModelCrossSectionsat13TeV NNLO times BR=(3*0.108)**2
 WWTo2L2Nu = kreator.makeMCComponent("WWTo2L2Nu", "/WWTo2L2Nu_13TeV-powheg/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM", "CMS", ".*root", 118.7*((3*0.108)**2) )
 
@@ -139,9 +174,36 @@ TTJets_LO_50ns = kreator.makeMCComponent("TTJets_LO_50ns", "/TTJets_TuneCUETP8M1
 ### V+jets inclusive
 DYJetsToLL_M50_50ns = kreator.makeMCComponent("DYJetsToLL_M50_50ns","/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v2/MINIAODSIM", "CMS", ".*root", 2008.*3)
 
+DYJetsToLL_M10to50_50ns = kreator.makeMCComponent("DYJetsToLL_M10to50_50ns","/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v1/MINIAODSIM", "CMS", ".*root", 18610)
+
 WJetsToLNu_50ns = kreator.makeMCComponent("WJetsToLNu_50ns","/WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v1/MINIAODSIM", "CMS", ".*root", 20508.9*3)
 
-### QCD
+# Single top cross sections: https://twiki.cern.ch/twiki/bin/viewauth/CMS/SingleTopSigma
+TToLeptons_tch_50ns = kreator.makeMCComponent("TToLeptons_tch_50ns", "/ST_t-channel_4f_leptonDecays_13TeV-amcatnlo-pythia8_TuneCUETP8M1/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v1/MINIAODSIM", "CMS", ".*root", (136.05+80.97)*0.108*3) 
+TBar_tWch_50ns = kreator.makeMCComponent("TBar_tWch_50ns", "/ST_tW_antitop_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v2/MINIAODSIM", "CMS", ".*root",35.6)
+T_tWch_50ns = kreator.makeMCComponent("T_tWch_50ns", "/ST_tW_top_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v1/MINIAODSIM", "CMS", ".*root",35.6)
+
+SingleTop_50ns = [
+    TToLeptons_tch_50ns, TBar_tWch_50ns, T_tWch_50ns
+]
+
+# cross section from StandardModelCrossSectionsat13TeV NNLO times BR=(3*0.108)**2
+WWTo2L2Nu_50ns = kreator.makeMCComponent("WWTo2L2Nu", "/WWTo2L2Nu_13TeV-powheg/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v2/MINIAODSIM", "CMS", ".*root", 118.7*((3*0.108)**2) )
+
+# cross section from StandardModelCrossSectionsat13TeV (NLO MCFM, mll > 12); to be checked if it's really m(ll) > 12 also for Pythia sample
+ZZp8_50ns = kreator.makeMCComponent("ZZp8_50ns", "/ZZ_TuneCUETP8M1_13TeV-pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v2/MINIAODSIM", "CMS", ".*root", 31.8)
+
+# cros section from StandardModelCrossSectionsat13TeV (NLO MCFM, mll > 12); to be checked if it's really m(ll) > 12 also for Pythia sample
+WZp8_50ns = kreator.makeMCComponent("WZp8_50ns", "/WZ_TuneCUETP8M1_13TeV-pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v2/MINIAODSIM", "CMS", ".*root", (40.2+25.9))
+
+DiBosons_50ns = [ WWTo2L2Nu_50ns, ZZp8_50ns, WZp8_50ns ] 
+
+
+### QCD, 50 ns
+QCD_Pt10to15_50ns = kreator.makeMCComponent("QCD_Pt10to15_50ns","/QCD_Pt_10to15_TuneCUETP8M1_13TeV_pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v1/MINIAODSIM", "CMS", ".*root", 5887580000)
+QCD_Pt15to30_50ns = kreator.makeMCComponent("QCD_Pt15to30_50ns","/QCD_Pt_15to30_TuneCUETP8M1_13TeV_pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v1/MINIAODSIM", "CMS", ".*root", 1837410000)
+QCD_Pt30to50_50ns = kreator.makeMCComponent("QCD_Pt30to50_50ns","/QCD_Pt_30to50_TuneCUETP8M1_13TeV_pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v2/MINIAODSIM", "CMS", ".*root", 140932000)
+QCD_Pt50to80_50ns = kreator.makeMCComponent("QCD_Pt50to80_50ns","/QCD_Pt_50to80_TuneCUETP8M1_13TeV_pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v1/MINIAODSIM", "CMS", ".*root", 19204300)
 QCD_Pt80to120_50ns = kreator.makeMCComponent("QCD_Pt80to120_50ns","/QCD_Pt_80to120_TuneCUETP8M1_13TeV_pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v1/MINIAODSIM", "CMS", ".*root", 2762530)
 QCD_Pt120to170_50ns = kreator.makeMCComponent("QCD_Pt120to170_50ns","/QCD_Pt_120to170_TuneCUETP8M1_13TeV_pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v1/MINIAODSIM", "CMS", ".*root", 471100)
 QCD_Pt170to300_50ns = kreator.makeMCComponent("QCD_Pt170to300_50ns","/QCD_Pt_170to300_TuneCUETP8M1_13TeV_pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v2/MINIAODSIM", "CMS", ".*root", 117276)
@@ -156,6 +218,10 @@ QCD_Pt2400to3200_50ns = kreator.makeMCComponent("QCD_Pt2400to3200_50ns","/QCD_Pt
 QCD_Pt3200toInf_50ns = kreator.makeMCComponent("QCD_Pt3200_50ns","/QCD_Pt_3200toInf_TuneCUETP8M1_13TeV_pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v1/MINIAODSIM", "CMS", ".*root", 0.000165445)
 
 QCDPt_50ns = [
+QCD_Pt10to15_50ns,
+QCD_Pt15to30_50ns,
+QCD_Pt30to50_50ns,
+QCD_Pt50to80_50ns,
 QCD_Pt80to120_50ns,
 QCD_Pt120to170_50ns,
 QCD_Pt170to300_50ns,
@@ -169,6 +235,29 @@ QCD_Pt1800to2400_50ns,
 QCD_Pt2400to3200_50ns,
 QCD_Pt3200toInf_50ns
 ]
+
+# Muon-enriched QCD, 50 ns
+QCD_Mu15_50ns = kreator.makeMCComponent("QCD_Mu15_50ns", "/QCD_Pt-20toInf_MuEnrichedPt15_TuneCUETP8M1_13TeV_pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v2/MINIAODSIM", "CMS", ".*root", 720.65e6*0.00042)
+QCD_Pt15to20_Mu5_50ns = kreator.makeMCComponent("QCD_Pt15to20_Mu5_50ns", "/QCD_Pt-15to20_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v3/MINIAODSIM", "CMS", ".*root", 1273190000*0.003)
+QCD_Pt20to30_Mu5_50ns = kreator.makeMCComponent("QCD_Pt20to30_Mu5_50ns", "/QCD_Pt-20to30_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v2/MINIAODSIM", "CMS", ".*root", 558528000*0.0053)
+QCD_Pt30to50_Mu5_50ns = kreator.makeMCComponent("QCD_Pt30to50_Mu5_50ns", "/QCD_Pt-30to50_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v1/MINIAODSIM", "CMS", ".*root", 139803000*0.01182)
+QCD_Pt50to80_Mu5_50ns = kreator.makeMCComponent("QCD_Pt50to80_Mu5_50ns", "/QCD_Pt-50to80_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v1/MINIAODSIM", "CMS", ".*root", 19222500*0.02276)
+QCD_Pt80to120_Mu5_50ns = kreator.makeMCComponent("QCD_Pt80to120_Mu5_50ns", "/QCD_Pt-80to120_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v1/MINIAODSIM", "CMS", ".*root", 2758420*0.03844) 
+QCD_Pt120to170_Mu5_50ns = kreator.makeMCComponent("QCD_Pt120to170_Mu5_50ns", "/QCD_Pt-120to170_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v1/MINIAODSIM", "CMS", ".*root", 469797*0.05362)
+QCD_Pt170to300_Mu5_50ns = kreator.makeMCComponent("QCD_Pt170to300_Mu5_50ns", "/QCD_Pt-170to300_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v2/MINIAODSIM", "CMS", ".*root", 117989*0.07335)
+QCD_Pt300to470_Mu5_50ns = kreator.makeMCComponent("QCD_Pt300to470_Mu5_50ns", "/QCD_Pt-300to470_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v3/MINIAODSIM", "CMS", ".*root", 7820.25*0.10196)
+QCD_Pt470to600_Mu5_50ns = kreator.makeMCComponent("QCD_Pt470to600_Mu5_50ns", "/QCD_Pt-470to600_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v3/MINIAODSIM", "CMS", ".*root", 645.528*0.12242)
+QCD_Pt600to800_Mu5_50ns = kreator.makeMCComponent("QCD_Pt600to800_Mu5_50ns", "/QCD_Pt-600to800_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v2/MINIAODSIM", "CMS", ".*root", 187.109*0.13412)
+QCD_Pt800to1000_Mu5_50ns = kreator.makeMCComponent("QCD_Pt800to1000_Mu5_50ns", "/QCD_Pt-800to1000_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v2/MINIAODSIM", "CMS", ".*root", 32.3486*0.14552)
+QCD_Pt1000toInf_Mu5_50ns = kreator.makeMCComponent("QCD_Pt1000toInf_Mu5_50ns", "/QCD_Pt-1000toInf_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v2/MINIAODSIM", "CMS", ".*root", 10.4305*0.15544)
+QCD_Mu5_50ns = [ QCD_Pt15to20_Mu5_50ns, QCD_Pt20to30_Mu5_50ns, QCD_Pt30to50_Mu5_50ns, QCD_Pt50to80_Mu5_50ns, 
+            QCD_Pt80to120_Mu5_50ns, QCD_Pt120to170_Mu5_50ns, QCD_Pt170to300_Mu5_50ns, QCD_Pt300to470_Mu5_50ns, 
+            QCD_Pt470to600_Mu5_50ns, QCD_Pt600to800_Mu5_50ns, QCD_Pt800to1000_Mu5_50ns, QCD_Pt1000toInf_Mu5_50ns ]
+QCD_MuX_50ns = [ QCD_Mu15_50ns ] + QCD_Mu5_50ns
+
+
+
+
 
 ### ----------------------------- Zero Tesla run  ----------------------------------------
 
@@ -190,7 +279,7 @@ jetHT_0T = cfg.DataComponent(
 
 mcSamples_Asymptotic25ns = TTs + SingleTop + VJets + WJetsToLNuHT + GJetsHT + QCDPt + DiBosons + Higgs
 
-mcSamples_Asymptotic50ns = [ TTJets_50ns, TTJets_LO_50ns, WJetsToLNu_50ns, DYJetsToLL_M50_50ns ] + QCDPt_50ns
+mcSamples_Asymptotic50ns = [ TTJets_50ns, TTJets_LO_50ns, WJetsToLNu_50ns, DYJetsToLL_M10to50_50ns, DYJetsToLL_M50_50ns ] + QCDPt_50ns + SingleTop_50ns + DiBosons_50ns
 
 mcSamples = RelVals740 + mcSamples_Asymptotic25ns + mcSamples_Asymptotic50ns
 

--- a/CMGTools/RootTools/python/samples/samples_13TeV_74X.py
+++ b/CMGTools/RootTools/python/samples/samples_13TeV_74X.py
@@ -188,7 +188,7 @@ SingleTop_50ns = [
 ]
 
 # cross section from StandardModelCrossSectionsat13TeV NNLO times BR=(3*0.108)**2
-WWTo2L2Nu_50ns = kreator.makeMCComponent("WWTo2L2Nu", "/WWTo2L2Nu_13TeV-powheg/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v2/MINIAODSIM", "CMS", ".*root", 118.7*((3*0.108)**2) )
+WWTo2L2Nu_50ns = kreator.makeMCComponent("WWTo2L2Nu_50ns", "/WWTo2L2Nu_13TeV-powheg/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v2/MINIAODSIM", "CMS", ".*root", 118.7*((3*0.108)**2) )
 
 # cross section from StandardModelCrossSectionsat13TeV (NLO MCFM, mll > 12); to be checked if it's really m(ll) > 12 also for Pythia sample
 ZZp8_50ns = kreator.makeMCComponent("ZZp8_50ns", "/ZZ_TuneCUETP8M1_13TeV-pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v2/MINIAODSIM", "CMS", ".*root", 31.8)
@@ -277,9 +277,9 @@ jetHT_0T = cfg.DataComponent(
 
 ### ----------------------------- summary ----------------------------------------
 
-mcSamples_Asymptotic25ns = TTs + SingleTop + VJets + WJetsToLNuHT + GJetsHT + QCDPt + DiBosons + Higgs
+mcSamples_Asymptotic25ns = TTs + SingleTop + VJets + WJetsToLNuHT + GJetsHT + QCDPt + DiBosons + Higgs + QCD_ElX
 
-mcSamples_Asymptotic50ns = [ TTJets_50ns, TTJets_LO_50ns, WJetsToLNu_50ns, DYJetsToLL_M10to50_50ns, DYJetsToLL_M50_50ns ] + QCDPt_50ns + SingleTop_50ns + DiBosons_50ns
+mcSamples_Asymptotic50ns = [ TTJets_50ns, TTJets_LO_50ns, WJetsToLNu_50ns, DYJetsToLL_M10to50_50ns, DYJetsToLL_M50_50ns ] + QCDPt_50ns + SingleTop_50ns + DiBosons_50ns + QCD_MuX_50ns
 
 mcSamples = RelVals740 + mcSamples_Asymptotic25ns + mcSamples_Asymptotic50ns
 

--- a/CMGTools/TTHAnalysis/cfg/run_susyMultilepton_cfg.py
+++ b/CMGTools/TTHAnalysis/cfg/run_susyMultilepton_cfg.py
@@ -175,7 +175,7 @@ if False: # select only a subset of a sample, corresponding to a given luminosit
 if False: # For running on data
     json = None; 
     processing = "Run2015B-PromptReco-v1"; short = "Run2015B_v1"; 
-    run_ranges = [ (251168,251168), (251244,251244), (251251,251252) ]
+    run_ranges = [ (251244,251244), (251251,251252), (251559,251562), (251636,251636), (251638,251638), (251640,251640), (251643,251643), (251721,251721), (251883,251883) ]
     DatasetsAndTriggers = []
     DatasetsAndTriggers.append( ("DoubleMuon", triggers_mumu_iso + triggers_mumu_ss + triggers_mumu_ht + triggers_3mu + triggers_3mu_alt) )
     DatasetsAndTriggers.append( ("DoubleEG",   triggers_ee + triggers_ee_ht + triggers_3e) )
@@ -183,6 +183,24 @@ if False: # For running on data
     DatasetsAndTriggers.append( ("SingleMuon", triggers_1mu_iso + triggers_1mu_iso_50ns + triggers_1mu_noniso) )
     DatasetsAndTriggers.append( ("SingleElectron", triggers_1e + triggers_1e_50ns) )
     selectedComponents = []; vetos = []
+    if False: # for fake rate measurements in data
+        lepAna.loose_muon_dxy = 999
+        lepAna.loose_electron_dxy = 999
+        ttHLepSkim.minLeptons = 1
+        FRTrigs = triggers_FR_1mu_iso + triggers_FR_1mu_noiso + triggers_FR_1e_noiso + triggers_FR_1e_iso
+        for t in FRTrigs:
+            tShort = t.replace("HLT_","FR_").replace("_v*","")
+            triggerFlagsAna.triggerBits[tShort] = [ t ]
+        FRTrigs_mu = triggers_FR_1mu_iso + triggers_FR_1mu_noiso
+        FRTrigs_el = triggers_FR_1e_noiso + triggers_FR_1e_iso
+        for pd,trig in DatasetsAndTriggers:
+            if pd in ['DoubleMuon','SingleMuon']:
+                trig.extend(FRTrigs_mu)
+            elif pd in ['DoubleEG','SingleElectron']:
+                trig.extend(FRTrigs_el)
+            else:
+                print 'the strategy for trigger selection on MuonEG for FR studies should yet be implemented'
+                assert(False)
     for pd,triggers in DatasetsAndTriggers:
         for run_range in run_ranges:
             label = "runs_%d_%d" % run_range if run_range[0] != run_range[1] else "run_%d" % (run_range[0],)
@@ -193,7 +211,7 @@ if False: # For running on data
                                              run_range=run_range, 
                                              triggers=triggers[:], vetoTriggers = vetos[:])
             print "Will process %s (%d files)" % (comp.name, len(comp.files))
-            # print "\ttrigger sel %s, veto %s"i % (triggers, vetos)
+#            print "\ttrigger sel %s, veto %s" % (triggers, vetos)
             comp.splitFactor = 1 #len(comp.files)
             comp.fineSplitFactor = 4
             selectedComponents.append( comp )
@@ -202,14 +220,15 @@ if False: # For running on data
         susyCoreSequence.remove(jsonAna)
 
 if False: # QCD
-    selectedComponents = QCD_MuX
+    selectedComponents = QCD_MuX_50ns + QCDPt_50ns + QCD_ElX
+    lepAna.loose_muon_dxy = 999
+    lepAna.loose_electron_dxy = 999
     ttHLepSkim.minLeptons = 1
     FRTrigs = triggers_FR_1mu_iso + triggers_FR_1mu_noiso + triggers_FR_1e_noiso + triggers_FR_1e_iso
     for c in selectedComponents:
         c.triggers = [] # FRTrigs
         c.vetoTriggers = [] 
-        c.files = c.files[:len(c.files)/4]
-        c.splitFactor = len(c.files)
+        c.splitFactor = len(c.files)/4
     for t in FRTrigs:
         tShort = t.replace("HLT_","FR_").replace("_v*","")
         triggerFlagsAna.triggerBits[tShort] = [ t ]


### PR DESCRIPTION
Summary of changes:
- added QCD EM-enriched + bcToE 25 ns Spring15 samples
- added muon-enriched QCD 50 ns Spring15 samples
- added low-pt QCD 50 ns Spring15 samples (not enriched) - beware: the QCDPt_50ns list has consequently been extended
- added diboson 50 ns Spring15 samples
- adapted susyMultilepton configuration for RA5 fake-rate studies on early data (run range updated)
