### PR TITLE
Run on SMS scans + updates to plotting and skimming macros

### DIFF
--- a/CMGTools/TTHAnalysis/macros/lxbatch_runner_noWorkDir.sh
+++ b/CMGTools/TTHAnalysis/macros/lxbatch_runner_noWorkDir.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+export SCRAM_ARCH=slc6_amd64_gcc481
+SRC=$1; shift
+cd $SRC; 
+eval $(scramv1 runtime -sh);
+cd -
+exec $*

--- a/CMGTools/TTHAnalysis/macros/splitSMSTrees.py
+++ b/CMGTools/TTHAnalysis/macros/splitSMSTrees.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+import ROOT
+import pickle, os, random, sys
+from PhysicsTools.HeppyCore.statistics.counter import Counter
+
+if __name__ == "__main__":
+    from optparse import OptionParser
+    parser = OptionParser(usage="%prog [options] outputDir inputDirs")
+    parser.add_option("-t", "--tree",  dest="tree", default='treeProducerSusyMultilepton', help="Pattern for tree name");
+    parser.add_option("-u", "--url",  dest="url", default=None, help="Url to remotely save the produced trees")
+    parser.add_option("-q", dest="queue", default=None, help="Queue to send jobs (one per dataset/chunk)")
+    parser.add_option("-D", "--drop",  dest="drop", type="string", default=[], action="append",  help="Branches to drop, as per TTree::SetBranchStatus") 
+    parser.add_option("-K", "--keep",  dest="keep", type="string", default=[], action="append",  help="Branches to keep, as per TTree::SetBranchStatus") 
+
+    (options, args) = parser.parse_args()
+
+    for _in in args[1:]:
+
+        if options.queue:
+            basecmd = "echo bsub -q {queue} {macros}/lxbatch_runner_noWorkDir.sh {cmssw} python {self} -t {tree} {output} {idir}".format(
+                macros = '/'.join(sys.argv[0].split('/')[:-1])+'/../../macros', queue = options.queue, cmssw = os.environ['CMSSW_BASE'],
+                self=sys.argv[0], tree=options.tree, output=args[0], idir=_in
+                )
+            for br in options.drop: basecmd+=' -D %s'%br
+            for br in options.keep: basecmd+=' -K %s'%br
+            if options.url: basecmd+=' -u %s'%options.url
+            os.system(basecmd)
+            continue
+
+
+        indir = _in.strip()
+        dset = indir.strip().split('/')[-1]
+        remdir = args[0].strip()
+        outdir = 'splitoutput'
+        treename = options.tree
+        allmasses={}
+
+        if not os.path.exists(outdir):
+            os.system("mkdir -p "+outdir)
+
+        print "Will write selected trees to "+remdir
+        if not os.path.exists(remdir):
+            os.system("mkdir -p "+remdir)
+
+        fname = '%s/%s/tree.root'%(indir,treename)
+        if not os.path.exists(fname) and os.path.exists(fname+'.url'):
+            fname = open(fname+".url","r").readline().strip()
+        f = ROOT.TFile.Open(fname,'read')
+        t = f.tree
+        h = f.CountSMS
+        hw = f.SumGenWeightsSMS
+
+        print 'Total events: %d originally, %d after production skim'%(int(h.Integral()),t.GetEntries())
+
+        t.SetBranchStatus('*',0)
+        t.SetBranchStatus('GenSusyMScan1',1)
+        t.SetBranchStatus('GenSusyMScan2',1)
+        for nev in xrange(t.GetEntries()):
+            if nev%100000==0: print 'Scanning event %d'%nev
+            t.GetEntry(nev)
+            m = (t.GenSusyMScan1,t.GenSusyMScan2)
+            if m not in allmasses:
+                mname = '%s_%s'%(m[0],m[1])
+                allmasses[m] = ROOT.TEventList(mname,mname)
+            allmasses[m].Enter(nev)
+
+        for m in sorted(allmasses.keys()): print '(%d,%d): %d events'%(m[0],m[1],allmasses[m].GetN())
+
+        t.SetBranchStatus("*",1)
+        for drop in options.drop: t.SetBranchStatus(drop,0)
+        for keep in options.keep: t.SetBranchStatus(keep,1)
+
+        for m,elist in allmasses.iteritems():
+            splitdir = '%s/SMS_%d_%d_%s_Chunk%d'%(outdir,m[0],m[1],dset,random.randint(1e5,1e10))
+            os.system("mkdir -p "+splitdir)
+            os.system("mkdir -p %s/%s"%(splitdir,treename))
+            if os.path.exists('%s/%s/%s/tree.root'%(remdir,splitdir.split('/')[-1],treename)): raise RuntimeError, 'Output file already exists'
+            fout = ROOT.TFile('%s/%s/tree.root'%(splitdir,treename),'recreate')
+            fout.cd()
+            t.SetEventList(elist)
+            out = t.CopyTree('1')
+            fout.WriteTObject(out,'tree')
+            fout.Close()
+            cx = Counter('SkimReport')
+            cx.register('All Events')
+            cx.register('Sum Weights')
+            cx.inc('All Events', h.GetBinContent(h.GetXaxis().FindBin(m[0]),h.GetYaxis().FindBin(m[1]),1))
+            cx.inc('Sum Weights', hw.GetBinContent(hw.GetXaxis().FindBin(m[0]),hw.GetYaxis().FindBin(m[1]),1))
+            os.system("mkdir -p %s/skimAnalyzerCount"%splitdir)
+            cx.write('%s/skimAnalyzerCount'%splitdir)
+            if options.url:
+                os.system('archiveTreesOnEOS.py --auto -t %s --dset %s %s %s'%(treename,splitdir.split('/')[-1],outdir,options.url))
+            os.system('rsync -av %s %s'%(splitdir.rstrip('/'),remdir))
+            os.system('rm %s/%s/tree.root'%(splitdir,treename))
+            os.system('rm %s/%s/tree.root.url'%(splitdir,treename))
+            os.system('rm %s/skimAnalyzerCount/SkimReport.pck'%splitdir)
+            os.system('rm %s/skimAnalyzerCount/SkimReport.txt'%splitdir)
+            os.system('rmdir %s/%s'%(splitdir,treename))
+            os.system('rmdir %s/skimAnalyzerCount'%splitdir)
+            os.system('rmdir %s'%splitdir)
+            os.system('rmdir %s'%outdir)
+
+    
+
+
+

--- a/CMGTools/TTHAnalysis/python/analyzers/ntupleTypes.py
+++ b/CMGTools/TTHAnalysis/python/analyzers/ntupleTypes.py
@@ -5,6 +5,7 @@ from PhysicsTools.Heppy.analyzers.objects.autophobj import  *
 from PhysicsTools.HeppyCore.utils.deltar import deltaR
 
 from CMGTools.TTHAnalysis.signedSip import *
+from CMGTools.TTHAnalysis.tools.emulateElectronTriggerCuts import _susy2lss_idEmu_cuts,_susy2lss_idIsoEmu_cuts
 
 ##------------------------------------------  
 ## LEPTON
