### PR TITLE
add options in the alphat calculation

### DIFF
--- a/PhysicsTools/Heppy/interface/AlphaT.h
+++ b/PhysicsTools/Heppy/interface/AlphaT.h
@@ -20,8 +20,10 @@ struct AlphaT {
 
   static double getAlphaT( const std::vector<double>& et,
 		    const std::vector<double>& px,
-		    const std::vector<double>& py );
-   
+		    const std::vector<double>& py,
+		    std::vector<int> * jet_pseudoFlag,
+		    double& minDeltaHT);
+  
 };
 
 };

--- a/PhysicsTools/Heppy/python/analyzers/eventtopology/AlphaTAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/eventtopology/AlphaTAnalyzer.py
@@ -1,71 +1,59 @@
-import operator 
-import itertools
-import copy
 from math import *
 
-#from ROOT import TLorentzVector, TVectorD
-
-from PhysicsTools.HeppyCore.utils.deltar import deltaR, deltaPhi
 from PhysicsTools.Heppy.analyzers.core.Analyzer import Analyzer
 from PhysicsTools.HeppyCore.framework.event import Event
-from PhysicsTools.HeppyCore.statistics.counter import Counter, Counters
-from PhysicsTools.Heppy.analyzers.core.AutoHandle import AutoHandle
-
-# from PhysicsTools.Heppy.physicsobjects.PhysicsObjects import Lepton
-# from PhysicsTools.Heppy.physicsobjects.PhysicsObjects import Photon
-# from PhysicsTools.Heppy.physicsobjects.PhysicsObjects import Electron
-# from PhysicsTools.Heppy.physicsobjects.PhysicsObjects import Muon
-# from PhysicsTools.Heppy.physicsobjects.PhysicsObjects import Tau
-from PhysicsTools.Heppy.physicsobjects.PhysicsObjects import Jet
 
 import ROOT
-from ROOT.heppy import AlphaT
 
-
-import os
-
-class AlphaTAnalyzer( Analyzer ):
+##__________________________________________________________________||
+class AlphaTAnalyzer(Analyzer):
     def __init__(self, cfg_ana, cfg_comp, looperName ):
-        super(AlphaTAnalyzer,self).__init__(cfg_ana,cfg_comp,looperName) 
+        super(AlphaTAnalyzer, self).__init__(cfg_ana, cfg_comp, looperName)
+        self.alphaTCalc = ROOT.heppy.AlphaT()
 
-    def declareHandles(self):
-        super(AlphaTAnalyzer, self).declareHandles()
-       #genJets                                                                                                                                                                     
-        self.handles['genJets'] = AutoHandle( 'slimmedGenJets','std::vector<reco::GenJet>')
+    def process(self, event):
+        self.readCollections( event.input )
 
-    def beginLoop(self,setup):
-        super(AlphaTAnalyzer,self).beginLoop(setup)
-        self.counters.addCounter('pairs')
-        count = self.counters.counter('pairs')
-        count.register('all events')
+        jets = getattr(event, self.cfg_ana.jets)
 
+        if self.cfg_ana.jetSelectionFunc is not None:
+            jets = [j for j in jets if self.cfg_ana.jetSelectionFunc(j)]
 
-    # Calculate alphaT using jet ET
+        alphaT, minDeltaHT, jetFlags = self.makeAlphaT(jets)
+
+        setattr(event, self.cfg_ana.alphaT, alphaT)
+
+        if self.cfg_ana.minDeltaHT is not None: setattr(event, self.cfg_ana.minDeltaHT, minDeltaHT)
+
+        if self.cfg_ana.pseudoJetFlag is not None:
+            for i, jet in enumerate(getattr(event, self.cfg_ana.jets)):
+                pseudoJetFlag = jetFlags[i] if i < len(jetFlags) else -1
+                setattr(jet, self.cfg_ana.pseudoJetFlag, pseudoJetFlag)
+
+        if self.cfg_ana.inPseudoJet is not None:
+            for i, jet in enumerate(getattr(event, self.cfg_ana.jets)):
+                inPseudoJet = i < len(jetFlags)
+                setattr(jet, self.cfg_ana.inPseudoJet, inPseudoJet)
+
+        return True
+
     def makeAlphaT(self, jets):
 
-        if len(jets) == 0:
-            return 0.
+        if len(jets) < 2: return -1, 0, [ ] # alphat, minDeltaHT, jetFlags
         
         px  = ROOT.std.vector('double')()
         py  = ROOT.std.vector('double')()
         et  = ROOT.std.vector('double')()
 
-        #Make alphaT from lead 10 jets
-	for jet in jets[:10]:
+	for jet in jets[:10]: # use lead 10 jets
             px.push_back(jet.px())
             py.push_back(jet.py())
             et.push_back(jet.et())
 
