### PR TITLE
Updated PhotonID bits and updated Jet PU ID (76X WP tuning)

### DIFF
--- a/PhysicsTools/Heppy/python/analyzers/objects/PhotonAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/PhotonAnalyzer.py
@@ -112,8 +112,10 @@ class PhotonAnalyzer( Analyzer ):
                     id=3
                 return id
 
-            gamma.idCutBased = idWP(gamma, "POG_SPRING15_25ns_%s")
-
+            # bits to store in the trees
+            gamma.idWPs = idWP(gamma, "POG_SPRING15_25ns_%s")
+            # bit to be used in selection
+            gamma.idCutBased = 0
 
             keepThisPhoton = True
 

--- a/PhysicsTools/Heppy/python/analyzers/objects/PhotonAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/PhotonAnalyzer.py
@@ -87,13 +87,23 @@ class PhotonAnalyzer( Analyzer ):
 
             gamma.rho = float(self.handles['rhoPhoton'].product()[0])
             # https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedPhotonIdentificationRun2#Selection_implementation_details
-            if   abs(gamma.eta()) < 1.0:   gamma.EffectiveArea03 = [ 0.0234, 0.0053, 0.078  ]
-            elif abs(gamma.eta()) < 1.479: gamma.EffectiveArea03 = [ 0.0189, 0.0103, 0.0629 ]
-            elif abs(gamma.eta()) < 2.0:   gamma.EffectiveArea03 = [ 0.0171, 0.0057, 0.0264 ]
-            elif abs(gamma.eta()) < 2.2:   gamma.EffectiveArea03 = [ 0.0129, 0.0070, 0.0462 ]
-            elif abs(gamma.eta()) < 2.3:   gamma.EffectiveArea03 = [ 0.0110, 0.0152, 0.0740 ]
-            elif abs(gamma.eta()) < 2.4:   gamma.EffectiveArea03 = [ 0.0074, 0.0232, 0.0924 ]
-            else:                          gamma.EffectiveArea03 = [ 0.0035, 0.1709, 0.1484 ]
+            if 'PHYS14_25ns' in self.cfg_ana.gammaID:
+                if   abs(gamma.eta()) < 1.0:   gamma.EffectiveArea03 = [ 0.0234, 0.0053, 0.078  ]
+                elif abs(gamma.eta()) < 1.479: gamma.EffectiveArea03 = [ 0.0189, 0.0103, 0.0629 ]
+                elif abs(gamma.eta()) < 2.0:   gamma.EffectiveArea03 = [ 0.0171, 0.0057, 0.0264 ]
+                elif abs(gamma.eta()) < 2.2:   gamma.EffectiveArea03 = [ 0.0129, 0.0070, 0.0462 ]
+                elif abs(gamma.eta()) < 2.3:   gamma.EffectiveArea03 = [ 0.0110, 0.0152, 0.0740 ]
+                elif abs(gamma.eta()) < 2.4:   gamma.EffectiveArea03 = [ 0.0074, 0.0232, 0.0924 ]
+                else:                          gamma.EffectiveArea03 = [ 0.0035, 0.1709, 0.1484 ]
+            else:
+                # default: values for SPRING15_25ns
+                if   abs(gamma.eta()) < 1.0:   gamma.EffectiveArea03 = [ 0.0, 0.0599, 0.1271  ]
+                elif abs(gamma.eta()) < 1.479: gamma.EffectiveArea03 = [ 0.0, 0.0819, 0.1101 ]
+                elif abs(gamma.eta()) < 2.0:   gamma.EffectiveArea03 = [ 0.0, 0.0696, 0.0756 ]
+                elif abs(gamma.eta()) < 2.2:   gamma.EffectiveArea03 = [ 0.0, 0.0360, 0.1175 ]
+                elif abs(gamma.eta()) < 2.3:   gamma.EffectiveArea03 = [ 0.0, 0.0360, 0.1498 ]
+                elif abs(gamma.eta()) < 2.4:   gamma.EffectiveArea03 = [ 0.0, 0.0462, 0.1857 ]
+                else:                          gamma.EffectiveArea03 = [ 0.0, 0.0656, 0.2183 ]
 
             if self.doFootprintRemovedIsolation:
                 self.attachFootprintRemovedIsolation(gamma)
@@ -104,11 +114,11 @@ class PhotonAnalyzer( Analyzer ):
                 """Create an integer equal to 1-2-3 for (loose,medium,tight)"""
 
                 id=0
-                if gamma.CutBasedIDWP(X%"Loose"):
+                if gamma.passPhotonID(X%"Loose", self.cfg_ana.conversionSafe_eleVeto) and gamma.passPhotonIso(X%"Loose",self.cfg_ana.gamma_isoCorr):
                     id=1 
