### PR TITLE
Include the possibility to use the conversion-safe electron veto in the PhotonAnalyzer

### DIFF
--- a/PhysicsTools/Heppy/python/analyzers/objects/PhotonAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/PhotonAnalyzer.py
@@ -113,15 +113,15 @@ class PhotonAnalyzer( Analyzer ):
                     gamma.idCutBased = 0
             elif "NoIso" in self.cfg_ana.gammaID:
                 idName = re.split('_NoIso',self.cfg_ana.gammaID)
-                keepThisPhoton = gamma.passPhotonID(idName[0])
+                keepThisPhoton = gamma.passPhotonID(idName[0],self.cfg_ana.conversionSafe_eleVeto)
                 basenameID = re.split('_looseSieie',idName[0])
-                gamma.idCutBased = gamma.passPhotonID(basenameID[0])
+                gamma.idCutBased = gamma.passPhotonID(basenameID[0],self.cfg_ana.conversionSafe_eleVeto)
             else:
                 # Reading from miniAOD directly
                 #keepThisPhoton = gamma.photonID(self.cfg_ana.gammaID)
 
                 # implement cut based ID with CMGTools
-                keepThisPhoton = gamma.passPhotonID(self.cfg_ana.gammaID) and gamma.passPhotonIso(self.cfg_ana.gammaID,self.cfg_ana.gamma_isoCorr)
+                keepThisPhoton = gamma.passPhotonID(self.cfg_ana.gammaID,self.cfg_ana.conversionSafe_eleVeto) and gamma.passPhotonIso(self.cfg_ana.gammaID,self.cfg_ana.gamma_isoCorr)
 
             if keepThisPhoton:
                 event.selectedPhotons.append(gamma)
@@ -342,6 +342,7 @@ setattr(PhotonAnalyzer,"defaultConfig",cfg.Analyzer(
     doFootprintRemovedIsolation = False, # off by default since it requires access to all PFCandidates
     packedCandidates = 'packedPFCandidates',
     footprintRemovedIsolationPUCorr = 'rhoArea', # Allowed options: 'rhoArea', 'raw' (uncorrected)
+    conversionSafe_eleVeto = False,
     do_mc_match = True,
     do_randomCone = False,
   )

--- a/PhysicsTools/Heppy/python/physicsobjects/Photon.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Photon.py
@@ -133,13 +133,14 @@ class Photon(PhysicsObject ):
         return offset + exp(slope_exp*self.pt()+offset_exp)
 
 
-    def passPhotonID(self,name):
+    def passPhotonID(self,name,conversionSafe_eleVeto=False):
         
         idForBarrel = self.etaRegionID()
         passPhotonID = True
 
-        if self.CutBasedIDWP(name)["conversionVeto"][idForBarrel] and self.physObj.hasPixelSeed():
-            passPhotonID = False
+        if self.CutBasedIDWP(name)["conversionVeto"][idForBarrel]:
+            if (conversionSafe_eleVeto==False and self.physObj.hasPixelSeed()) or (conversionSafe_eleVeto==True and self.physObj.passElectronVeto()):
+                passPhotonID = False
 
         if self.CutBasedIDWP(name)["H/E"][idForBarrel] < self.hOVERe():
             passPhotonID = False

--- a/PhysicsTools/Heppy/python/physicsobjects/Photon.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Photon.py
@@ -139,7 +139,7 @@ class Photon(PhysicsObject ):
         passPhotonID = True
 
         if self.CutBasedIDWP(name)["conversionVeto"][idForBarrel]:
-            if (conversionSafe_eleVeto==False and self.physObj.hasPixelSeed()) or (conversionSafe_eleVeto==True and self.physObj.passElectronVeto()):
+            if (conversionSafe_eleVeto==False and self.physObj.hasPixelSeed()) or (conversionSafe_eleVeto==True and self.physObj.passElectronVeto()==False):
                 passPhotonID = False
 
         if self.CutBasedIDWP(name)["H/E"][idForBarrel] < self.hOVERe():


### PR DESCRIPTION
since photonID includes the conversion veto, add the possibility to choose between
- hasPixelSeed()
- passElectronVeto()

default remains as before (hasPixelSeed()) not to change anything was already using this.
