### PR TITLE
Workaround for memory leak in GenAnalyzer

### DIFF
--- a/PhysicsTools/Heppy/interface/genutils.h
+++ b/PhysicsTools/Heppy/interface/genutils.h
@@ -1,0 +1,13 @@
+#ifndef PhysicsTools_Heppy_genutils_h
+#define PhysicsTools_Heppy_genutils_h
+
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+
+namespace heppy {
+    class GenParticleRefHelper {
+        public:
+            static int motherKey(const reco::GenParticle &gp, int index)  ;
+            static int daughterKey(const reco::GenParticle &gp, int index)  ;
+    };
+}
+#endif

--- a/PhysicsTools/Heppy/python/analyzers/gen/GeneratorAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/gen/GeneratorAnalyzer.py
@@ -1,6 +1,6 @@
 from PhysicsTools.Heppy.analyzers.core.Analyzer import Analyzer
 from PhysicsTools.Heppy.analyzers.core.AutoHandle import AutoHandle
-from PhysicsTools.Heppy.physicsutils.genutils import isNotFromHadronicShower, realGenMothers, realGenDaughters
+from PhysicsTools.Heppy.physicsutils.genutils import isNotFromHadronicShower, realGenMothers, realGenDaughters, motherRef
 
 def interestingPdgId(id,includeLeptons=False):        
     id = abs(id)
@@ -136,14 +136,14 @@ class GeneratorAnalyzer( Analyzer ):
             gp.motherIndex = -1
             gp.sourceId    = 99
             gp.genSummaryIndex = igp
-            ancestor = None if gp.numberOfMothers() == 0 else gp.motherRef(0)
-            while ancestor != None and ancestor.isNonnull():
-                if ancestor.key() in keymap:
-                    gp.motherIndex = keymap[ancestor.key()]
+            (ancestor, ancestorKey) = (None,-1) if gp.numberOfMothers() == 0 else motherRef(gp)
+            while ancestor:
+                if ancestorKey in keymap:
+                    gp.motherIndex = keymap[ancestorKey]
                     if ancestor.pdgId() != good[gp.motherIndex].pdgId():
                         print "Error keying %d: motherIndex %d, ancestor.pdgId %d, good[gp.motherIndex].pdgId() %d " % (igp, gp.motherIndex, ancestor.pdgId(),  good[gp.motherIndex].pdgId())
                     break
-                ancestor = None if ancestor.numberOfMothers() == 0 else ancestor.motherRef(0)
+                (ancestor, ancestorKey) = (None,-1) if ancestor.numberOfMothers() == 0 else motherRef(ancestor)
             if abs(gp.pdgId()) not in [1,2,3,4,5,11,12,13,14,15,16,21]:
                 gp.sourceId = gp.pdgId()
             if gp.motherIndex != -1:

--- a/PhysicsTools/Heppy/python/physicsutils/genutils.py
+++ b/PhysicsTools/Heppy/python/physicsutils/genutils.py
@@ -1,5 +1,6 @@
 from PhysicsTools.Heppy.physicsobjects.PhysicsObjects import printOut 
 from PhysicsTools.Heppy.physicsobjects.PhysicsObjects import GenParticle 
+import ROOT
 
 def findStatus1Leptons(particle):
     '''Returns status 1 e and mu among the particle daughters'''
@@ -107,6 +108,11 @@ def realGenMothers(gp):
         else:
             ret.append(mom)
     return ret
+
+def motherRef(gp,i=0):
+    return (gp.mother(), ROOT.heppy.GenParticleRefHelper.motherKey(gp,i))
+def daughterRef(gp,i=0):
+    return (gp.daughter(), ROOT.heppy.GenParticleRefHelper.daughterKey(gp,i))
 
 def lastGenCopy(gp):
     me = gp.pdgId();

--- a/PhysicsTools/Heppy/src/classes.h
+++ b/PhysicsTools/Heppy/src/classes.h
@@ -21,6 +21,7 @@
 //#include "EgammaAnalysis/ElectronTools/interface/ElectronEnergyCalibrator.h"
 
 #include "PhysicsTools/Heppy/interface/PdfWeightProducerTool.h"
+#include "PhysicsTools/Heppy/interface/genutils.h"
 
 #include <vector>
 namespace {

--- a/PhysicsTools/Heppy/src/classes_def.xml
+++ b/PhysicsTools/Heppy/src/classes_def.xml
@@ -18,6 +18,7 @@
   <class name="heppy::JetUtils"  transient="true"/>
   <class name="heppy::IsolationComputer"  transient="true"/>
 
+  <class name="heppy::GenParticleRefHelper"  transient="true"/>
   <!--<class name="heppy::SimpleElectron" transient="true" />-->
   <!--<class name="ElectronEnergyCalibrator" transient="true" />-->
   <!--<class name="heppy::ElectronEPcombinator" transient="true" />-->

--- a/PhysicsTools/Heppy/src/genutils.cc
+++ b/PhysicsTools/Heppy/src/genutils.cc
@@ -1,0 +1,4 @@
+#include "PhysicsTools/Heppy/interface/genutils.h"
+
+int heppy::GenParticleRefHelper::motherKey(const reco::GenParticle &gp, int index) { return gp.motherRef(index).key(); }
+int heppy::GenParticleRefHelper::daughterKey(const reco::GenParticle &gp, int index) { return gp.daughterRef(index).key(); }

--- a/PhysicsTools/HeppyCore/python/framework/heppy_loop.py
+++ b/PhysicsTools/HeppyCore/python/framework/heppy_loop.py
@@ -45,12 +45,14 @@ def runLoop( comp, outDir, config, options):
     fullName = '/'.join( [outDir, comp.name ] )
     # import pdb; pdb.set_trace()
     config.components = [comp]
+    memcheck = 2 if getattr(options,'memCheck',False) else 0
     loop = Looper( fullName,
                    config,
                    options.nevents, 0,
                    nPrint = options.nprint,
                    timeReport = options.timeReport,
-                   quiet = options.quiet)
+                   quiet = options.quiet,
+                   memCheckFromEvent = memcheck)
     # print loop
     if options.iEvent is None:
         loop.loop()

--- a/PhysicsTools/HeppyCore/scripts/heppy_loop.py
+++ b/PhysicsTools/HeppyCore/scripts/heppy_loop.py
@@ -58,6 +58,12 @@ if __name__ == '__main__':
                       type="int",
                       help="number of parallel tasks to span",
                       default=10)
+    parser.add_option("--memcheck", 
+                      dest="memCheck",
+                      action='store_true',
+                      help="Activate memory checks per event",
+                      default=False)
+
 
     (options,args) = parser.parse_args()
 


### PR DESCRIPTION
Apparently the method `motherRef` of the `reco::GenParticle` class leaks memory within ROOT/Cling type resolution. This PR fixes it by getting the key of the reference in C++ instead of python.
Added also the option `--memcheck` to heppy to turn on memory checking from command line.

Similar fixes to some other CMG modules will also be needed.

@arizzi @mmarionncern @peruzzim @mangano 