-                if gamma.CutBasedIDWP(X%"Medium"):
+                if gamma.passPhotonID(X%"Medium", self.cfg_ana.conversionSafe_eleVeto) and gamma.passPhotonIso(X%"Medium",self.cfg_ana.gamma_isoCorr):
                     id=2 
-                if gamma.CutBasedIDWP(X%"Tight"):
+                if gamma.passPhotonID(X%"Tight", self.cfg_ana.conversionSafe_eleVeto) and gamma.passPhotonIso(X%"Tight",self.cfg_ana.gamma_isoCorr):
                     id=3
                 return id
 

--- a/PhysicsTools/Heppy/python/analyzers/objects/PhotonAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/PhotonAnalyzer.py
@@ -104,15 +104,15 @@ class PhotonAnalyzer( Analyzer ):
                 """Create an integer equal to 1-2-3 for (loose,medium,tight)"""
 
                 id=0
-                if gamma.photonID(X%"Loose"):
-                    id=1
-                #if gamma.photonID(X%"Medium"):
-                #    id=2 
-                if gamma.photonID(X%"Tight"):
+                if gamma.CutBasedIDWP(X%"Loose"):
+                    id=1 
+                if gamma.CutBasedIDWP(X%"Medium"):
+                    id=2 
+                if gamma.CutBasedIDWP(X%"Tight"):
                     id=3
                 return id
 
-            gamma.idCutBased = idWP(gamma, "PhotonCutBasedID%s")
+            gamma.idCutBased = idWP(gamma, "POG_SPRING15_25ns_%s")
 
 
             keepThisPhoton = True

