### PR TITLE
Heppy H->ZZ trackerHighPt muon ID

### DIFF
--- a/PhysicsTools/Heppy/python/physicsobjects/Muon.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Muon.py
@@ -48,6 +48,18 @@ class Muon( Lepton ):
                 return self.physObj.innerTrack().validFraction() > 0.8 and self.physObj.segmentCompatibility() >= (0.303 if goodGlb else 0.451)
             if name == "POG_Global_OR_TMArbitrated":
                 return self.physObj.isGlobalMuon() or (self.physObj.isTrackerMuon() and self.physObj.numberOfMatchedStations() > 0)
+        elif name.startswith("HZZ_"):
+            if name == "HZZ_ID_TkHighPt":
+                primaryVertex = vertex if vertex != None else getattr(self, 'associatedVertex', None) 
+                return ( self.physObj.numberOfMatchedStations() > 1 
+                         and (self.physObj.muonBestTrack().ptError()/self.physObj.muonBestTrack().pt()) < 0.3 
+                         and abs(self.physObj.muonBestTrack().dxy(primaryVertex.position())) < 0.2 
+                         and abs(self.physObj.muonBestTrack().dz(primaryVertex.position())) < 0.5 
+                         and self.physObj.innerTrack().hitPattern().numberOfValidPixelHits() > 0 
+                         and self.physObj.innerTrack().hitPattern().trackerLayersWithMeasurement() > 5 )
+            if name == "HZZ_ID_LooseOrTkHighPt":
+                if self.physObj.isLooseMuon(): return True
+                return self.physObj.pt() > 200 and self.muonID("HZZ_ID_TkHighPt")
         return self.physObj.muonID(name)
             
     def mvaId(self):


### PR DESCRIPTION
As POG HighPtMuonID but without the requirement of being a global muon, that causes inefficiencies for boosted Z's
