### PR TITLE
Type1 MET corrections in python (and cleanup of JetReCalibrator)

### DIFF
--- a/CMGTools/TTHAnalysis/python/analyzers/susyCore_modules_cff.py
+++ b/CMGTools/TTHAnalysis/python/analyzers/susyCore_modules_cff.py
@@ -301,14 +301,16 @@ jetAna = cfg.Analyzer(
     smearJets = False,
     shiftJER = 0, # set to +1 or -1 to get +/-1 sigma shifts  
     alwaysCleanPhotons = False,
+    cleanGenJetsFromPhoton = False,
     cleanJetsFromFirstPhoton = False,
     cleanJetsFromTaus = False,
     cleanJetsFromIsoTracks = False,
     doQG = False,
     do_mc_match = True,
-    cleanGenJetsFromPhoton = False,
     collectionPostFix = "",
-    calculateSeparateCorrections = True
+    calculateSeparateCorrections = True,
+    calculateType1METCorrection  = False,
+    type1METParams = { 'jetPtThreshold':15., 'skipEMfractionThreshold':0.9, 'skipMuons':True },
     )
 
 #PFcharged jets analyzer
@@ -345,7 +347,8 @@ pfChargedCHSjetAna = cfg.Analyzer(
     do_mc_match = True,
     cleanGenJetsFromPhoton = False,
     collectionPostFix = "PFChargedCHS",
-    calculateSeparateCorrections = False
+    calculateSeparateCorrections = False,
+    calculateType1METCorrection  = False,
     )
 
 ## Fat Jets Analyzer (generic)
