### PR TITLE
Fix DAS cache issue from typo in dataset pattern

### DIFF
--- a/CMGTools/Production/python/dataset.py
+++ b/CMGTools/Production/python/dataset.py
@@ -452,8 +452,8 @@ def createDataset( user, dataset, pattern, readcache=False,
         rr = "_run%s_%s" % (run_range[0], run_range[1]) if run_range else ""
         return '{user}%{name}{rr}%{pattern}.pck'.format( user = user, name = data.replace('/','_'), pattern = pattern, rr=rr)
 
-    def writeCache(dataset, run_range):
-        writeDatasetToCache( cacheFileName(dataset.name, dataset.user, dataset.pattern, run_range), dataset )
+    def writeCache(dataset, data, user, pattern, run_range):
+        writeDatasetToCache( cacheFileName(data, user, pattern, run_range), dataset )
 
     def readCache(data, user, pattern, run_range):
         return getDatasetFromCache( cacheFileName(data, user, pattern, run_range) )
@@ -473,7 +473,7 @@ def createDataset( user, dataset, pattern, readcache=False,
             info = False
         else:
             data = Dataset( dataset, user, pattern)
-        writeCache(data, run_range)
+        writeCache(data, dataset, user, pattern, run_range)
     return data
 
 ### MM

--- a/CMGTools/Production/python/dataset.py
+++ b/CMGTools/Production/python/dataset.py
@@ -445,7 +445,8 @@ def writeDatasetToCache( cachename, dataset ):
 
 def createDataset( user, dataset, pattern, readcache=False, 
                    basedir = None, run_range = None):
-    
+    if user == 'CMS' and pattern != ".*root":
+        raise RuntimeError, "For 'CMS' datasets, the pattern must be '.*root', while you configured '%s' for %s, %s" % (pattern, name, dataset)
 
     def cacheFileName(data, user, pattern, run_range):
         rr = "_run%s_%s" % (run_range[0], run_range[1]) if run_range else ""

--- a/CMGTools/RootTools/python/samples/samples_13TeV_74X.py
+++ b/CMGTools/RootTools/python/samples/samples_13TeV_74X.py
@@ -135,13 +135,13 @@ QCD_Pt3200toInf
 ]
 
 # QCD HT bins (cross sections from McM)
-QCD_HT200to300 = kreator.makeMCComponent("QCD_HT200to300", "/QCD_HT200to300_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v2/MINIAODSIM", "CMS", "*.root",1735000)
-QCD_HT300to500 = kreator.makeMCComponent("QCD_HT300to500", "/QCD_HT300to500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v2/MINIAODSIM", "CMS", "*.root",367000)
-QCD_HT500to700 = kreator.makeMCComponent("QCD_HT500to700", "/QCD_HT500to700_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v2/MINIAODSIM", "CMS", "*.root",29400)
-QCD_HT700to1000 = kreator.makeMCComponent("QCD_HT700to1000", "/QCD_HT700to1000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v2/MINIAODSIM", "CMS", "*.root",6524)
-QCD_HT1000to1500 = kreator.makeMCComponent("QCD_HT1000to1500", "/QCD_HT1000to1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v2/MINIAODSIM", "CMS", "*.root",1064)
-QCD_HT1500to2000 = kreator.makeMCComponent("QCD_HT2150to2000", "/QCD_HT21500to2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v2/MINIAODSIM", "CMS", "*.root",121.5)
-QCD_HT2000toInf = kreator.makeMCComponent("QCD_HT2000toInf", "/QCD_HT2000toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v2/MINIAODSIM", "CMS", "*.root",25.42)
+QCD_HT200to300 = kreator.makeMCComponent("QCD_HT200to300", "/QCD_HT200to300_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v2/MINIAODSIM", "CMS", ".*root",1735000)
+QCD_HT300to500 = kreator.makeMCComponent("QCD_HT300to500", "/QCD_HT300to500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v2/MINIAODSIM", "CMS", ".*root",367000)
+QCD_HT500to700 = kreator.makeMCComponent("QCD_HT500to700", "/QCD_HT500to700_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v2/MINIAODSIM", "CMS", ".*root",29400)
+QCD_HT700to1000 = kreator.makeMCComponent("QCD_HT700to1000", "/QCD_HT700to1000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v2/MINIAODSIM", "CMS", ".*root",6524)
+QCD_HT1000to1500 = kreator.makeMCComponent("QCD_HT1000to1500", "/QCD_HT1000to1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v2/MINIAODSIM", "CMS", ".*root",1064)
+QCD_HT1500to2000 = kreator.makeMCComponent("QCD_HT2150to2000", "/QCD_HT21500to2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v2/MINIAODSIM", "CMS", ".*root",121.5)
+QCD_HT2000toInf = kreator.makeMCComponent("QCD_HT2000toInf", "/QCD_HT2000toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v2/MINIAODSIM", "CMS", ".*root",25.42)
 QCDHT = [
 QCD_HT200to300,
 QCD_HT300to500,


### PR DESCRIPTION
The QCD HT-binned datasets from #469 had pattern `*.root` instead of the correct `.*root`. CMS datasets from DAS are always created with pattern `.*root`, and was confusing the cache since on read it searched for the user-specified parameter (`*.root`) while on write it used the one of the dataset (`.*root`).

Thus, caching fails and queries are repeated over and over again, as I noticed when trying to run my cfg twice.

This fix enforces the pattern to be always `.*root` for CMS files, since that's the only correct value for those kinds of datasets, and it also fixes the sample file, and the caching mechanism (now it will be consistent, always using the parameters specified on input when defining the file to read or write)