-        alphaTCalc   = AlphaT()
-        return alphaTCalc.getAlphaT( et, px, py )
+	minDeltaHT = ROOT.Double(0.)
+	jetFlags   = ROOT.std.vector('int')()
 
-    def process(self, event):
-        self.readCollections( event.input )
+        alphaT =  self.alphaTCalc.getAlphaT(et, px, py, jetFlags, minDeltaHT)
+        return alphaT, float(minDeltaHT), list(jetFlags)
 
-        event.alphaT = self.makeAlphaT(event.cleanJets)
-
-        #Do the same with gen jets for MC
-        if self.cfg_comp.isMC:
-            event.genAlphaT = self.makeAlphaT(event.cleanGenJets)
-
-        return True
+##__________________________________________________________________||

--- a/PhysicsTools/Heppy/python/analyzers/eventtopology/AlphaTAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/eventtopology/AlphaTAnalyzer.py
@@ -11,6 +11,8 @@ class AlphaTAnalyzer(Analyzer):
         super(AlphaTAnalyzer, self).__init__(cfg_ana, cfg_comp, looperName)
         self.alphaTCalc = ROOT.heppy.AlphaT()
 
+        self.usePt = hasattr(self.cfg_ana, 'usePt') and self.cfg_ana.usePt
+
     def process(self, event):
         self.readCollections( event.input )
 
@@ -41,17 +43,24 @@ class AlphaTAnalyzer(Analyzer):
 
         if len(jets) < 2: return -1, 0, [ ] # alphat, minDeltaHT, jetFlags
         
+        jets = jets[:10] # use lead 10 jets
+
         px  = ROOT.std.vector('double')()
         py  = ROOT.std.vector('double')()
-        et  = ROOT.std.vector('double')()
 
-	for jet in jets[:10]: # use lead 10 jets
+        for jet in jets:
             px.push_back(jet.px())
             py.push_back(jet.py())
-            et.push_back(jet.et())
 
-	minDeltaHT = ROOT.Double(0.)
-	jetFlags   = ROOT.std.vector('int')()
+        et  = ROOT.std.vector('double')()
+
+        if self.usePt:
+            for jet in jets: et.push_back(jet.pt())
+        else:
+            for jet in jets: et.push_back(jet.et())
+
+        minDeltaHT = ROOT.Double(0.)
+        jetFlags   = ROOT.std.vector('int')()
 
         alphaT =  self.alphaTCalc.getAlphaT(et, px, py, jetFlags, minDeltaHT)
         return alphaT, float(minDeltaHT), list(jetFlags)

--- a/PhysicsTools/Heppy/src/AlphaT.cc
+++ b/PhysicsTools/Heppy/src/AlphaT.cc
@@ -8,8 +8,19 @@ namespace heppy {
 
 double AlphaT::getAlphaT( const std::vector<double>& et,
 			  const std::vector<double>& px,
-			  const std::vector<double>& py ){
-    
+			  const std::vector<double>& py,
+			  std::vector<int> * jet_pseudoFlag,
+			  double& minDeltaHT){
+   
+    // Clear pesudo-jet container
+    if (jet_pseudoFlag){
+      jet_pseudoFlag->clear();
+      jet_pseudoFlag->resize(et.size());
+    }
+
+    // Initialization of DeltaHT to overwrite the previous values stored
+    minDeltaHT = 0.;
+
     // Momentum sums in transverse plane
     const double sum_et = accumulate( et.begin(), et.end(), 0. );
     const double sum_px = accumulate( px.begin(), px.end(), 0. );
@@ -25,10 +36,21 @@ double AlphaT::getAlphaT( const std::vector<double>& et,
       }
       if ( ( fabs(delta_sum_et) < min_delta_sum_et || min_delta_sum_et < 0. ) ) {
 	min_delta_sum_et = fabs(delta_sum_et);
+	if (jet_pseudoFlag){
+	// if (!jet_pseudoFlag.empty()){
+          for (unsigned int j = 0; j < et.size(); ++j){
+            //bool testBool = ((i & (1U << j)) == 0);
+	    if (((i & (1U << j)) == 0)) (*jet_pseudoFlag)[j] = 1;
+	    else (*jet_pseudoFlag)[j] = 0;
+	  }
+        }
       }
     }
-    if ( min_delta_sum_et < 0. ) { return 0.; }
     
+    if ( min_delta_sum_et < 0. ) { return 0.; }
+   
+    minDeltaHT = min_delta_sum_et;
+
     // Alpha_T
     return ( 0.5 * ( sum_et - min_delta_sum_et ) / sqrt( sum_et*sum_et - (sum_px*sum_px+sum_py*sum_py) ) );
 


### PR DESCRIPTION
A PR from the RA1 private code.

This PR adds options in the alphat calculation:
- an option to attache pseudo-jet flags to jets
- an option to use pT instead of ET
