### PR TITLE
Protecting Jet for case one wants to run Jet analyzer on AK8

### DIFF
--- a/PhysicsTools/Heppy/python/physicsobjects/Jet.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Jet.py
@@ -89,7 +89,9 @@ class Jet(PhysicsObject):
         return self.jetID("POG_PFID_Loose")
 
     def puMva(self, label="pileupJetId:fullDiscriminant"):
-        return self.userFloat(label)
+        if self.hasUserFloat(label):
+            return self.userFloat(label)
+        return -99
 
     def puJetId(self, label="pileupJetId:fullDiscriminant"):
         '''Full mva PU jet id'''


### PR DESCRIPTION
In AK8 jets there is no userfloat for puJetID so the JetAna crashes
if the userfloat doesnt exist I modified the class to give -9
