### PR TITLE
Added N_ISR jets to event for SUSY signal model systematics

### DIFF
--- a/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
@@ -443,13 +443,9 @@ class JetAnalyzer( Analyzer ):
                 momid = abs(mc.mother().pdgId())
                 if not (momid==6 or momid==23 or momid==24 or momid==25 or momid>1e6): continue
                     #check against daughter in case of hard initial splitting
-                    #for (size_t idau(0); idau < mc.numberOfDaughters(); idau++) {
                 for idau in range(mc.numberOfDaughters()):
-                    #float dR = deltaR(clean_jets[ijet], mc.daughter(idau)->p4());
                     dR = math.sqrt(deltaR2(jet.eta(),jet.phi(), mc.daughter(idau).p4().eta(),mc.daughter(idau).p4().phi()))
                     if dR<0.3:
-                    #     if (verbose) cout<<"Jet: ("<<clean_jets[ijet].pt()<<", "<<clean_jets[ijet].eta()<<", "<<clean_jets[ijet].phi()
-                    # <<"), MC: ("<<mc.daughter(idau)->pt()<<", "<<mc.daughter(idau)->eta()<<", "<<mc.daughter(idau)->phi()<<"), ID "<<mc.daughter(idau)->pdgId()<<". dR "<<dR <<endl;
                         matched = True
                         break
             if not matched:

--- a/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
@@ -429,7 +429,6 @@ class JetAnalyzer( Analyzer ):
 
     def makeNIsr(self,event):
 
-        verbose = False
         event.nIsr = 0
 
         for jet in self.cleanJetsAll:

--- a/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
@@ -435,7 +435,7 @@ class JetAnalyzer( Analyzer ):
         for jet in self.cleanJetsAll:
 
             if jet.pt()<30.0: continue
-            #if abs(jet.eta())>3.0: continue
+            if abs(jet.eta())>2.4: continue
             matched = False
             for mc in event.genParticles:
                 if matched: break

--- a/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
@@ -340,7 +340,6 @@ class JetAnalyzer( Analyzer ):
             if self.cfg_ana.do_mc_match:
                 self.jetFlavour(event)
             self.makeNIsr(event)
-            print event.nIsr
 
         if hasattr(event,"jets"+self.cfg_ana.collectionPostFix): raise RuntimeError("Event already contains a jet collection with the following postfix: "+self.cfg_ana.collectionPostFix)
         setattr(event,"rho"                    +self.cfg_ana.collectionPostFix, self.rho                    ) 
@@ -443,9 +442,9 @@ class JetAnalyzer( Analyzer ):
                 if not (momid==6 or momid==23 or momid==24 or momid==25 or momid>1e6): continue
                     #check against daughter in case of hard initial splitting
                     #for (size_t idau(0); idau < mc.numberOfDaughters(); idau++) {
-                for dau in mc.daughter():
+                for idau in range(mc.numberOfDaughters()):
                     #float dR = deltaR(clean_jets[ijet], mc.daughter(idau)->p4());
-                    dR = math.sqrt(deltaR2(jet.eta(),jet.phi(), dau.p4().eta(),dau.p4().phi()))
+                    dR = math.sqrt(deltaR2(jet.eta(),jet.phi(), mc.daughter(idau).p4().eta(),mc.daughter(idau).p4().phi()))
                     if dR<0.3:
                     #     if (verbose) cout<<"Jet: ("<<clean_jets[ijet].pt()<<", "<<clean_jets[ijet].eta()<<", "<<clean_jets[ijet].phi()
                     # <<"), MC: ("<<mc.daughter(idau)->pt()<<", "<<mc.daughter(idau)->eta()<<", "<<mc.daughter(idau)->phi()<<"), ID "<<mc.daughter(idau)->pdgId()<<". dR "<<dR <<endl;

--- a/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
@@ -445,7 +445,7 @@ class JetAnalyzer( Analyzer ):
                     #for (size_t idau(0); idau < mc.numberOfDaughters(); idau++) {
                 for dau in mc.daughter():
                     #float dR = deltaR(clean_jets[ijet], mc.daughter(idau)->p4());
-                    dR = deltaR(jet, dau.p4())
+                    dR = math.sqrt(deltaR2(jet.eta(),jet.phi(), dau.p4().eta(),dau.p4().phi()))
                     if dR<0.3:
                     #     if (verbose) cout<<"Jet: ("<<clean_jets[ijet].pt()<<", "<<clean_jets[ijet].eta()<<", "<<clean_jets[ijet].phi()
                     # <<"), MC: ("<<mc.daughter(idau)->pt()<<", "<<mc.daughter(idau)->eta()<<", "<<mc.daughter(idau)->phi()<<"), ID "<<mc.daughter(idau)->pdgId()<<". dR "<<dR <<endl;

--- a/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
@@ -434,6 +434,8 @@ class JetAnalyzer( Analyzer ):
 
         for jet in self.cleanJetsAll:
 
+            if jet.pt()<30.0: continue
+            #if abs(jet.eta())>3.0: continue
             matched = False
             for mc in event.genParticles:
                 if matched: break


### PR DESCRIPTION
The N_ISR variable for ISR signal model systematics was introduced in a SUSY meeting in the following talk: https://indico.cern.ch/event/557678/contributions/2247944/attachments/1311994/1963568/16-07-19_ana_manuelf_isr.pdf

A sample of code was provided by @manuelfs in: https://github.com/manuelfs/babymaker/blob/0136340602ee28caab14e3f6b064d1db81544a0a/bmaker/plugins/bmaker_full.cc#L1268-L1295

This has been converted to python and implemented in the Jet analyzer here.
