### PR TITLE
Lep-aware-JEC ptratio + tkJets + HBHE noise filter update + misc framework updates

### DIFF
--- a/CMGTools/TTHAnalysis/cfg/run_susyMultilepton_cfg.py
+++ b/CMGTools/TTHAnalysis/cfg/run_susyMultilepton_cfg.py
@@ -535,7 +535,8 @@ from CMGTools.TTHAnalysis.tools.EOSEventsWithDownload import EOSEventsWithDownlo
 event_class = EOSEventsWithDownload if not preprocessor else Events
 EOSEventsWithDownload.aggressive = 2 # always fetch if running on Wigner
 if getHeppyOption("nofetch"):
-    event_class = Events 
+    event_class = Events
+    if preprocessor: preprocessor.prefetch = False
 config = cfg.Config( components = selectedComponents,
                      sequence = sequence,
                      services = outputService, 


### PR DESCRIPTION
Summary of changes:
- added possibility of adding variables to object types at runtime (Heppy)
- added possibility of prefetching input files for preprocessor (Heppy)
- avoid overwriting event data members and lepton-jet association by analyzer modules (jet and MET) (Heppy)
- patch of DataFormats/FWLite to avoid crashes when preprocessing empty files
- updated configuration of HBHE noise filter with 50 and 25 ns cuts + added HBHE iso-based noise filter
- added lepton-aware-JEC calculation of the lepton ptratio variable
- added uncorrected ak4PFchs jets built with charged PF candidates from PV only
- fixed naming of metNoHF analyzer to avoid conflict with default MET analyzer
- configuration update for multilepton cfg

@gpetruc @cbotta 
