### PR TITLE
Bugfix: allow running without recalibrateJets with v2 lepton quantities

### DIFF
--- a/CMGTools/TTHAnalysis/python/analyzers/ntupleTypes.py
+++ b/CMGTools/TTHAnalysis/python/analyzers/ntupleTypes.py
@@ -240,6 +240,7 @@ def jetLepAwareJEC(lep): # use only if jetAna.calculateSeparateCorrections==True
     p4j = lep.jet.p4()
     j = ROOT.TLorentzVector(p4j.Px(),p4j.Py(),p4j.Pz(),p4j.E())
     if ((j*lep.jet.rawFactor()-l).Rho()<1e-4): return l # matched to jet containing only the lepton
+    if not hasattr(lep.jet, 'CorrFactor_L1'): return l # if separate corrections have not been calculated, return lepton
     j = (j*lep.jet.rawFactor()-l*(1.0/lep.jet.CorrFactor_L1))*lep.jet.CorrFactor_L1L2L3Res+l
     return j
 def ptRelv2(lep): # use only if jetAna.calculateSeparateCorrections==True


### PR DESCRIPTION
Separate re-calculation of L1 and L2L3Res JEC is necessary to calculate v2 lepton-jet quantities with lep-aware JEC. If recalibrateJets==False, this does not happen. In this case, this PR sets ptRatiov2=1, ptRelv2=0.