@@ -78,6 +79,8 @@ leptonTypeSusyExtra = NTupleObjectType("leptonSusyExtra", baseObjectTypes = [ le
     NTupleVariable("hcalPFClusterIso", lambda lepton :  lepton.hcalPFClusterIso() if abs(lepton.pdgId())==11 else -999, help="Electron hcalPFClusterIso"),
     NTupleVariable("dr03TkSumPt", lambda lepton: lepton.dr03TkSumPt() if abs(lepton.pdgId())==11 else -999, help="Electron dr03TkSumPt isolation"),
     NTupleVariable("trackIso", lambda lepton :  lepton.trackIso() if abs(lepton.pdgId())==11 else -999, help="Electron trackIso (in cone of 0.4)"),
+    NTupleVariable("idEmu", lambda lepton: _susy2lss_idEmu_cuts(lepton), help="Electron pass trigger ID emulation cuts"),
+    NTupleVariable("idIsoEmu", lambda lepton: _susy2lss_idIsoEmu_cuts(lepton), help="Electron pass trigger ID+ISO emulation cuts"),
 ])
 leptonTypeSusyExtra.addSubObjects([
         NTupleSubObject("jetLepAwareJEC",lambda x: jetLepAwareJEC(x), tlorentzFourVectorType)

--- a/CMGTools/TTHAnalysis/python/analyzers/susyCore_modules_cff.py
+++ b/CMGTools/TTHAnalysis/python/analyzers/susyCore_modules_cff.py
@@ -12,6 +12,12 @@ import os
 from CMGTools.TTHAnalysis.analyzers.ttHhistoCounterAnalyzer import ttHhistoCounterAnalyzer
 susyCounter = cfg.Analyzer(
     ttHhistoCounterAnalyzer, name="ttHhistoCounterAnalyzer",
+    SMS_max_mass = 3000, # maximum mass allowed in the scan
+    SMS_mass_1 = 'genSusyMScan1', # first scanned mass
+    SMS_mass_2 = 'genSusyMScan2', # second scanned mass
+    SMS_varying_masses = [], # other mass variables that are expected to change in the tree (e.g., in T1tttt it should be set to ['genSusyMGluino','genSusyMNeutralino'])
+    SMS_regexp_evtGenMass = 'genSusyM.+',
+    bypass_trackMass_check = True # bypass check that non-scanned masses are the same in all events
     )
 
 PDFWeights = []

--- a/CMGTools/TTHAnalysis/python/analyzers/susyParameterScanAnalyzer.py
+++ b/CMGTools/TTHAnalysis/python/analyzers/susyParameterScanAnalyzer.py
@@ -64,9 +64,12 @@ class susyParameterScanAnalyzer( Analyzer ):
                 self.warned_already = True
             return
         lheprod = self.mchandles['lhe'].product()
-        scanline = re.compile(r"#\s*model\s+([A-Za-z0-9]+)_((\d+\.?\d*)(_\d+\.?\d*)*)\s+(\d+\.?\d*)\s*")
+        scanline = re.compile(r"#\s*model\s+([A-Za-z0-9]+)_((\d+\.?\d*)(_\d+\.?\d*)*)(\s+(\d+\.?\d*))*\s*")
         for i in xrange(lheprod.comments_size()):
             comment = lheprod.getComment(i)
+            if (not hasattr(self,'model_printed')) and ('model' in comment):
+                print 'LHE contains this model string: %s (will not print the ones in the following events)'%comment
+                self.model_printed = True
             m = re.match(scanline, comment) 
             if m:
                 event.susyModel = m.group(1)

--- a/CMGTools/TTHAnalysis/python/analyzers/ttHhistoCounterAnalyzer.py
+++ b/CMGTools/TTHAnalysis/python/analyzers/ttHhistoCounterAnalyzer.py
@@ -13,11 +13,14 @@ from PhysicsTools.Heppy.analyzers.core.AutoHandle import AutoHandle
 
 import ROOT
 import os
+import re
 
 class ttHhistoCounterAnalyzer( Analyzer ):
     def __init__(self, cfg_ana, cfg_comp, looperName ):
         super(ttHhistoCounterAnalyzer,self).__init__(cfg_ana,cfg_comp,looperName) 
         self.doLHE = getattr(cfg_ana, 'doLHE', True)
+        self.cfg_ana = cfg_ana
+        self.isInitSMS = False
 
     def declareHandles(self):
         super(ttHhistoCounterAnalyzer, self).declareHandles()
@@ -32,23 +35,74 @@ class ttHhistoCounterAnalyzer( Analyzer ):
             setup.services["outputfile"].file.cd()
             self.inputCounter = ROOT.TH1D("Count","Count",1,0,2)
             if self.cfg_comp.isMC:
+                self.maxSMSmass = getattr(self.cfg_ana, 'SMS_max_mass', 3000)
+                self.inputCounterSMS = ROOT.TH3D("CountSMS","CountSMS",int(self.maxSMSmass+1),-0.5,self.maxSMSmass+0.5,int(self.maxSMSmass+1),-0.5,self.maxSMSmass+0.5,1,0,2)
                 if self.doLHE:
                     self.inputLHE = ROOT.TH1D("CountLHE","CountLHE",20001,-0.5,20000.5)
+#                    self.inputLHESMS = ROOT.TH3D("CountLHESMS","CountLHESMS",int(self.maxSMSmass+1),-0.5,self.maxSMSmass+0.5,int(self.maxSMSmass+1),-0.5,self.maxSMSmass+0.5,10001,-0.5,10000.5) ### too big!
                 self.inputGenWeights = ROOT.TH1D("SumGenWeights","SumGenWeights",1,0,2)
+                self.inputGenWeightsSMS = ROOT.TH3D("SumGenWeightsSMS","SumGenWeightsSMS",int(self.maxSMSmass+1),-0.5,self.maxSMSmass+0.5,int(self.maxSMSmass+1),-0.5,self.maxSMSmass+0.5,1,0,2)
+
+    def initSMS(self,event):
+        if self.isInitSMS: raise RuntimeError, 'Trying to initSMS twice!'
+        self.massfill1 = getattr(self.cfg_ana, 'SMS_mass_1', 'genSusyMScan1')
+        self.massfill2 = getattr(self.cfg_ana, 'SMS_mass_2', 'genSusyMScan2')
+        self.masses_to_track = [self.massfill1,self.massfill2]
+        for mass in getattr(self.cfg_ana, 'SMS_varying_masses', []):
+            if mass not in self.masses_to_track: self.masses_to_track.append(mass)
+        self.allmasses={}
+        self.genMregexp = getattr(self.cfg_ana, 'SMS_regexp_evtGenMass', 'genSusyM.+')
+        for name in dir(event):
+            if not re.match(self.genMregexp,name): continue
+            self.allmasses[name]=-1
+        self.susyModel = event.susyModel
+        for trkM in self.masses_to_track:
+            if trkM not in self.allmasses: raise RuntimeError, 'Trying to track a SUSY SMS gen mass that does not exist in the event: %s'%trkM
+        for mass in self.allmasses:
+            self.allmasses[mass] = getattr(event,mass)
+        self.bypass_trackMass_check = getattr(self.cfg_ana, 'bypass_trackMass_check', False)
+        self.isInitSMS=True
+        print 'SUSY SMS: the first event looks like this:'
+        for mass,val in self.allmasses.iteritems():
+            tag = '???'
+            if mass == self.massfill1: tag = 'used as first tracked mass'
+            elif mass == self.massfill2: tag = 'used as second tracked mass'
+            elif mass in self.masses_to_track: tag = 'allowed to change between different events'
+            else: tag = 'not allowed to change between different events unless bypass_trackMass_check is set to True'
+            print '%s = %.1f, %s'%(mass,val,tag)
 
     def process(self, event):
         self.readCollections( event.input )
         self.inputCounter.Fill(1)
-        
+
+        isSMS = self.cfg_comp.isMC and event.susyModel
+
+        if isSMS:
+
+            if not self.isInitSMS: self.initSMS(event)
+
+            if event.susyModel!=self.susyModel: raise RuntimeError, 'The SMS model changed in the middle of the run, from %s to %s!'%(self.susyModel,event.susyModel)
+            if not self.bypass_trackMass_check:
+                for mass,val in self.allmasses.iteritems():
+                    if mass in self.masses_to_track: continue
+                    if val!=getattr(event,mass): raise RuntimeError, 'An untracked SMS mass (%s) changed in the middle of the run! If expected, add it to the SMS_varying_masses list.'%mass
+
+            m1 = getattr(event,self.massfill1)
+            m2 = getattr(event,self.massfill2)
+            if max(m1,m2)>self.maxSMSmass: raise RuntimeError, 'SMS mass found too large to be contained in the histogram: %f. Adapt the SMS_regexp_evtGenMass parameter.'%max(m1,m2)
+            self.inputCounterSMS.Fill(m1,m2,1)
+
         if self.cfg_comp.isMC:
             if self.doLHE:
               for w in event.LHE_weights:
                     id_ = float(w.id)
                     wgt_ = float(w.wgt)
                     self.inputLHE.Fill(id_, wgt_)
+#                    if isSMS: self.inputLHESMS.Fill(m1,m2,id_, wgt_)
 
         if self.cfg_comp.isMC:
             genWeight_ = float(self.mchandles['GenInfo'].product().weight())
             self.inputGenWeights.Fill(1, genWeight_);
+            if isSMS: self.inputGenWeightsSMS.Fill(m1,m2,1, genWeight_);
 
         return True

--- a/CMGTools/TTHAnalysis/python/analyzers/ttHhistoCounterAnalyzer.py
+++ b/CMGTools/TTHAnalysis/python/analyzers/ttHhistoCounterAnalyzer.py
@@ -35,16 +35,17 @@ class ttHhistoCounterAnalyzer( Analyzer ):
             setup.services["outputfile"].file.cd()
             self.inputCounter = ROOT.TH1D("Count","Count",1,0,2)
             if self.cfg_comp.isMC:
-                self.maxSMSmass = getattr(self.cfg_ana, 'SMS_max_mass', 3000)
-                self.inputCounterSMS = ROOT.TH3D("CountSMS","CountSMS",int(self.maxSMSmass+1),-0.5,self.maxSMSmass+0.5,int(self.maxSMSmass+1),-0.5,self.maxSMSmass+0.5,1,0,2)
                 if self.doLHE:
                     self.inputLHE = ROOT.TH1D("CountLHE","CountLHE",20001,-0.5,20000.5)
-#                    self.inputLHESMS = ROOT.TH3D("CountLHESMS","CountLHESMS",int(self.maxSMSmass+1),-0.5,self.maxSMSmass+0.5,int(self.maxSMSmass+1),-0.5,self.maxSMSmass+0.5,10001,-0.5,10000.5) ### too big!
                 self.inputGenWeights = ROOT.TH1D("SumGenWeights","SumGenWeights",1,0,2)
-                self.inputGenWeightsSMS = ROOT.TH3D("SumGenWeightsSMS","SumGenWeightsSMS",int(self.maxSMSmass+1),-0.5,self.maxSMSmass+0.5,int(self.maxSMSmass+1),-0.5,self.maxSMSmass+0.5,1,0,2)
+
 
     def initSMS(self,event):
-        if self.isInitSMS: raise RuntimeError, 'Trying to initSMS twice!'
+        if self.isInitSMS or (not self.cfg_comp.isMC): raise RuntimeError, 'Trying to initSMS twice or to call it on data!'
+        self.maxSMSmass = getattr(self.cfg_ana, 'SMS_max_mass', 3000)
+        self.inputCounterSMS = ROOT.TH3D("CountSMS","CountSMS",int(self.maxSMSmass+1),-0.5,self.maxSMSmass+0.5,int(self.maxSMSmass+1),-0.5,self.maxSMSmass+0.5,1,0,2)
+#        if self.doLHE: self.inputLHESMS = ROOT.TH3D("CountLHESMS","CountLHESMS",int(self.maxSMSmass+1),-0.5,self.maxSMSmass+0.5,int(self.maxSMSmass+1),-0.5,self.maxSMSmass+0.5,10001,-0.5,10000.5) ### too big!
+        self.inputGenWeightsSMS = ROOT.TH3D("SumGenWeightsSMS","SumGenWeightsSMS",int(self.maxSMSmass+1),-0.5,self.maxSMSmass+0.5,int(self.maxSMSmass+1),-0.5,self.maxSMSmass+0.5,1,0,2)        
         self.massfill1 = getattr(self.cfg_ana, 'SMS_mass_1', 'genSusyMScan1')
         self.massfill2 = getattr(self.cfg_ana, 'SMS_mass_2', 'genSusyMScan2')
         self.masses_to_track = [self.massfill1,self.massfill2]

--- a/CMGTools/TTHAnalysis/python/analyzers/ttHhistoCounterAnalyzer.py
+++ b/CMGTools/TTHAnalysis/python/analyzers/ttHhistoCounterAnalyzer.py
@@ -75,7 +75,7 @@ class ttHhistoCounterAnalyzer( Analyzer ):
         self.readCollections( event.input )
         self.inputCounter.Fill(1)
 
-        isSMS = self.cfg_comp.isMC and event.susyModel
+        isSMS = self.cfg_comp.isMC and getattr(event,'susyModel',False)
 
         if isSMS:
 

--- a/CMGTools/TTHAnalysis/python/plotter/fakeRate.cc
+++ b/CMGTools/TTHAnalysis/python/plotter/fakeRate.cc
@@ -37,6 +37,13 @@ TH2 * FR_el_FO4_insitu = 0;
 TH2 * FRi_FO_mu[8];
 TH2 * FRi_FO_el[8];
 
+TH2 * FR_mu_QCD_iso = 0;
+TH2 * FR_mu_QCD_noniso = 0;
+TH2 * FR_el_QCD_iso = 0;
+TH2 * FR_el_QCD_noniso = 0;
+TH2 * FRi_fHT_FO_mu[2];
+TH2 * FRi_fHT_FO_el[2];
+
 bool loadFRHisto(const std::string &histoName, const char *file, const char *name) {
     TH2 **histo = 0, **hptr2 = 0;
     if      (histoName == "FR_mu")  { histo = & FR_mu;  hptr2 = & FRi_mu[0]; }
@@ -66,6 +73,10 @@ bool loadFRHisto(const std::string &histoName, const char *file, const char *nam
     else if (histoName == "FR_el_FO3_insitu")  { histo = &FR_el_FO3_insitu ;  hptr2 = & FRi_FO_el[5]; }
     else if (histoName == "FR_el_FO4_QCD")  { histo = &FR_el_FO4_QCD ;  hptr2 = & FRi_FO_el[6]; }
     else if (histoName == "FR_el_FO4_insitu")  { histo = &FR_el_FO4_insitu ;  hptr2 = & FRi_FO_el[7]; }
+    else if (histoName == "FR_mu_QCD_iso")  { histo = &FR_mu_QCD_iso ;  hptr2 = & FRi_fHT_FO_mu[0]; }
+    else if (histoName == "FR_mu_QCD_noniso")  { histo = &FR_mu_QCD_noniso ;  hptr2 = & FRi_fHT_FO_mu[1]; }
+    else if (histoName == "FR_el_QCD_iso")  { histo = &FR_el_QCD_iso ;  hptr2 = & FRi_fHT_FO_el[0]; }
+    else if (histoName == "FR_el_QCD_noniso")  { histo = &FR_el_QCD_noniso ;  hptr2 = & FRi_fHT_FO_el[1]; }
     if (histo == 0)  {
         std::cerr << "ERROR: histogram " << histoName << " is not defined in fakeRate.cc." << std::endl;
         return 0;
@@ -744,63 +755,123 @@ float fakeRateReader_2lss_FO(float l1eta, float l1pt, float l2eta, float l2pt, i
     }
 }
 
+float fakeRateReader_2lss_fHT_FO(float l1eta, float l1pt, float l2eta, float l2pt, int l1pdgId, int l2pdgId, int pass1, int pass2, int isiso)
+{
+  int ind = isiso ? 0 : 1;
+  int nfail = 2-pass1-pass2;
+    switch (nfail) {
+        case 1: {
+            double fpt,feta; int fid;
+            if (pass2)   { fpt = l1pt; feta = std::abs(l1eta); fid = abs(l1pdgId); }
+            else         { fpt = l2pt; feta = std::abs(l2eta); fid = abs(l2pdgId); }
+            TH2 *hist = (fid == 11 ? FRi_fHT_FO_el[ind] : FRi_fHT_FO_mu[ind]);
+	    if (!hist){
+	      std::cout << "Error: FR histo not filled " << fid << " " << ind << std::endl;
+	      assert(false);
+	    }
+	    int ptbin  = std::max(1, std::min(hist->GetNbinsX(), hist->GetXaxis()->FindBin(fpt)));
+	    int etabin = std::max(1, std::min(hist->GetNbinsY(), hist->GetYaxis()->FindBin(feta)));
+	    double fr = hist->GetBinContent(ptbin,etabin);
+	    //	    std::cout << "returning " << fr/(1-fr) << std::endl;
+            return fr/(1-fr);
+        }
+      case 2: {
+            TH2 *hist1 = (abs(l1pdgId) == 11 ? FRi_fHT_FO_el[ind] : FRi_fHT_FO_mu[ind]);
+	    int ptbin1  = std::max(1, std::min(hist1->GetNbinsX(), hist1->GetXaxis()->FindBin(l1pt)));
+	    int etabin1 = std::max(1, std::min(hist1->GetNbinsY(), hist1->GetYaxis()->FindBin(std::abs(l1eta))));
+	    double fr1 = hist1->GetBinContent(ptbin1,etabin1);
+           TH2 *hist2 = (abs(l2pdgId) == 11 ? FRi_fHT_FO_el[ind] : FRi_fHT_FO_mu[ind]);
+	   int ptbin2  = std::max(1, std::min(hist2->GetNbinsX(), hist2->GetXaxis()->FindBin(l2pt)));
+	   int etabin2 = std::max(1, std::min(hist2->GetNbinsY(), hist2->GetYaxis()->FindBin(std::abs(l2eta))));
+	   double fr2 = hist2->GetBinContent(ptbin2,etabin2);
+	   //	   std::cout << "returning " << -fr1*fr2/((1-fr1)*(1-fr2)) << std::endl;
+            return -fr1*fr2/((1-fr1)*(1-fr2));
+      }
+        default: return 0;
+    }
+}
+
 namespace WP {
     enum WPId { V=0, VL=0, VVL=-1, L=1, M=2, T=3, VT=4, HT=5 } ;
 }
-float multiIso_singleWP(float LepGood_miniRelIso, float LepGood_jetPtRatio, float LepGood_jetPtRel, WP::WPId wp) {
+float multiIso_singleWP(float LepGood_miniRelIso, float LepGood_jetPtRatiov2, float LepGood_jetPtRelv2, WP::WPId wp) {
     switch (wp) {
-        case WP::HT: return LepGood_miniRelIso < 0.05  && (LepGood_jetPtRatio>0.725 || LepGood_jetPtRel>8   );
-        case WP::VT: return LepGood_miniRelIso < 0.075 && (LepGood_jetPtRatio>0.725 || LepGood_jetPtRel>7   );
-        case WP::T:  return LepGood_miniRelIso < 0.10  && (LepGood_jetPtRatio>0.700 || LepGood_jetPtRel>7   );
-        case WP::M:  return LepGood_miniRelIso < 0.14  && (LepGood_jetPtRatio>0.68  || LepGood_jetPtRel>6.7 );
-        case WP::L:  return LepGood_miniRelIso < 0.22  && (LepGood_jetPtRatio>0.63  || LepGood_jetPtRel>6.0 );
+        case WP::VT: return LepGood_miniRelIso < 0.09  && (LepGood_jetPtRatiov2>0.84  || LepGood_jetPtRelv2>7.2 );
+        case WP::T:  return LepGood_miniRelIso < 0.12  && (LepGood_jetPtRatiov2>0.80  || LepGood_jetPtRelv2>7.2 );
+        case WP::M:  return LepGood_miniRelIso < 0.16  && (LepGood_jetPtRatiov2>0.76  || LepGood_jetPtRelv2>7.2 );
+        case WP::L:  return LepGood_miniRelIso < 0.20  && (LepGood_jetPtRatiov2>0.69  || LepGood_jetPtRelv2>6.0 );
+        case WP::VL: return LepGood_miniRelIso < 0.25  && (LepGood_jetPtRatiov2>0.67  || LepGood_jetPtRelv2>4.4 );
         case WP::VVL: return LepGood_miniRelIso < 0.4;
         default:
             std::cerr << "Working point " << wp << " not implemented for multiIso_singleWP" << std::endl;
             abort();
     }
 }
-float multiIso_singleWP(float LepGood_miniRelIso, float LepGood_jetPtRatio, float LepGood_jetPtRel, int wp) {
-    return multiIso_singleWP(LepGood_miniRelIso,LepGood_jetPtRatio,LepGood_jetPtRel, WP::WPId(wp));
-}
-float multiIso_multiWP(int LepGood_pdgId, float LepGood_pt, float LepGood_eta, float LepGood_miniRelIso, float LepGood_jetPtRatio, float LepGood_jetPtRel, WP::WPId wp) {
+float multiIso_multiWP(int LepGood_pdgId, float LepGood_pt, float LepGood_eta, float LepGood_miniRelIso, float LepGood_jetPtRatiov2, float LepGood_jetPtRelv2, WP::WPId wp) {
     switch (wp) {
         case WP::VT: 
            return abs(LepGood_pdgId)==13 ? 
-                    multiIso_singleWP(LepGood_miniRelIso,LepGood_jetPtRatio,LepGood_jetPtRel, WP::VT) :
-                    multiIso_singleWP(LepGood_miniRelIso,LepGood_jetPtRatio,LepGood_jetPtRel, WP::HT) ;
+                    multiIso_singleWP(LepGood_miniRelIso,LepGood_jetPtRatiov2,LepGood_jetPtRelv2, WP::VT) :
+                    multiIso_singleWP(LepGood_miniRelIso,LepGood_jetPtRatiov2,LepGood_jetPtRelv2, WP::HT) ;
         case WP::T:
            return abs(LepGood_pdgId)==13 ? 
-                    multiIso_singleWP(LepGood_miniRelIso,LepGood_jetPtRatio,LepGood_jetPtRel, WP::T) :
-                    multiIso_singleWP(LepGood_miniRelIso,LepGood_jetPtRatio,LepGood_jetPtRel, WP::VT) ;
+                    multiIso_singleWP(LepGood_miniRelIso,LepGood_jetPtRatiov2,LepGood_jetPtRelv2, WP::T) :
+                    multiIso_singleWP(LepGood_miniRelIso,LepGood_jetPtRatiov2,LepGood_jetPtRelv2, WP::VT) ;
         case WP::M:
            return abs(LepGood_pdgId)==13 ? 
-                    multiIso_singleWP(LepGood_miniRelIso,LepGood_jetPtRatio,LepGood_jetPtRel, WP::M) :
-                    multiIso_singleWP(LepGood_miniRelIso,LepGood_jetPtRatio,LepGood_jetPtRel, WP::T) ;
-        case WP::L:
-           return abs(LepGood_pdgId)==13 ? 
-                    multiIso_singleWP(LepGood_miniRelIso,LepGood_jetPtRatio,LepGood_jetPtRel, WP::L) :
-                    multiIso_singleWP(LepGood_miniRelIso,LepGood_jetPtRatio,LepGood_jetPtRel, WP::M) ;
+                    multiIso_singleWP(LepGood_miniRelIso,LepGood_jetPtRatiov2,LepGood_jetPtRelv2, WP::M) :
+                    multiIso_singleWP(LepGood_miniRelIso,LepGood_jetPtRatiov2,LepGood_jetPtRelv2, WP::T) ;
         case WP::VVL: return LepGood_miniRelIso < 0.4;
         default:
             std::cerr << "Working point " << wp << " not implemented for multiIso_multiWP" << std::endl;
             abort();
     }
 }
-float multiIso_multiWP(int LepGood_pdgId, float LepGood_pt, float LepGood_eta, float LepGood_miniRelIso, float LepGood_jetPtRatio, float LepGood_jetPtRel, int wp) {
-    return multiIso_multiWP(LepGood_pdgId,LepGood_pt,LepGood_eta,LepGood_miniRelIso,LepGood_jetPtRatio,LepGood_jetPtRel,WP::WPId(wp));
+float multiIso_multiWP(int LepGood_pdgId, float LepGood_pt, float LepGood_eta, float LepGood_miniRelIso, float LepGood_jetPtRatiov2, float LepGood_jetPtRelv2, int wp) {
+    return multiIso_multiWP(LepGood_pdgId,LepGood_pt,LepGood_eta,LepGood_miniRelIso,LepGood_jetPtRatiov2,LepGood_jetPtRelv2,WP::WPId(wp));
 }
 
-float multiIso_singleWP_relaxFO3(int LepGood_pdgId, float LepGood_pt, float LepGood_CorrConePt, float LepGood_eta, float LepGood_miniRelIso, float LepGood_jetPtRatio, float LepGood_jetPtRel, WP::WPId wp) {
+float multiIso_singleWP_relaxFO3(int LepGood_pdgId, float LepGood_pt, float LepGood_CorrConePt, float LepGood_eta, float LepGood_miniRelIso, float LepGood_jetPtRatiov2, float LepGood_jetPtRelv2, WP::WPId wp) {
   assert (wp==2);
-  return multiIso_multiWP(LepGood_pdgId,LepGood_pt,LepGood_eta,(LepGood_miniRelIso>=0.4),LepGood_CorrConePt/LepGood_pt*LepGood_jetPtRatio,LepGood_jetPtRel,wp)>0;
+  return multiIso_multiWP(LepGood_pdgId,LepGood_pt,LepGood_eta,(LepGood_miniRelIso>=0.4),LepGood_CorrConePt/LepGood_pt*LepGood_jetPtRatiov2,LepGood_jetPtRelv2,wp)>0;
 }
 
-float multiIso_singleWP_relaxFO4(int LepGood_pdgId, float LepGood_pt, float LepGood_eta, float LepGood_miniRelIso, float LepGood_jetPtRatio, float LepGood_jetPtRel, WP::WPId wp) {
+float multiIso_singleWP_relaxFO4(int LepGood_pdgId, float LepGood_pt, float LepGood_eta, float LepGood_miniRelIso, float LepGood_jetPtRatiov2, float LepGood_jetPtRelv2, WP::WPId wp) {
   assert (wp==2);
-  if (abs(LepGood_pdgId)==13) return (LepGood_miniRelIso<0.4 && (1/LepGood_jetPtRatio < (1/0.7 + LepGood_miniRelIso)));
-  else if (abs(LepGood_pdgId)==11) return (LepGood_miniRelIso<0.4 && (1/LepGood_jetPtRatio < (1/0.68 + LepGood_miniRelIso)));
+  if (abs(LepGood_pdgId)==13) return (LepGood_miniRelIso<0.4 && (1/LepGood_jetPtRatiov2 < (1/0.76 + LepGood_miniRelIso)));
+  else if (abs(LepGood_pdgId)==11) return (LepGood_miniRelIso<0.4 && (1/LepGood_jetPtRatiov2 < (1/0.80 + LepGood_miniRelIso)));
   else assert(false);
+}
+
+
+float mvaIdSpring15(int LepGood_pdgId, float LepGood_eta, float LepGood_mvaIdSpring15, int wp, int iso_emulation_applied){
+  if (abs(LepGood_pdgId)!=11) return 1;
+
+  float eta = fabs(LepGood_eta);
+
+  switch (wp) {
+
+  case WP::VL:
+    if (iso_emulation_applied) {
+      if (eta<0.8) return LepGood_mvaIdSpring15>-0.155;
+      else if (eta<=1.479) return LepGood_mvaIdSpring15>-0.56;
+      else return LepGood_mvaIdSpring15>-0.76;
+    }
+    else {
+      if (eta<0.8) return LepGood_mvaIdSpring15>-0.70;
+      else if (eta<=1.479) return LepGood_mvaIdSpring15>-0.83;
+      else return LepGood_mvaIdSpring15>-0.92;
+  }
+
+  case WP::T:
+    if (eta<0.8) return LepGood_mvaIdSpring15>0.87;
+    else if (eta<=1.479) return LepGood_mvaIdSpring15>0.60;
+    else return LepGood_mvaIdSpring15>0.17;
+
+  default:
+    std::cerr << "Working point " << wp << " not implemented for mvaIdSpring15" << std::endl;
+    abort();
+  }
 }
 
 void fakeRate() {}

--- a/CMGTools/TTHAnalysis/python/plotter/fakeRate.py
+++ b/CMGTools/TTHAnalysis/python/plotter/fakeRate.py
@@ -40,7 +40,7 @@ class FakeRate:
 	            if self._weight is None: raise RuntimeError, "cut-file must follow weight declaration in fake rate file "+file
 	            addcuts = CutsFile(fields[1],options=None,ignoreEmptyOptionsEnforcement=True)
 	            self._weight = '((%s)*(%s))' % (self._weight,addcuts.allCuts(doProduct=True))
-                    print "WARNING: cuts loaded from fake rate file "+file
+#                    print "WARNING: cuts loaded from fake rate file "+file
 	        else:
 	            raise RuntimeError, "Unknown directive "+fields[0]
             if file==files[0]:

--- a/CMGTools/TTHAnalysis/python/plotter/mcDump.py
+++ b/CMGTools/TTHAnalysis/python/plotter/mcDump.py
@@ -29,17 +29,30 @@ class MCDumpModule(Module):
         self.fmt = fmt
         self.options = options
         self.mcde = MCDumpEvent()
+        self.passing_entries = 0
+        self.dumpFile = None
+    def __del__(self):
+        if self.dumpFile: self.dumpFile.close()
     def beginComponent(self,tty):
         self.mcde.beginComponent(tty)
+    def openOutFile(self,dumpFileName):
+        if self.dumpFile: raise RuntimeError,'Output file already open'
+        self.dumpFile = open(dumpFileName,'w')
+    def getPassingEntries(self):
+        return self.passing_entries
     def analyze(self,ev):
         self.mcde.update(ev)
-        print string.Formatter().vformat(self.fmt.replace("\\t","\t"),[],self.mcde)
+        out=string.Formatter().vformat(self.fmt.replace("\\t","\t"),[],self.mcde)
+        if len(out)>0:
+            self.passing_entries += 1
+            if self.dumpFile: self.dumpFile.write(out+'\n')
         return True
     
 
 def addMCDumpOptions(parser):
     addMCAnalysisOptions(parser)
     parser.add_option("-n", "--maxEvents",  dest="maxEvents", default=-1, type="int", help="Max events")
+    parser.add_option("--dumpFile",  dest="dumpFile", default=None, type="string", help="Dump file name")
 
 if __name__ == "__main__":
     from optparse import OptionParser
@@ -49,5 +62,7 @@ if __name__ == "__main__":
     mca = MCAnalysis(args[0],options)
     cut = CutsFile(args[1],options).allCuts()
     mcdm = MCDumpModule("dump",args[2],options)
+    if options.dumpFile: mcdm.openOutFile(options.dumpFile)
     el = EventLoop([mcdm])
     mca.processEvents(EventLoop([mcdm]), cut=cut)
+    print 'Passing entries:',mcdm.getPassingEntries()

--- a/CMGTools/TTHAnalysis/python/plotter/skimFTrees.py
+++ b/CMGTools/TTHAnalysis/python/plotter/skimFTrees.py
@@ -1,0 +1,30 @@
+import ROOT
+import os, sys
+
+# usage: python skimFTrees.py BIGTREE_DIR FTREE_DIR outdir DATASET_NAME ...
+
+dsets = sys.argv[4:]
+if len(sys.argv)<5:
+    dsets = [d.replace('evVarFriend_','').replace('.root','') for d in os.listdir(sys.argv[2]) if 'evVarFriend' in d]
+dsets = [d for d in dsets if d in os.listdir(sys.argv[1])]
+
+fname = [x for x in sys.argv[2].split('/') if x!=''][-1]
+
+for dset in dsets:
+    print dset,
+    fsel = ROOT.TFile.Open(sys.argv[1]+'/'+dset+'/selection_eventlist.root')
+    elist = fsel.elist
+    f_f = ROOT.TFile.Open(sys.argv[2]+'/evVarFriend_'+dset+'.root')
+    t_f = f_f.Get("sf/t")
+    t_f.SetEventList(elist)
+    os.system('mkdir -p %s/%s'%(sys.argv[3],fname))
+    f2 = ROOT.TFile('%s/%s/evVarFriend_%s.root'%(sys.argv[3],fname,dset),'recreate')
+    f2.cd()
+    f2.mkdir('sf')
+    f2.cd('sf')
+    t2 = t_f.CopyTree('1')
+    f2.Write()
+    print ': skimmed friend trees put in %s'%f2.GetName()
+    f2.Close()
+    f_f.Close()
+    fsel.Close()

--- a/CMGTools/TTHAnalysis/python/plotter/skimTrees.py
+++ b/CMGTools/TTHAnalysis/python/plotter/skimTrees.py
@@ -2,7 +2,29 @@
 #from mcPlots import *
 from CMGTools.TTHAnalysis.plotter.mcAnalysis import *
 
+import array
 import ROOT
+
+class CheckEventVetoList:
+    _store={}
+    def __init__(self,fname):
+        self.loadFile(fname)
+        print 'Initialized CheckEventVetoList from %s'%fname
+        self.name = fname.strip().split('/')[-1]
+    def loadFile(self,fname):
+        with open(fname, 'r') as f:
+            for line in f:
+                if len(line.strip()) == 0 or line.strip()[0] == '#': continue
+                run,lumi,evt = line.strip().split(':')
+                self.addEvent(int(run),int(lumi),long(evt))
+    def addEvent(self,run,lumi,evt):
+        if (run,lumi) not in self._store:
+            self._store[(run,lumi)]=array.array('L')
+        self._store[(run,lumi)].append(evt)
+    def filter(self,run,lumi,evt):
+        mylist=self._store.get((run,lumi),None)
+        return ((not mylist) or (long(evt) not in mylist))
+
 
 if __name__ == "__main__":
     from optparse import OptionParser
@@ -10,6 +32,7 @@ if __name__ == "__main__":
     parser.add_option("-D", "--drop",  dest="drop", type="string", default=[], action="append",  help="Branches to drop, as per TTree::SetBranchStatus") 
     parser.add_option("-K", "--keep",  dest="keep", type="string", default=[], action="append",  help="Branches to keep, as per TTree::SetBranchStatus") 
     parser.add_option("--oldstyle",    dest="oldstyle", default=False, action="store_true",  help="Oldstyle naming (e.g. file named as <analyzer>_tree.root)") 
+    parser.add_option("--vetoevents",  dest="vetoevents", type="string", default=[], action="append",  help="File containing list of events to filter out")
     addMCAnalysisOptions(parser)
     (options, args) = parser.parse_args()
     options.weight = False
@@ -21,6 +44,8 @@ if __name__ == "__main__":
     print "Will write selected trees to "+outdir
     if not os.path.exists(outdir):
         os.system("mkdir -p "+outdir)
+
+    selectors=[CheckEventVetoList(fname) for fname in options.vetoevents]
 
     for proc in mca.listProcesses():
         print "Process %s" % proc
@@ -44,16 +69,42 @@ if __name__ == "__main__":
                 fout = ROOT.TFile("%s/%s/tree.root" % (myoutpath,options.tree), "RECREATE");
             else:
                 fout = ROOT.TFile("%s/%s/%s_tree.root" % (myoutpath,options.tree,options.tree), "RECREATE");
-            fout = ROOT.TFile("%s/%s/tree.root" % (myoutpath,options.tree), "RECREATE");
+            mytree.Draw('>>elist',mycut)
+            elist = ROOT.gDirectory.Get('elist')
+            if len(options.vetoevents)>0:
+                mytree.SetBranchStatus("*",0)
+                mytree.SetBranchStatus("run",1)
+                mytree.SetBranchStatus("lumi",1)
+                mytree.SetBranchStatus("evt",1)
+                mytree.SetBranchStatus("isData",1)
+                elistveto = ROOT.TEventList("vetoevents","vetoevents")
+                for ev in xrange(elist.GetN()):
+                    tev = elist.GetEntry(ev)
+                    mytree.GetEntry(tev)
+                    if not mytree.isData:
+                        print "You don't want to filter by event number on MC, skipping for this sample"
+                        break
+                    for selector in selectors:
+                        if not selector.filter(mytree.run,mytree.lumi,mytree.evt):
+                            print 'Selector %s rejected tree entry %d (%d among selected): %d:%d:%d'%(selector.name,tev,ev,mytree.run,mytree.lumi,mytree.evt)
+                            elistveto.Enter(tev)
+                            break
+                mytree.SetBranchStatus("*",1)
+                elist.Subtract(elistveto)
+                print '%d events survived vetoes'%(elist.GetN(),)
             # drop and keep branches
             for drop in options.drop: mytree.SetBranchStatus(drop,0)
             for keep in options.keep: mytree.SetBranchStatus(keep,1)
-            out = mytree.CopyTree(mycut)
+            f2 = ROOT.TFile("%s/selection_eventlist.root"%myoutpath,"recreate")
+            f2.cd()
+            elist.Write()
+            f2.Close()
+            fout.cd()
+            mytree.SetEventList(elist)
+            out = mytree.CopyTree('1')
             friends = out.GetListOfFriends() or []
             for tf in friends:
                     out.RemoveFriend(tf.GetTree())
             fout.WriteTObject(out,options.tree if options.oldstyle else "tree")
-            fout.WriteTObject(out,"tree")
             if histo: histo.Write()
             fout.Close()
-

--- a/CMGTools/TTHAnalysis/python/plotter/susy-multilepton/for-pu-rew/alwaystrue.txt
+++ b/CMGTools/TTHAnalysis/python/plotter/susy-multilepton/for-pu-rew/alwaystrue.txt
@@ -1,0 +1,1 @@
+alwaystrue: 1

--- a/CMGTools/TTHAnalysis/python/plotter/susy-multilepton/for-pu-rew/commands.py
+++ b/CMGTools/TTHAnalysis/python/plotter/susy-multilepton/for-pu-rew/commands.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python
 
-MYTREEDIR="~/work/ra5trees/TREES_74X_061015_MiniIso_7_4_12_JECv5_noPreProc"
-MYLUMI="0.2092"
+MYTREEDIR="/data1/p/peruzzi/TREES_74X_191115_MiniIso_v6"
+MYLUMI="2.11"
 
 EXE="python mcPlots.py"
 WDIR="susy-multilepton/for-pu-rew"
 COMMOPT='--s2v --tree treeProducerSusyMultilepton --noErrorBandOnRatio  --rspam "%(lumi) (13 TeV)  " --lspam "#bf{CMS} #it{Preliminary}" --legendBorder=0 --legendFontSize 0.055 --legendWidth=0.35 --showRatio --maxRatioRange 0 2 --showRatio --poisson -j 8 -f --sp ".*"'
 MCA = 'mca_13tev.txt'
 
-print "%s %s/%s %s/zjets-4-nvtx.txt %s/zjets-4-nvtx_plots.txt %s -P %s -l %s --pdir %s/pu_plots"%(EXE,WDIR,MCA,WDIR,WDIR,COMMOPT,MYTREEDIR,MYLUMI,WDIR)
+print "%s %s/%s %s/zjets-4-nvtx.txt %s/zjets-4-nvtx_plots.txt %s --xp 'ZZTo4L' -P %s -l %s --pdir %s/pu_plots"%(EXE,WDIR,MCA,WDIR,WDIR,COMMOPT,MYTREEDIR,MYLUMI,WDIR)
+
+print "%s %s/%s %s/alwaystrue.txt %s/zjets-4-nvtx_plots_true.txt %s -p 'ZZTo4L' -P %s -l %s --pdir %s/pu_plots"%(EXE,WDIR,MCA,WDIR,WDIR,COMMOPT,MYTREEDIR,MYLUMI,WDIR)
 

--- a/CMGTools/TTHAnalysis/python/plotter/susy-multilepton/for-pu-rew/mca_13tev.txt
+++ b/CMGTools/TTHAnalysis/python/plotter/susy-multilepton/for-pu-rew/mca_13tev.txt
@@ -1,10 +1,35 @@
-DY : DYJetsToLL_M50: xsec ; FillColor=ROOT.kCyan
+#DY : DYJetsToLL_M50: xsec ; FillColor=ROOT.kCyan
 
-# 2015D 25ns data
+#data: DoubleEG_Run2015C_Oct05_runs_254231_254914
+#data: DoubleEG_Run2015D_Oct05_runs_256630_258158
+#data: DoubleEG_Run2015D_PromptV4_runs_258159_258750
+#data: DoubleEG_Run2015D_PromptV4_runs_258751_260627
+#data: DoubleMuon_Run2015C_Oct05_runs_254231_254914
+#data: DoubleMuon_Run2015D_Oct05_runs_256630_258158
+#data: DoubleMuon_Run2015D_PromptV4_runs_258159_258750
+#data: DoubleMuon_Run2015D_PromptV4_runs_258751_260627
+#data: MuonEG_Run2015C_Oct05_runs_254231_254914
+#data: MuonEG_Run2015D_Oct05_runs_256630_258158
+#data: MuonEG_Run2015D_PromptV4_runs_258159_258750
+#data: MuonEG_Run2015D_PromptV4_runs_258751_260627
+#data: SingleElectron_Run2015C_Oct05_runs_254231_254914
+#data: SingleElectron_Run2015D_Oct05_runs_256630_258158
+#data: SingleElectron_Run2015D_PromptV4_runs_258159_258750
+#data: SingleElectron_Run2015D_PromptV4_runs_258751_260627
+#data: SingleMuon_Run2015C_Oct05_runs_254231_254914
+#data: SingleMuon_Run2015D_Oct05_runs_256630_258158
+#data: SingleMuon_Run2015D_PromptV4_runs_258159_258750
+#data: SingleMuon_Run2015D_PromptV4_runs_258751_260627
 
-data: DoubleMuon_Run2015D_v3_runs_256630_257599
-data: DoubleEG_Run2015D_v3_runs_256630_257599
-data: MuonEG_Run2015D_v3_runs_256630_257599
-data: SingleMuon_Run2015D_v3_runs_256630_257599
-data: SingleElectron_Run2015D_v3_runs_256630_257599
+ZZTo4L: ZZTo4L: xsec ; FillColor=ROOT.kOrange
 
+##v6
+data: DoubleEG_Run2015C_Oct05_runs_254231_254914
+data: DoubleEG_Run2015D_Oct05_runs_256630_258158
+data: DoubleEG_Run2015D_PromptV4_runs_258159_260627
+data: DoubleMuon_Run2015C_Oct05_runs_254231_254914
+data: DoubleMuon_Run2015D_Oct05_runs_256630_258158
+data: DoubleMuon_Run2015D_PromptV4_runs_258159_260627
+data: MuonEG_Run2015C_Oct05_runs_254231_254914
+data: MuonEG_Run2015D_Oct05_runs_256630_258158
+data: MuonEG_Run2015D_PromptV4_runs_258159_260627

--- a/CMGTools/TTHAnalysis/python/plotter/susy-multilepton/for-pu-rew/zjets-4-nvtx_plots_true.txt
+++ b/CMGTools/TTHAnalysis/python/plotter/susy-multilepton/for-pu-rew/zjets-4-nvtx_plots_true.txt
@@ -1,0 +1,1 @@
+nTrueInt: nTrueInt: 50,0,50 ; XTitle="nPUtrue", Legend='TR'

--- a/CMGTools/TTHAnalysis/python/plotter/tree2yield.py
+++ b/CMGTools/TTHAnalysis/python/plotter/tree2yield.py
@@ -58,6 +58,7 @@ class TreeToYield:
         self._weightString  = options.weightString if not self._isdata else "1"
         self._scaleFactor = scaleFactor
         self._fullYield = 0 # yield of the full sample, as if it passed the full skim and all cuts
+        self._fullNevt = 0 # number of events of the full sample, as if it passed the full skim and all cuts
         self._settings = settings
         loadMCCorrections(options)            ## make sure this is loaded
         self._mcCorrs = globalMCCorrections() ##  get defaults
@@ -100,6 +101,8 @@ class TreeToYield:
         return self._scaleFactor
     def setFullYield(self,fullYield):
         self._fullYield = fullYield
+    def setFullNevt(self,fullNevt):
+        self._fullNevt = fullNevt
     def name(self):
         return self._name
     def cname(self):
@@ -178,7 +181,7 @@ class TreeToYield:
                 cut = cv
             report.append((cn,self._getYield(self._tree,cut)))
         if self._options.fullSampleYields and not noEntryLine:
-            report.insert(0, ('full sample', [self._fullYield,0]) )
+            report.insert(0, ('full sample', [self._fullYield,0,self._fullNevt]) )
         return report
     def prettyPrint(self,report):
         # maximum length of the cut descriptions
@@ -224,13 +227,13 @@ class TreeToYield:
             histo = ROOT.TH1D("dummy","dummy",1,0.0,1.0); histo.Sumw2()
             nev = tree.Draw("0.5>>dummy", cut, "goff", self._options.maxEntries)
             self.negativeCheck(histo)
-            return [ histo.GetBinContent(1), histo.GetBinError(1) ]
+            return [ histo.GetBinContent(1), histo.GetBinError(1), nev ]
         else: 
             cut = self.adaptExpr(cut,cut=True)
             if self._options.doS2V:
                 cut  = scalarToVector(cut)
             npass = tree.Draw("1",self.adaptExpr(cut,cut=True),"goff", self._options.maxEntries);
-            return [ npass, sqrt(npass) ]
+            return [ npass, sqrt(npass), npass ]
     def _stylePlot(self,plot,spec):
         ## Sample specific-options, from self
         if self.hasOption('FillColor'):
@@ -243,7 +246,7 @@ class TreeToYield:
         plot.SetLineStyle(self.getOption('LineStyle',1))
         plot.SetMarkerColor(self.getOption('MarkerColor',1))
         plot.SetMarkerStyle(self.getOption('MarkerStyle',20))
-        plot.SetMarkerSize(self.getOption('MarkerSize',1.6))
+        plot.SetMarkerSize(self.getOption('MarkerSize',1.1))
         ## Plot specific-options, from spec
         if "TH3" not in plot.ClassName():
             plot.GetYaxis().SetTitle(spec.getOption('YTitle',"Events"))
@@ -432,6 +435,7 @@ def mergeReports(reports):
         for i,(c,x) in enumerate(two):
             one[i][1][0] += x[0]
             one[i][1][1] += pow(x[1],2)
+            one[i][1][2] += x[2]
     for i,(c,x) in enumerate(one):
         one[i][1][1] = sqrt(one[i][1][1])
     return one

--- a/CMGTools/TTHAnalysis/python/tools/emulateElectronTriggerCuts.py
+++ b/CMGTools/TTHAnalysis/python/tools/emulateElectronTriggerCuts.py
@@ -1,0 +1,17 @@
+def _susy2lss_idEmu_cuts(lep):
+    if (abs(lep.pdgId())!=11): return True
+    if (lep.full5x5_sigmaIetaIeta()>=(0.011 if abs(lep.superCluster().eta())<1.479 else 0.031)): return False
+    if (lep.hadronicOverEm()>=0.08): return False
+    if (abs(lep.deltaEtaSuperClusterTrackAtVtx())>=0.01): return False
+    if (abs(lep.deltaPhiSuperClusterTrackAtVtx())>=(0.04 if abs(lep.superCluster().eta())<1.479 else 0.08)): return False
+    if (abs((1.0/lep.ecalEnergy() - lep.eSuperClusterOverP()/lep.ecalEnergy()) if lep.ecalEnergy()>0. else 9e9)>=0.01): return False
+    return True
+
+def _susy2lss_idIsoEmu_cuts(lep):
+    if (abs(lep.pdgId())!=11): return True
+    if not _susy2lss_idEmu_cuts(lep): return False
+    if (lep.ecalPFClusterIso()>=0.45*lep.pt()): return False
+    if (lep.hcalPFClusterIso()>=0.25*lep.pt()): return False
+    if (lep.dr03TkSumPt()>=0.2*lep.pt()): return False
+    return True
+


### PR DESCRIPTION
Summary of changes:
- adaptations for running on SMS scans, including model parsing, mass point per-event and sum-of-weights storage, and tree splitting by mass point
- added precalculated id/iso emulation for electrons
- skimTrees can now veto events (based on run:lumi:evt txt files) and skim friend trees as well
- updates to mcAnalysis/mcPlots/mcDump: rescaling/regrouping datasets, draw uncertainties on MC, normalization fitting, save dump to txt file
- updated fake rate application functions and multiIso working points
- added functionalities to SUSY datacard preparation script

Follows PR #594.