--- a/PhysicsTools/Heppy/python/analyzers/objects/autophobj.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/autophobj.py
@@ -155,7 +155,8 @@ isoTrackType = NTupleObjectType("isoTrack",  baseObjectTypes = [ particleType ],
 ##------------------------------------------  
 
 photonType = NTupleObjectType("gamma", baseObjectTypes = [ particleType ], variables = [
-    NTupleVariable("idCutBased", lambda x : x.idCutBased, int, help="1,2,3 if the gamma passes the loose, medium, tight WP of PhotonCutBasedID"),
+    NTupleVariable("etaSc", lambda x : x.superCluster().eta(), help="Photon supercluster pseudorapidity"),
+    NTupleVariable("idCutBased", lambda x : x.idWPs, int, help="1,2,3 if the gamma passes the loose, medium, tight WP of PhotonCutBasedID"),
     NTupleVariable("hOverE",  lambda x : x.hOVERe(), float, help="hoverE for photons"),
     NTupleVariable("r9",  lambda x : x.full5x5_r9(), float, help="r9 for photons"),
     NTupleVariable("sigmaIetaIeta",  lambda x : x.full5x5_sigmaIetaIeta(), float, help="sigmaIetaIeta for photons"),

--- a/PhysicsTools/Heppy/python/physicsobjects/Jet.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Jet.py
@@ -1,5 +1,6 @@
 from PhysicsTools.Heppy.physicsobjects.PhysicsObject import *
 from PhysicsTools.HeppyCore.utils.deltar import deltaPhi
+from PhysicsTools.Heppy.physicsutils.PuJetIDWP import PuJetIDWP
 import math
 
 loose_WP = [
@@ -140,19 +141,23 @@ class Jet(PhysicsObject):
             return self.userFloat(label)
         return -99
 
-    def puJetId(self, label="pileupJetId:fullDiscriminant"):
+    def puJetId(self, label="pileupJetId:fullDiscriminant", tuning="76X", wp="loose"):
         '''Full mva PU jet id'''
+        
+        if tuning=="76X":
+            puId76X = PuJetIDWP()
+            return puId76X.passWP(self,wp)
+        else:
+            puMva = self.puMva(label)
+            wp = loose_53X_WP
+            eta = abs(self.eta())
 
-        puMva = self.puMva(label)
-        wp = loose_53X_WP
-        eta = abs(self.eta())
-        
-        for etamin, etamax, cut in wp:
-            if not(eta>=etamin and eta<etamax):
-                continue
-            return puMva>cut
-        return -99
-        
+            for etamin, etamax, cut in wp:
+                if not(eta>=etamin and eta<etamax):
+                    continue
+                return puMva>cut
+            return -99
+                    
     def rawFactor(self):
         return self.jecFactor('Uncorrected') * self._rawFactorMultiplier
 

--- a/PhysicsTools/Heppy/python/physicsobjects/Photon.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Photon.py
@@ -196,9 +196,8 @@ class Photon(PhysicsObject ):
         else:
             if self.calScaledIsoValueLin(*self.CutBasedIDWP(name)["neuHadIso"][idForBarrel]) < self.neutralHadronIso(isocorr):
                 passPhotonIso = False
-
-        if self.calScaledIsoValueLin(*self.CutBasedIDWP(name)["phoIso"][idForBarrel]) < self.photonIso(isocorr):
-            passPhotonIso = False
+            if self.calScaledIsoValueLin(*self.CutBasedIDWP(name)["phoIso"][idForBarrel]) < self.photonIso(isocorr):
+                passPhotonIso = False
         
         return passPhotonIso
 

--- a/PhysicsTools/Heppy/python/physicsutils/PuJetIDWP.py
+++ b/PhysicsTools/Heppy/python/physicsutils/PuJetIDWP.py
@@ -1,0 +1,57 @@
+import ROOT as rt
+import numpy as np
+
+class PuJetIDWP:
+    def __init__(self):
+
+        # tuning in 76X
+        self.xbins = np.array([0.00,2.50,2.75,3.00,5.00])
+        self.ybins = np.array([0,10,20,30,50])
+        grid = rt.TH2F('grid','',4,self.xbins,4,self.ybins)
+
+        loose = grid.Clone('loose')
+        loose.SetBinContent(1,1,-0.96); loose.SetBinContent(1,2,-0.96); loose.SetBinContent(1,3,-0.96); loose.SetBinContent(1,4,-0.93);
+        loose.SetBinContent(2,1,-0.62); loose.SetBinContent(2,2,-0.62); loose.SetBinContent(2,3,-0.62); loose.SetBinContent(2,4,-0.52);
+        loose.SetBinContent(3,1,-0.53); loose.SetBinContent(3,2,-0.53); loose.SetBinContent(3,3,-0.53); loose.SetBinContent(3,4,-0.39);
+        loose.SetBinContent(4,1,-0.49); loose.SetBinContent(4,2,-0.49); loose.SetBinContent(4,3,-0.49); loose.SetBinContent(4,4,-0.31);
+
+        medium = grid.Clone('medium')
+        medium.SetBinContent(1,1,-0.58); medium.SetBinContent(1,2,-0.58); medium.SetBinContent(1,3,-0.58); medium.SetBinContent(1,4,-0.20);
+        medium.SetBinContent(2,1,-0.52); medium.SetBinContent(2,2,-0.52); medium.SetBinContent(2,3,-0.52); medium.SetBinContent(2,4,-0.39);
+        medium.SetBinContent(3,1,-0.40); medium.SetBinContent(3,2,-0.40); medium.SetBinContent(3,3,-0.40); medium.SetBinContent(3,4,-0.24);
+        medium.SetBinContent(4,1,-0.36); medium.SetBinContent(4,2,-0.36); medium.SetBinContent(4,3,-0.36); medium.SetBinContent(4,4,-0.19);
+
+        tight = grid.Clone('tight')
+        tight.SetBinContent(1,1,0.09); tight.SetBinContent(1,2,0.09); tight.SetBinContent(1,3,0.09); tight.SetBinContent(1,4,0.52);
+        tight.SetBinContent(2,1,-0.37); tight.SetBinContent(2,2,-0.37); tight.SetBinContent(2,3,-0.37); tight.SetBinContent(2,4,-0.19);
+        tight.SetBinContent(3,1,-0.24); tight.SetBinContent(3,2,-0.24); tight.SetBinContent(3,3,-0.24); tight.SetBinContent(3,4,-0.06);
+        tight.SetBinContent(4,1,-0.21); tight.SetBinContent(4,2,-0.21); tight.SetBinContent(4,3,-0.21); tight.SetBinContent(4,4,-0.03);
+
+        self.wps = {}
+        self.wps['loose'] = loose
+        self.wps['medium'] = medium
+        self.wps['tight'] = tight
+
+    def getBin(self, bvec, val):
+        return int(bvec.searchsorted(val, side="right")) - 1
+
+    def passWP(self, jet, wp='loose'):
+        if wp not in self.wps: return False
+        wph = self.wps[wp]
+        #if jet is a simple class with attributes
+        if isinstance(getattr(jet, "pt"), float):
+            pt   = getattr(jet, "pt")
+            aeta = abs(getattr(jet, "eta"))
+        #if jet is a heppy Jet object
+        else:
+            pt   = jet.pt()
+            aeta = abs(jet.eta())
+
+        binx = self.getBin(self.xbins,aeta)
+        biny = self.getBin(self.ybins,pt)
+
+        if binx == wph.GetNbinsX(): return True
+        if biny == wph.GetNbinsY(): return True        
+
+        cut = wph.GetBinContent(binx,biny)
+        return jet.puMva > cut


### PR DESCRIPTION
- Updated the bits of the photon ID (including the medium one) taking the values from the Spring15 25ns cut-based selections computed in heppy instead using the values stored in the photon object which is obsolete
- updated the PU jet ID to a new WP tuning done on top of the MVA training in 76X. This will be redone in 80X, but this should be better than the cuts that were tuned on the 53X 
  - the 53X version is still there, and can be used 
