### PR TITLE
prevent Jet.puJetId() from returning None

### DIFF
--- a/PhysicsTools/Heppy/python/physicsobjects/Jet.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Jet.py
@@ -94,6 +94,7 @@ class Jet(PhysicsObject):
             if not(eta>=etamin and eta<etamax):
                 continue
             return puMva>cut
+        return -99
         
     def rawFactor(self):
         return self.jecFactor('Uncorrected') * self._rawFactorMultiplier


### PR DESCRIPTION
This PR prevents `Jet.puJetId()` from returning `None`.

Currently, if the control never reaches at L96, it ends the "for" loop and the function returns `None`.

This PR makes this function return `-99` instead of `None`

`-99` is the value that would be stored in the flat tree if the jet doesn't have `puJetIdPassed` according to [autophobj.py#L165](https://github.com/CERN-PH-CMG/cmg-cmssw/blob/bee1f0a41aaa0eb464f1fb234e5af8121840ab84/PhysicsTools/Heppy/python/analyzers/objects/autophobj.py#L165).

When I was processing the file `/store/data/Run2015C/MET/MINIAOD/PromptReco-v1/000/254/905/00000/A2B58C92-BA4B-E511-90E2-02163E014381.root`, I received the following error:

``` bash
Traceback (most recent call last):
  File "/storage/ts14043/work/cms/c140607_alphaT/c150903_prod_tree/s150903_01_CMSSW_7_4_7/src/PhysicsTools/HeppyCore/python/framework/looper.py", line 271, in <module>
    looper.loop()
  File "/storage/ts14043/work/cms/c140607_alphaT/c150903_prod_tree/s150903_01_CMSSW_7_4_7/src/PhysicsTools/HeppyCore/python/framework/looper.py", line 179, in loop
    self.process( iEv )
  File "/storage/ts14043/work/cms/c140607_alphaT/c150903_prod_tree/s150903_01_CMSSW_7_4_7/src/PhysicsTools/HeppyCore/python/framework/looper.py", line 228, in process
    ret = analyzer.process( self.event )
  File "/storage/ts14043/work/cms/c140607_alphaT/c150903_prod_tree/s150903_01_CMSSW_7_4_7/python/PhysicsTools/Heppy/analyzers/core/AutoFillTreeProducer.py", line 150, in process
    self.fillTree(event)
  File "/storage/ts14043/work/cms/c140607_alphaT/c150903_prod_tree/s150903_01_CMSSW_7_4_7/python/PhysicsTools/Heppy/analyzers/core/AutoFillTreeProducer.py", line 176, in fillTree
    c.fillBranchesVector(self.tree, getattr(event, cn), isMC)
  File "/storage/ts14043/work/cms/c140607_alphaT/c150903_prod_tree/s150903_01_CMSSW_7_4_7/python/PhysicsTools/Heppy/analyzers/core/autovars.py", line 212, in fillBranchesVector
    treeNumpy.vfill(name, [ v(collection[i]) for i in xrange(num) ])
  File "/storage/ts14043/work/cms/c140607_alphaT/c150903_prod_tree/s150903_01_CMSSW_7_4_7/python/PhysicsTools/HeppyCore/statistics/tree.py", line 126, in vfill
    a[i]=v
TypeError: long() argument must be a string or a number, not 'NoneType'
```

This error occurred because the value of `puJetIdPassed` for a jet was `None`.

The lambda at [autophobj.py#L165](https://github.com/CERN-PH-CMG/cmg-cmssw/blob/bee1f0a41aaa0eb464f1fb234e5af8121840ab84/PhysicsTools/Heppy/python/analyzers/objects/autophobj.py#L165) returns `-99` when a jet doesn't have a attributes `puJetIdPassed`. However, it returns `None` when a jet does have the attributes `puJetIdPassed` and its value is `None`.

Then at [tree.py#L126](https://github.com/CERN-PH-CMG/cmg-cmssw/blob/bee1f0a41aaa0eb464f1fb234e5af8121840ab84/PhysicsTools/HeppyCore/python/statistics/tree.py#L126), the value of `v` will be `None`, which cannot be an element of `numpy.ndarray` and caused the above error.

This PR prevents the same error from occurring and, at the same time, stores the value consistent with the default value specified in `autophobj.py` in the flat tree.