@@ -392,8 +395,10 @@ metAna = cfg.Analyzer(
     doMetNoMu = False,
     doMetNoEle = False,
     doMetNoPhoton = False,
-    recalibrate = False,
-    jetAnalyzerCalibrationPostFix = "",
+    recalibrate = False, # or "type1", or True
+    applyJetSmearing = False, # does nothing unless the jet smearing is turned on in the jet analyzer
+    old74XMiniAODs = False, # set to True to get the correct Raw MET when running on old 74X MiniAODs
+    jetAnalyzerPostFix = "",
     candidates='packedPFCandidates',
     candidatesTypes='std::vector<pat::PackedCandidate>',
     dzMax = 0.1,
@@ -411,7 +416,9 @@ metNoHFAna = cfg.Analyzer(
     doMetNoEle = False,
     doMetNoPhoton = False,
     recalibrate = False,
-    jetAnalyzerCalibrationPostFix = "",
+    applyJetSmearing = False, # does nothing unless the jet smearing is turned on in the jet analyzer
+    old74XMiniAODs = False,   # can't be true, since MET NoHF wasn't there in old 74X MiniAODs
+    jetAnalyzerPostFix = "",
     candidates='packedPFCandidates',
     candidatesTypes='std::vector<pat::PackedCandidate>',
     dzMax = 0.1,

--- a/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
@@ -59,17 +59,22 @@ class JetAnalyzer( Analyzer ):
         if   self.recalibrateJets == "MC"  : self.recalibrateJets =     self.cfg_comp.isMC
         elif self.recalibrateJets == "Data": self.recalibrateJets = not self.cfg_comp.isMC
         elif self.recalibrateJets not in [True,False]: raise RuntimeError, "recalibrateJets must be any of { True, False, 'MC', 'Data' }, while it is %r " % self.recalibrateJets
-        
-        self.doJEC = self.recalibrateJets or (self.shiftJEC != 0) or self.addJECShifts
+       
+        calculateSeparateCorrections = getattr(cfg_ana,"calculateSeparateCorrections", False);
+        calculateType1METCorrection  = getattr(cfg_ana,"calculateType1METCorrection",  False);
+        self.doJEC = self.recalibrateJets or (self.shiftJEC != 0) or self.addJECShifts or calculateSeparateCorrections or calculateType1METCorrection
         if self.doJEC:
           doResidual = getattr(cfg_ana, 'applyL2L3Residual', 'Data')
           if   doResidual == "MC":   doResidual = self.cfg_comp.isMC
           elif doResidual == "Data": doResidual = not self.cfg_comp.isMC
           elif doResidual not in [True,False]: raise RuntimeError, "If specified, applyL2L3Residual must be any of { True, False, 'MC', 'Data'(default)}"
-          if self.cfg_comp.isMC:
-            self.jetReCalibrator = JetReCalibrator(mcGT,self.cfg_ana.recalibrationType, doResidual, cfg_ana.jecPath, calculateSeparateCorrections=getattr(cfg_ana,"calculateSeparateCorrections",False))
-          else:
-            self.jetReCalibrator = JetReCalibrator(dataGT,self.cfg_ana.recalibrationType, doResidual, cfg_ana.jecPath, calculateSeparateCorrections=getattr(cfg_ana,"calculateSeparateCorrections",False))
+          GT = mcGT if self.cfg_comp.isMC else dataGT
+          # Now take care of the optional arguments
+          kwargs = { 'calculateSeparateCorrections':calculateSeparateCorrections,
+                     'calculateType1METCorrection' :calculateType1METCorrection, }
+          if kwargs['calculateType1METCorrection']: kwargs['type1METParams'] = cfg_ana.type1METParams
+          # instantiate the jet re-calibrator
+          self.jetReCalibrator = JetReCalibrator(GT, cfg_ana.recalibrationType, doResidual, cfg_ana.jecPath, **kwargs)
         self.doPuId = getattr(self.cfg_ana, 'doPuId', True)
         self.jetLepDR = getattr(self.cfg_ana, 'jetLepDR', 0.4)
         self.jetLepArbitration = getattr(self.cfg_ana, 'jetLepArbitration', lambda jet,lepton: lepton) 
@@ -104,9 +109,24 @@ class JetAnalyzer( Analyzer ):
           allJets = map(Jet, self.handles['jets'].product()) 
 
         self.deltaMetFromJEC = [0.,0.]
+        self.type1METCorr    = [0.,0.,0.]
 #        print "before. rho",self.rho,self.cfg_ana.collectionPostFix,'allJets len ',len(allJets),'pt', [j.pt() for j in allJets]
         if self.doJEC:
-            self.jetReCalibrator.correctAll(allJets, rho, delta=self.shiftJEC, metShift=self.deltaMetFromJEC, addCorr=True, addShifts=self.addJECShifts)           
+            if not self.recalibrateJets:  # check point that things won't change
+                jetsBefore = [ (j.pt(),j.eta(),j.phi(),j.rawFactor()) for j in allJets ]
+            self.jetReCalibrator.correctAll(allJets, rho, delta=self.shiftJEC, 
+                                                addCorr=True, addShifts=self.addJECShifts,
+                                                metShift=self.deltaMetFromJEC, type1METCorr=self.type1METCorr )           
+            if not self.recalibrateJets: 
+                jetsAfter = [ (j.pt(),j.eta(),j.phi(),j.rawFactor()) for j in allJets ]
+                if len(jetsBefore) != len(jetsAfter): 
+                    print "ERROR: I had to recompute jet corrections, and they rejected some of the jets:\nold = %s\n new = %s\n" % (jetsBefore,jetsAfter)
+                else:
+                    for (told, tnew) in zip(jetsBefore,jetsAfter):
+                        if (deltaR2(told[1],told[2],tnew[1],tnew[2])) > 0.0001:
+                            print "ERROR: I had to recompute jet corrections, and one jet direction moved: old = %s, new = %s\n" % (told, tnew)
+                        elif abs(told[0]-tnew[0])/(told[0]+tnew[0]) > 0.5e-3 or abs(told[3]-tnew[3]) > 0.5e-3:
+                            print "ERROR: I had to recompute jet corrections, and one jet pt or corr changed: old = %s, new = %s\n" % (told, tnew)
         self.allJetsUsedForMET = allJets
 #        print "after. rho",self.rho,self.cfg_ana.collectionPostFix,'allJets len ',len(allJets),'pt', [j.pt() for j in allJets]
 
@@ -260,6 +280,7 @@ class JetAnalyzer( Analyzer ):
         if hasattr(event,"jets"+self.cfg_ana.collectionPostFix): raise RuntimeError, "Event already contains a jet collection with the following postfix: "+self.cfg_ana.collectionPostFix
         setattr(event,"rho"                    +self.cfg_ana.collectionPostFix, self.rho                    ) 
         setattr(event,"deltaMetFromJEC"        +self.cfg_ana.collectionPostFix, self.deltaMetFromJEC        ) 
+        setattr(event,"type1METCorr"           +self.cfg_ana.collectionPostFix, self.type1METCorr           ) 
         setattr(event,"allJetsUsedForMET"      +self.cfg_ana.collectionPostFix, self.allJetsUsedForMET      ) 
         setattr(event,"jets"                   +self.cfg_ana.collectionPostFix, self.jets                   ) 
         setattr(event,"jetsFailId"             +self.cfg_ana.collectionPostFix, self.jetsFailId             ) 
@@ -380,8 +401,8 @@ class JetAnalyzer( Analyzer ):
                jet.deltaMetFromJetSmearing = [ -(ptscale-1)*jet.rawFactor()*jet.px(), -(ptscale-1)*jet.rawFactor()*jet.py() ]
                if ptscale != 0:
                   jet.setP4(jet.p4()*ptscale)
-               # leave the uncorrected unchanged for sync
-               jet._rawFactorMultiplier *= (1.0/ptscale) if ptscale != 0 else 1
+                  # leave the uncorrected unchanged for sync
+                  jet.setRawFactor(jet.rawFactor()/ptscale)
             #else: print "jet with pt %.1d, eta %.2f is unmatched" % (jet.pt(), jet.eta())
 
 
@@ -410,13 +431,16 @@ setattr(JetAnalyzer,"defaultConfig", cfg.Analyzer(
     addJECShifts = False, # if true, add  "corr", "corrJECUp", and "corrJECDown" for each jet (requires uncertainties to be available!)
     smearJets = True,
     shiftJER = 0, # set to +1 or -1 to get +/-1 sigma shifts    
+    jecPath = "",
+    calculateSeparateCorrections = False,
+    calculateType1METCorrection  = False,
+    type1METParams = { 'jetPtThreshold':15., 'skipEMfractionThreshold':0.9, 'skipMuons':True },
+    cleanGenJetsFromPhoton = False,
     cleanJetsFromFirstPhoton = False,
     cleanJetsFromTaus = False,
     cleanJetsFromIsoTracks = False,
     alwaysCleanPhotons = False,
-    jecPath = "",
     do_mc_match=True,
-    cleanGenJetsFromPhoton = False,
     collectionPostFix = ""
     )
 )

--- a/PhysicsTools/Heppy/python/analyzers/objects/METAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/METAnalyzer.py
@@ -4,7 +4,7 @@ from PhysicsTools.Heppy.analyzers.core.AutoHandle import AutoHandle
 from PhysicsTools.Heppy.physicsobjects.PhysicsObjects import Jet
 from PhysicsTools.HeppyCore.utils.deltar import * 
 from PhysicsTools.HeppyCore.statistics.counter import Counter, Counters
-from PhysicsTools.Heppy.physicsutils.JetReCalibrator import JetReCalibrator
+from PhysicsTools.Heppy.physicsutils.JetReCalibrator import Type1METCorrector, setFakeRawMETOnOldMiniAODs
 import PhysicsTools.HeppyCore.framework.config as cfg
 
 import operator 
@@ -19,6 +19,15 @@ from copy import deepcopy
 class METAnalyzer( Analyzer ):
     def __init__(self, cfg_ana, cfg_comp, looperName ):
         super(METAnalyzer,self).__init__(cfg_ana,cfg_comp,looperName)
+        self.recalibrateMET   = cfg_ana.recalibrate
+        self.applyJetSmearing = cfg_comp.isMC and cfg_ana.applyJetSmearing
+        self.old74XMiniAODs         = cfg_ana.old74XMiniAODs
+        self.jetAnalyzerPostFix = getattr(cfg_ana, 'jetAnalyzerPostFix', '')
+        if self.recalibrateMET in [ "type1", True ]:
+            if self.recalibrateMET == "type1":
+                self.type1METCorrector = Type1METCorrector(self.old74XMiniAODs)
+        elif self.recalibrateMET != False:
+            raise RuntimeError, "Unsupported value %r for option 'recalibrate': allowed are True, False, 'type1'" % self.recalibrateMET
 
     def declareHandles(self):
         super(METAnalyzer, self).declareHandles()
@@ -175,6 +184,17 @@ class METAnalyzer( Analyzer ):
           self.met = self.handles['met'].product()[0]
           if self.cfg_ana.doMetNoPU: self.metNoPU = self.handles['nopumet'].product()[0]
 
+        if self.recalibrateMET == "type1":
+          type1METCorr = getattr(event, 'type1METCorr'+self.jetAnalyzerPostFix)
+          self.type1METCorrector.correct(self.met, type1METCorr)
+        elif self.recalibrateMET == True:
+          deltaMetJEC = getattr(event, 'deltaMetFromJEC'+self.jetAnalyzerPostFix)
+          self.applyDeltaMet(self.met, deltaMetJEC)
+        if self.applyJetSmearing:
+          deltaMetSmear = getattr(event, 'deltaMetFromJetSmearing'+self.jetAnalyzerPostFix)
+          self.applyDeltaMet(self.met, deltaMetSmear)
+
+
         #Shifted METs: to be re-enabled after updates to MiniAOD pass 2
         #Uncertainties defined in https://github.com/cms-sw/cmssw/blob/CMSSW_7_2_X/DataFormats/PatCandidates/interface/MET.h#L168
         #event.met_shifted = []
@@ -189,29 +209,20 @@ class METAnalyzer( Analyzer ):
 
         self.met_sig = self.met.significance()
         self.met_sumet = self.met.sumEt()
-        if  hasattr(event,'zll_p4'):
-            self.adduParaPerp(self.met,event.zll_p4,"_zll")
 
-        if  hasattr(event,'zll_p4'):
-            px,py=self.met.shiftedPx(self.met.NoShift, self.met.Raw),self.met.shiftedPy(self.met.NoShift, self.met.Raw)
-            self.met_raw=ROOT.reco.Particle.LorentzVector(px,py,0,math.hypot(px,py))
+        if self.old74XMiniAODs and self.recalibrateMET != "type1":
+           oldraw = self.met.shiftedP2_74x(12,0);
+           setFakeRawMETOnOldMiniAODs( self.met, px, py, self.met.shiftedSumEt_74x(12,0) )
+        else:
+           px, py = self.met.uncorPx(), self.met.uncorPy()
+        self.met_raw = ROOT.reco.Particle.LorentzVector(px,py,0,math.hypot(px,py))
+
+        if hasattr(event,'zll_p4'):
+            self.adduParaPerp(self.met,event.zll_p4,"_zll")
             self.adduParaPerp(self.met_raw, event.zll_p4,"_zll")
             setattr(event,"met_raw"+self.cfg_ana.collectionPostFix, self.met_raw)
             setattr(event,"met_raw.upara_zll"+self.cfg_ana.collectionPostFix, self.met_raw.upara_zll)
             setattr(event,"met_raw.uperp_zll"+self.cfg_ana.collectionPostFix, self.met_raw.uperp_zll)
-
-        if self.cfg_ana.recalibrate and hasattr(event, 'deltaMetFromJetSmearing'+self.cfg_ana.jetAnalyzerCalibrationPostFix):
-          deltaMetSmear = getattr(event, 'deltaMetFromJetSmearing'+self.cfg_ana.jetAnalyzerCalibrationPostFix)
-          self.applyDeltaMet(self.met, deltaMetSmear)
-          if self.cfg_ana.doMetNoPU:
-            self.applyDeltaMet(self.metNoPU, deltaMetSmear) 
-        if self.cfg_ana.recalibrate and hasattr(event, 'deltaMetFromJEC'+self.cfg_ana.jetAnalyzerCalibrationPostFix):
-          deltaMetJEC = getattr(event, 'deltaMetFromJEC'+self.cfg_ana.jetAnalyzerCalibrationPostFix)
-#          print 'before JEC', self.cfg_ana.collectionPostFix, self.met.px(),self.met.py(), 'deltaMetFromJEC'+self.cfg_ana.jetAnalyzerCalibrationPostFix, deltaMetJEC
-          self.applyDeltaMet(self.met, deltaMetJEC)
-          if self.cfg_ana.doMetNoPU: 
-            self.applyDeltaMet(self.metNoPU, deltaMetJEC)
-#          print 'after JEC', self.cfg_ana.collectionPostFix, self.met.px(),self.met.py(), 'deltaMetFromJEC'+self.cfg_ana.jetAnalyzerCalibrationPostFix, deltaMetJEC
 
         if hasattr(event,"met"+self.cfg_ana.collectionPostFix): raise RuntimeError, "Event already contains met with the following postfix: "+self.cfg_ana.collectionPostFix
         setattr(event, "met"+self.cfg_ana.collectionPostFix, self.met)
@@ -257,12 +268,14 @@ setattr(METAnalyzer,"defaultConfig", cfg.Analyzer(
     noPUMetCollection = "slimmedMETs",
     copyMETsByValue = False,
     recalibrate = True,
-    jetAnalyzerCalibrationPostFix = "",
+    applyJetSmearing = True,
+    jetAnalyzerPostFix = "",
+    old74XMiniAODs = False, # need to set to True to get proper Raw MET on plain 74X MC produced with CMSSW <= 7_4_12
     doTkMet = False,
     includeTkMetCHS = True,
     includeTkMetPVLoose = True,
     includeTkMetPVTight = True,
-    doMetNoPU = True,  
+    doMetNoPU = False, # Not existing in MiniAOD at the moment
     doMetNoMu = False,  
     doMetNoEle = False,  
     doMetNoPhoton = False,  

--- a/PhysicsTools/Heppy/python/analyzers/objects/autophobj.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/autophobj.py
@@ -200,6 +200,8 @@ jetTypeExtra = NTupleObjectType("jetExtra",  baseObjectTypes = [ jetType ], vari
   
 metType = NTupleObjectType("met", baseObjectTypes = [ fourVectorType ], variables = [
     NTupleVariable("sumEt", lambda x : x.sumEt() ),
+    NTupleVariable("rawPt",  lambda x : x.uncorPt() ),
+    NTupleVariable("rawPhi", lambda x : x.uncorPhi() ),
     NTupleVariable("genPt",  lambda x : x.genMET().pt() if x.genMET() else 0 , mcOnly=True ),
     NTupleVariable("genPhi", lambda x : x.genMET().phi() if x.genMET() else 0, mcOnly=True ),
     NTupleVariable("genEta", lambda x : x.genMET().eta() if x.genMET() else 0, mcOnly=True ),

--- a/PhysicsTools/Heppy/python/physicsutils/JetReCalibrator.py
+++ b/PhysicsTools/Heppy/python/physicsutils/JetReCalibrator.py
@@ -1,13 +1,23 @@
 import ROOT
-import os
+import os, types
 from math import *
 from PhysicsTools.HeppyCore.utils.deltar import *
 
 class JetReCalibrator:
-    def __init__(self,globalTag,jetFlavour,doResidualJECs,jecPath,upToLevel=3,calculateSeparateCorrections=False):
+    def __init__(self,globalTag,jetFlavour,doResidualJECs,jecPath,upToLevel=3,
+                 calculateSeparateCorrections=False,
+                 calculateType1METCorrection=False, type1METParams={'jetPtThreshold':15., 'skipEMfractionThreshold':0.9, 'skipMuons':True} ):
         """Create a corrector object that reads the payloads from the text dumps of a global tag under
             CMGTools/RootTools/data/jec  (see the getJec.py there to make the dumps).
-           It will apply the L1,L2,L3 and possibly the residual corrections to the jets."""
+           It will apply the L1,L2,L3 and possibly the residual corrections to the jets.
+           If configured to do so, it will also compute the type1 MET corrections."""
+        self.globalTag = globalTag
+        self.jetFlavour = jetFlavour
+        self.doResidualJECs = doResidualJECs
+        self.jecPath = jecPath
+        self.upToLevel = upToLevel
+        self.calculateType1METCorr = calculateType1METCorrection
+        self.type1METParams  = type1METParams
         # Make base corrections
         path = os.path.expandvars(jecPath) #"%s/src/CMGTools/RootTools/data/jec" % os.environ['CMSSW_BASE'];
         self.L1JetPar  = ROOT.JetCorrectorParameters("%s/%s_L1FastJet_%s.txt" % (path,globalTag,jetFlavour),"");
@@ -31,45 +41,28 @@ class JetReCalibrator:
             print 'Missing JEC uncertainty file "%s/%s_Uncertainty_%s.txt", so jet energy uncertainties will not be available' % (path,globalTag,jetFlavour)
             self.JetUncertainty = None
         self.separateJetCorrectors = {}
-        if calculateSeparateCorrections:
+        if calculateSeparateCorrections or calculateType1METCorr:
             self.vParL1 = ROOT.vector(ROOT.JetCorrectorParameters)()
             self.vParL1.push_back(self.L1JetPar)
             self.separateJetCorrectors["L1"] = ROOT.FactorizedJetCorrector(self.vParL1)
-            if upToLevel >= 2:
+            if upToLevel >= 2 and calculateSeparateCorrections:
                 self.vParL2 = ROOT.vector(ROOT.JetCorrectorParameters)()
                 for i in [self.L1JetPar,self.L2JetPar]: self.vParL2.push_back(i)
                 self.separateJetCorrectors["L1L2"] = ROOT.FactorizedJetCorrector(self.vParL2)
-            if upToLevel >= 3:
+            if upToLevel >= 3 and calculateSeparateCorrections:
                 self.vParL3 = ROOT.vector(ROOT.JetCorrectorParameters)()
                 for i in [self.L1JetPar,self.L2JetPar,self.L3JetPar]: self.vParL3.push_back(i)
                 self.separateJetCorrectors["L1L2L3"] = ROOT.FactorizedJetCorrector(self.vParL3)
-            if doResidualJECs:
+            if doResidualJECs and calculateSeparateCorrections:
                 self.vParL3Res = ROOT.vector(ROOT.JetCorrectorParameters)()
                 for i in [self.L1JetPar,self.L2JetPar,self.L3JetPar,self.ResJetPar]: self.vParL3Res.push_back(i)
                 self.separateJetCorrectors["L1L2L3Res"] = ROOT.FactorizedJetCorrector(self.vParL3Res)
-    def correctAll(self,jets,rho,delta=0,metShift=[0,0], addCorr=False, addShifts=False):
-        """Applies 'correct' to all the jets, discard the ones that have bad corrections (corrected pt <= 0).
-           If addCorr is True, save the correction in jet.corr; 
-           if addShifts, save also jet.corrJEC{Up,Down}"""
-        badJets = []
-        for j in jets:
-            ok = self.correct(j,rho,delta,metShift,addCorr=addCorr,addShifts=addShifts)
-            if not ok: badJets.append(j)
-        if len(badJets) > 0:
-            print "Warning: %d out of %d jets flagged bad by JEC." % (len(badJets), len(jets))
-        for bj in badJets:
-            jets.remove(bj)
-        for j in jets:
-            for sepcorr in self.separateJetCorrectors.keys():
-                setattr(j,"CorrFactor_"+sepcorr,self.getCorrection(j,rho,0,[0,0],corrector=self.separateJetCorrectors[sepcorr]))
 
-    def getCorrection(self,jet,rho,delta=0,metShift=[0,0],corrector=None):
-        """Calculates the correction factor of a jet without modifying it
-        """
+    def getCorrection(self,jet,rho,delta=0,corrector=None):
         if not corrector: corrector = self.JetCorrector
-        if corrector!=self.JetCorrector and (delta!=0 or metShift!=[0,0]): raise RuntimeError, 'Configuration not supported'
+        if corrector != self.JetCorrector and delta!=0: raise RuntimeError, 'Configuration not supported'
         corrector.setJetEta(jet.eta())
-        corrector.setJetPt(jet.pt() * jet.rawFactor())
+        corrector.setJetPt(jet.pt()*jet.rawFactor())
         corrector.setJetA(jet.jetArea())
         corrector.setRho(rho)
         corr = corrector.getCorrection()
@@ -82,86 +75,123 @@ class JetReCalibrator:
             except RuntimeError, r:
                 print "Caught %s when getting uncertainty for jet of pt %.1f, eta %.2f\n" % (r,corr * jet.pt() * jet.rawFactor(),jet.eta())
                 jet.jetEnergyCorrUncertainty = 0.5
-        if jet.photonEnergyFraction() < 0.9 and jet.pt()*corr*jet.rawFactor() > 10:
-            metShift[0] -= jet.px()*(corr*jet.rawFactor() - 1)*(1-jet.muonEnergyFraction())
-            metShift[1] -= jet.py()*(corr*jet.rawFactor() - 1)*(1-jet.muonEnergyFraction()) 
-        if delta != 0:
             #print "   jet with corr pt %6.2f has an uncertainty %.2f " % (jet.pt()*jet.rawFactor()*corr, jet.jetEnergyCorrUncertainty)
             corr *= max(0, 1+delta*jet.jetEnergyCorrUncertainty)
-            if jet.pt()*jet.rawFactor()*corr > 10:
-                metShift[0] -= jet.px()*jet.rawFactor()*corr*delta*jet.jetEnergyCorrUncertainty
-                metShift[1] -= jet.py()*jet.rawFactor()*corr*delta*jet.jetEnergyCorrUncertainty
-        #print "   jet with raw pt %6.2f eta %+5.3f phi %+5.3f: previous corr %.4f, my corr %.4f " % (jet.pt()*jet.rawFactor(), jet.eta(), jet.phi(), 1./jet.rawFactor(), corr)
         return corr
 
-    def correct(self,jet,rho,delta=0,metShift=[0,0],addCorr=False,addShifts=False):
+    def rawP4forType1MET_(self, jet):
+        """Return the raw 4-vector, after subtracting the muons (if requested),
+           or None if the jet fails the EMF cut."""
+        p4 = jet.p4() * jet.rawFactor()
+        emf = ( jet.physObj.neutralEmEnergy() + jet.physObj.chargedEmEnergy() )/p4.E()
+        if emf > self.type1METParams['skipEMfractionThreshold']:
+            return None
+        if self.type1METParams['skipMuons']:
+            for idau in xrange(jet.numberOfDaughters()):
+                pfcand = jet.daughter(idau)
+                if pfcand.isGlobalMuon() or pfcand.isStandAloneMuon(): 
+                    p4 -= pfcand.p4()
+        return p4
+
+    def correct(self,jet,rho,delta=0,addCorr=False,addShifts=False, metShift=[0,0],type1METCorr=[0,0,0]):
         """Corrects a jet energy (optionally shifting it also by delta times the JEC uncertainty)
-           If a two-component list is passes as 'metShift', it will be modified adding to the first and second
-           component the change to the MET along x and y due to the JEC, defined as the negative difference
-           between the new and old jet 4-vectors, for jets with corrected pt > 10.
+
            If addCorr, set jet.corr to the correction.
-           If addShifts, set also the +1 and -1 jet shifts """
-        corr = self.getCorrection(jet,rho,delta,metShift)
-        if addCorr: jet.corr = corr
+           If addShifts, set also the +1 and -1 jet shifts 
+
+           The metShift vector will accumulate the x and y changes to the MET from the JEC, i.e. the 
+           negative difference between the new and old jet momentum, for jets eligible for type1 MET 
+           corrections, and after subtracting muons. The pt cut is applied to the new corrected pt.
+           This shift can be applied on top of the *OLD TYPE1 MET*, but only if there was no change 
+           in the L1 corrections nor in the definition of the type1 MET (e.g. jet pt cuts).
+
+           The type1METCorr vector, will accumulate the x, y, sumEt type1 MET corrections, to be
+           applied to the *RAW MET* (if the feature was turned on in the constructor of the class).
+        """
+        raw = jet.rawFactor()
+        corr = self.getCorrection(jet,rho,delta)
+        if addCorr: 
+            jet.corr = corr
+            for sepcorr in self.separateJetCorrectors.keys():
+                setattr(jet,"CorrFactor_"+sepcorr,self.getCorrection(jet,rho,delta=0,corrector=self.separateJetCorrectors[sepcorr]))
         if addShifts:
             for cdelta,shift in [(1.0, "JECUp"), (-1.0, "JECDown")]:
                 cshift = self.getCorrection(jet,rho,delta+cdelta)
-                setattr(j1, "corr"+shift, cshift)
+                setattr(jet, "corr"+shift, cshift)
         if corr <= 0:
             return False
-        jet.setP4(jet.p4() * (corr * jet.rawFactor()))
+        newpt = jet.pt()*raw*corr
+        if newpt > self.type1METParams['jetPtThreshold']:
+            rawP4forT1 = self.rawP4forType1MET_(jet)
+            if rawP4forT1 and rawP4forT1.Pt()*corr > self.type1METParams['jetPtThreshold']:
+                metShift[0] -= rawP4forT1.Px() * (corr - 1.0/raw)
+                metShift[1] -= rawP4forT1.Py() * (corr - 1.0/raw)
+                if self.calculateType1METCorr:
+                    l1corr = self.getCorrection(jet,rho,delta=0,corrector=self.separateJetCorrectors["L1"])
+                    #print "\tfor jet with raw pt %.5g, eta %.5g, dpx = %.5g, dpy = %.5g" % (
+                    #            jet.pt()*raw, jet.eta(), 
+                    #            rawP4forT1.Px()*(corr - l1corr), 
+                    #            rawP4forT1.Py()*(corr - l1corr))
+                    type1METCorr[0] -= rawP4forT1.Px() * (corr - l1corr) 
+                    type1METCorr[1] -= rawP4forT1.Py() * (corr - l1corr) 
+                    type1METCorr[2] += rawP4forT1.Et() * (corr - l1corr) 
+        jet.setP4(jet.p4() * (corr * raw))
         jet.setRawFactor(1.0/corr)
         return True
 
-class Type1METCorrection:
-    def __init__(self,globalTag,jetFlavour,doResidualJECs):
-        """Create a corrector object that reads the payloads from the text dumps of a global tag under
-           CMGTools/RootTools/data/jec  (see the getJec.py there to make the dumps).
-           It will make the Type1 MET."""
-        # Make base corrections
-        path = "%s/src/CMGTools/RootTools/data/jec" % os.environ['CMSSW_BASE'];
-        self.L1JetPar  = ROOT.JetCorrectorParameters("%s/%s_L1FastJet_%s.txt" % (path,globalTag,jetFlavour));
-        self.L2JetPar  = ROOT.JetCorrectorParameters("%s/%s_L2Relative_%s.txt" % (path,globalTag,jetFlavour));
-        self.L3JetPar  = ROOT.JetCorrectorParameters("%s/%s_L3Absolute_%s.txt" % (path,globalTag,jetFlavour));
-        self.vPar = ROOT.vector(ROOT.JetCorrectorParameters)()
-        self.vPar.push_back(self.L1JetPar);
-        self.vPar.push_back(self.L2JetPar);
-        self.vPar.push_back(self.L3JetPar);
-        # Add residuals if needed
-        if doResidualJECs : 
-            self.ResJetPar = ROOT.JetCorrectorParameters("%s/%s_L2L3Residual_%s.txt" % (path,globalTag,jetFlavour))
-            self.vPar.push_back(self.ResJetPar);
-        #Step3 (Construct a FactorizedJetCorrector object) 
-        self.JetCorrector = ROOT.FactorizedJetCorrector(self.vPar)
-        self.JetUncertainty = ROOT.JetCorrectionUncertainty("%s/%s_Uncertainty_%s.txt" % (path,globalTag,jetFlavour));
-        self.vPar1 = ROOT.vector(ROOT.JetCorrectorParameters)()
-        self.vPar1.push_back(self.L1JetPar);
-        self.JetCorrectorL1 = ROOT.FactorizedJetCorrector(self.vPar1)
-    def getMETCorrection(self,jets,rho,muons):
-        px0, py0 = 0, 0
+    def correctAll(self,jets,rho,delta=0, addCorr=False, addShifts=False, metShift=[0.,0.], type1METCorr=[0.,0.,0.]):
+        """Applies 'correct' to all the jets, discard the ones that have bad corrections (corrected pt <= 0)"""
+        badJets = []
+        if metShift     != [0.,0.   ]: raise RuntimeError, "input metShift tuple is not initialized to zeros"
+        if type1METCorr != [0.,0.,0.]: raise RuntimeError, "input type1METCorr tuple is not initialized to zeros"
         for j in jets:
-            if j.component(4).fraction() > 0.9: continue
-            jp4 = j.p4().__class__(j.p4());
-            jp4 *= j.rawFactor()
-            mup4 = j.p4().__class__(0,0,0,0)
-            for mu in muons:
-                if mu.sourcePtr().track().isNonnull() and (mu.sourcePtr().isGlobalMuon() or mu.sourcePtr().isStandAloneMuon()) and deltaR(mu.eta(),mu.phi(),j.eta(),j.phi()) < 0.5:
-                    mup4 += mu.p4()
-            jp4 -= mup4
-            self.JetCorrector.setJetEta(j.eta())
-            self.JetCorrector.setJetPt(j.pt()*j.rawFactor()) # NOTE: we don't subtract the muon here!
-            self.JetCorrector.setJetA(j.jetArea())
-            self.JetCorrector.setRho(rho)
-            corr3 = self.JetCorrector.getCorrection()
-            self.JetCorrectorL1.setJetEta(j.eta())
-            self.JetCorrectorL1.setJetPt(j.pt()*j.rawFactor()) # NOTE: we don't subtract the muon here!
-            self.JetCorrectorL1.setJetA(j.jetArea())
-            self.JetCorrectorL1.setRho(rho)
-            corr1 = self.JetCorrectorL1.getCorrection()
-            if jp4.pt() * corr3 < 10:
-                #print " no correction from jet of pt %8.2f / %8.2f , phi %+5.3f / %+5.3f (corr3 %5.3f, corr1 %5.3f):  %+7.3f %+7.3f" % (j.pt(),jp4.pt(),j.phi(), jp4.phi(), corr3, corr1, -jp4.X()*(corr3  -corr1),-jp4.Y()*(corr3-corr1))
-                continue
-            #print " correction from jet of pt %8.2f, phi %+5.3f / %+5.3f (corr3 %5.3f, corr1 %5.3f):  %+7.3f %+7.3f" % (j.pt(),j.phi(), jp4.phi(), corr3, corr1, -jp4.X()*(corr3-corr1), -jp4.Y()*(corr3-
-            px0 -= jp4.X()*(corr3-corr1)
-            py0 -= jp4.Y()*(corr3-corr1)
-        return [px0, py0]
+            ok = self.correct(j,rho,delta,addCorr=addCorr,addShifts=addShifts,metShift=metShift,type1METCorr=type1METCorr)
+            if not ok: badJets.append(j)
+        if len(badJets) > 0:
+            print "Warning: %d out of %d jets flagged bad by JEC." % (len(badJets), len(jets))
+        for bj in badJets:
+            jets.remove(bj)
+
+class Type1METCorrector:
+    def __init__(self, old74XMiniAODs):
+        """Object to apply type1 corrections computed by the JetReCalibrator to the MET.
+           old74XMiniAODs should be True if using inputs produced with CMSSW_7_4_11 or earlier."""
+        self.oldMC = old74XMiniAODs
+    def correct(self,met,type1METCorrections):
+        oldpx, oldpy = met.px(), met.py()
+        #print "old met: px %+10.5f, py %+10.5f" % (oldpx, oldpy)
+        if self.oldMC:
+            raw  = met.shiftedP2_74x(12,0);
+            rawsumet =  met.shiftedSumEt_74x(12,0);
+        else:
+            raw = met.uncorP2()
+            rawsumet =  met.uncorSumEt();
+        rawpx, rawpy = raw.px, raw.py
+        #print "raw met: px %+10.5f, py %+10.5f" % (rawpx, rawpy)
+        corrpx = rawpx + type1METCorrections[0]
+        corrpy = rawpy + type1METCorrections[1]
+        corrsumet = rawsumet  + type1METCorrections[2]
+        #print "done met: px %+10.5f, py %+10.5f\n" % (corrpx,corrpy)
+        met.setP4(ROOT.reco.Particle.LorentzVector(corrpx,corrpy,0,hypot(corrpx,corrpy)))
+        ## workaround for missing setSumEt in reco::MET and pat::MET
+        met._sumEt = corrsumet
+        met.sumEt = types.MethodType(lambda myself : myself._sumEt, met, met.__class__) 
+        if not self.oldMC:
+            met.setCorShift(rawpx, rawpy, rawsumet, met.Raw)
+        else: 
+            # to avoid segfauls in pat::MET, I need a more ugly solution
+            setFakeRawMETOnOldMiniAODs(met, rawpx,rawpy, rawsumet)
+
+def setFakeRawMETOnOldMiniAODs(met, rawpx, rawpy, rawsumet):
+        met._rawSumEt = rawsumet
+        met._rawP4    = ROOT.reco.Particle.LorentzVector(rawpx,rawpy,0,hypot(rawpx,rawpy))
+        met.uncorPt  = types.MethodType(lambda myself : myself._rawP4.Pt(), met, met.__class__)
+        met.uncorPx  = types.MethodType(lambda myself : myself._rawP4.Px(), met, met.__class__)
+        met.uncorPy  = types.MethodType(lambda myself : myself._rawP4.Py(), met, met.__class__)
+        met.uncorPhi = types.MethodType(lambda myself : myself._rawP4.Phi(), met, met.__class__)
+        met.uncorP4  = types.MethodType(lambda myself : myself._rawP4, met, met.__class__)
+        met.uncorSumEt = types.MethodType(lambda myself : myself._rawSumEt(), met, met.__class__)
+        # the two below are a bit more tricky, but probably less needed, but something dummy
+        met.uncorP2 = types.MethodType(lambda myself : None, met, met.__class__)
+        met.uncorP3 = types.MethodType(lambda myself : None, met, met.__class__)
+


### PR DESCRIPTION
Allow recomputing the type1 MET from raw MET + jets in the JetAnalyzer + METAnalyzer.
- Reproduces the one computed from AOD within numerical precision of MiniAOD (1-5 MeV in the ttbar events I tested). 
- It does not recompute other MET correction levels, nor MET uncertainties.
- It needs to know which CMSSW version was used to create the input pat::MET object, old (&le; 7_4_11) or new (&ge; 7_4_12)

In the process, I also cleaned up the implementation of JetReCalibrator a bit.
