### PR TITLE
Update PR #515

### DIFF
--- a/CMGTools/Production/python/dataset.py
+++ b/CMGTools/Production/python/dataset.py
@@ -140,17 +140,18 @@ class CMSDataset( BaseDataset ):
     def __init__(self, name, run_range = None, json = None):
         super(CMSDataset, self).__init__( name, 'CMS', run_range=run_range, json=json)
 
-    def buildListOfFilesDBS(self, pattern, begin=-1, end=-1):
+    def buildListOfFilesDBS(self, pattern, begin=-1, end=-1, run_range="self"):
         #print 'buildListOfFilesDBS',begin,end
         sampleName = self.name.rstrip('/')
         query, qwhat = sampleName, "dataset"
         if "#" in sampleName: qwhat = "block"
-        if self.run_range is not None and self.run_range != (-1,-1):
-            if self.run_range[0] == self.run_range[1]:
-                query += "   run=%s" % self.run_range[0]
+        if run_range == "self": run_range = self.run_range
+        if run_range is not None and run_range != (-1,-1):
+            if run_range[0] == run_range[1]:
+                query += "   run=%s" % run_range[0]
             else:
                 print "WARNING: queries with run ranges are slow in DAS"
-                query += "   run between [%s,%s]" % ( self.run_range[0],self.run_range[1] )
+                query += "   run between [%s,%s]" % ( run_range[0],run_range[1] )
         dbs='das_client.py --query="file %s=%s"'%(qwhat,query)
         if begin >= 0:
             dbs += ' --index %d' % begin
@@ -209,16 +210,12 @@ class CMSDataset( BaseDataset ):
                 if run_range is not None:
                     run_range_list.append(run_range)
 
-            run_range_org = self.run_range
-
             self.files = []
             for run_range in run_range_list:
-                self.run_range = run_range
-                DBSFiles = self.buildListOfFilesDBS(pattern)
+                DBSFiles = self.buildListOfFilesDBS(pattern, run_range=run_range)
                 DBSFiles = [f for f in DBSFiles if f not in self.files]
                 self.files.extend(DBSFiles)
 
-            self.run_range = run_range_org
             return
 
         self.files = self.buildListOfFilesDBS(pattern)

--- a/CMGTools/RootTools/python/samples/ComponentCreator.py
+++ b/CMGTools/RootTools/python/samples/ComponentCreator.py
@@ -158,7 +158,7 @@ class ComponentCreator(object):
         component = cfg.DataComponent(
             #dataset = dataset,
             name = name,
-            files = self.getFiles(dataset,user,pattern,run_range=run_range,useAAA=useAAA),
+            files = self.getFiles(dataset,user,pattern,run_range=run_range,useAAA=useAAA,json=json),
             intLumi = 1,
             triggers = triggers,
             json = json
@@ -167,9 +167,9 @@ class ComponentCreator(object):
         component.dataset_entries = self.getPrimaryDatasetEntries(dataset,user,pattern)
         return component
 
-    def getFiles(self, dataset, user, pattern, useAAA=False, run_range=None):
+    def getFiles(self, dataset, user, pattern, useAAA=False, run_range=None, json=None):
         # print 'getting files for', dataset,user,pattern
-        ds = createDataset( user, dataset, pattern, readcache=True, run_range=run_range )
+        ds = createDataset( user, dataset, pattern, readcache=True, run_range=run_range, json=json )
         files = ds.listOfGoodFiles()
         mapping = 'root://eoscms.cern.ch//eos/cms%s'
         if useAAA: mapping = 'root://cms-xrd-global.cern.ch/%s'

--- a/CMGTools/RootTools/python/samples/ComponentCreator.py
+++ b/CMGTools/RootTools/python/samples/ComponentCreator.py
@@ -154,15 +154,16 @@ class ComponentCreator(object):
         )
         return component
 
-    def makeDataComponent(self,name,dataset,user,pattern,json=None,run_range=None,triggers=[],vetoTriggers=[],useAAA=False):
+    def makeDataComponent(self,name,dataset,user,pattern,json=None,run_range=None,triggers=[],vetoTriggers=[],useAAA=False,jsonFilter=False):
         component = cfg.DataComponent(
             #dataset = dataset,
             name = name,
-            files = self.getFiles(dataset,user,pattern,run_range=run_range,useAAA=useAAA,json=json),
+            files = self.getFiles(dataset,user,pattern,run_range=run_range,useAAA=useAAA,json=(json if jsonFilter else None)),
             intLumi = 1,
             triggers = triggers,
-            json = json
+            json = (json if jsonFilter else None)
             )
+        component.json = json
         component.vetoTriggers = vetoTriggers
         component.dataset_entries = self.getPrimaryDatasetEntries(dataset,user,pattern)
         return component


### PR DESCRIPTION
- port PR #515 to the head branch
- clean up the usage of `self.run_range` within the loop
- introduce a switch `jsonFilter` in the `makeDataComponent` function of `ComponentCreator` (under RootTools) to toggle on or off the filtering of the files using the JSON
  By default, the feature is off since DAS queries are very slow and for normal JSONs we normally end up selecting a large fraction of the files in each dataset, but it's useful to turn on when using JSON files that select only a smaller set of runs.
