### PR TITLE
Trapping of SIGUSR2, and nillable objects

### DIFF
--- a/PhysicsTools/Heppy/python/analyzers/core/autovars.py
+++ b/PhysicsTools/Heppy/python/analyzers/core/autovars.py
@@ -132,11 +132,12 @@ class NTupleSubObject:
 
 class NTupleObject:
     """Type defining a set of branches associated to a single object (i.e. an instance of NTupleObjectType)"""
-    def __init__(self, name, objectType, help="", mcOnly=False):
+    def __init__(self, name, objectType, help="", mcOnly=False, nillable=False):
         self.name = name
         self.objectType = objectType
         self.mcOnly = mcOnly
         self.help = ""
+        self.nillable = nillable
     def makeBranches(self,treeNumpy,isMC):
         if not isMC and self.mcOnly: return
         allvars = self.objectType.allVars(isMC)
@@ -146,6 +147,9 @@ class NTupleObject:
             treeNumpy.var("%s_%s" % (self.name, v.name), type=v.type, default=v.default, title=h, filler=v.filler)
     def fillBranches(self,treeNumpy,object,isMC):
         if self.mcOnly and not isMC: return
+        if object is None:
+            if self.nillable: return
+            raise RuntimeError, "Error, object not found or None when filling branch %s" % self.name
         allvars = self.objectType.allVars(isMC)
         for v in allvars:
             treeNumpy.fill("%s_%s" % (self.name, v.name), v(object))

--- a/PhysicsTools/HeppyCore/python/framework/heppy_loop.py
+++ b/PhysicsTools/HeppyCore/python/framework/heppy_loop.py
@@ -8,7 +8,7 @@ import glob
 import sys
 import imp
 import copy
-from multiprocessing import Pool
+import multiprocessing 
 from pprint import pprint
 
 # import root in batch mode if "-i" is not among the options
@@ -41,6 +41,7 @@ def runLoopAsync(comp, outDir, configName, options):
         print traceback.format_exc()
         raise
 
+_globalGracefulStopFlag = multiprocessing.Value('i',0)
 def runLoop( comp, outDir, config, options):
     fullName = '/'.join( [outDir, comp.name ] )
     # import pdb; pdb.set_trace()
@@ -52,7 +53,8 @@ def runLoop( comp, outDir, config, options):
                    nPrint = options.nprint,
                    timeReport = options.timeReport,
                    quiet = options.quiet,
-                   memCheckFromEvent = memcheck)
+                   memCheckFromEvent = memcheck,
+                   stopFlag = _globalGracefulStopFlag)
     # print loop
     if options.iEvent is None:
         loop.loop()
@@ -180,7 +182,7 @@ def main( options, args, parser ):
         sys.exit(0)
     if len(selComps)>1:
         shutil.copy( cfgFileName, outDir )
-        pool = Pool(processes=min(len(selComps),options.ntasks))
+        pool = multiprocessing.Pool(processes=min(len(selComps),options.ntasks))
         ## workaround for a scoping problem in ipython+multiprocessing
         import PhysicsTools.HeppyCore.framework.heppy_loop as ML 
         for comp in selComps:

--- a/PhysicsTools/HeppyCore/python/framework/looper.py
+++ b/PhysicsTools/HeppyCore/python/framework/looper.py
@@ -56,7 +56,8 @@ class Looper(object):
                   nPrint=0,
                   timeReport=False,
                   quiet=False,
-                  memCheckFromEvent=-1):
+                  memCheckFromEvent=-1,
+                  stopFlag = None):
         """Handles the processing of an event sample.
         An Analyzer is built for each Config.Analyzer present
         in sequence. The Looper can then be used to process an event,
@@ -68,6 +69,12 @@ class Looper(object):
         nEvents : number of events to process. Defaults to all.
         firstEvent : first event to process. Defaults to the first one.
         nPrint  : number of events to print at the beginning
+    
+        stopFlag: it should be a multiprocessing.Value instance, that is set to 1 
+                  when this thread, or any other, receives a SIGUSR2 to ask for
+                  a graceful job termination. In this case, the looper will also
+                  set up a signal handler for SIGUSR2.
+                  (if set to None, nothing of all this happens)
         """
 
         self.config = config
@@ -89,6 +96,13 @@ class Looper(object):
         self.timeReport = [ {'time':0.0,'events':0} for a in self.analyzers ] if timeReport else False
         self.memReportFirstEvent = memCheckFromEvent
         self.memLast=0
+        self.stopFlag = stopFlag
+        if stopFlag:
+            import signal
+            def doSigUsr2(sig,frame):
+                print 'SIGUSR2 received, signaling graceful stop'
+                self.stopFlag.value = 1
+            signal.signal(signal.SIGUSR2, doSigUsr2)
         tree_name = None
         if( hasattr(self.cfg_comp, 'tree_name') ):
             tree_name = self.cfg_comp.tree_name
@@ -184,6 +198,9 @@ class Looper(object):
                 self.process( iEv )
                 if iEv<self.nPrint:
                     print self.event
+                if self.stopFlag.value:
+                    print 'stopping gracefully at event %d' % (iEv)
+                    break
 
         except UserWarning:
             print 'Stopped loop following a UserWarning exception'


### PR DESCRIPTION
Two small improvements to heppy:
- allow terminating a job gracefully, i.e. stills saving a valid tree in output, with `kill -USR2` (if running with multiple jobs, only **one** of the ones that are **running**). 
- allow a global object in the tree producer to be `None`
