### PR TITLE
Heppy: fix missing default parameter in LHEWeightAnalyzer

### DIFF
--- a/PhysicsTools/Heppy/python/analyzers/gen/LHEWeightAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/gen/LHEWeightAnalyzer.py
@@ -93,5 +93,6 @@ class LHEWeightAnalyzer( Analyzer ):
 
 setattr(LHEWeightAnalyzer,"defaultConfig",
     cfg.Analyzer(LHEWeightAnalyzer,
+                 useLumiInfo = False,
     )
 )


### PR DESCRIPTION
Bugfix for missing default parameter useLumiInfo in LHEWeightAnalyzer
Fixes https://github.com/CERN-PH-CMG/cmg-cmssw/pull/677#pullrequestreview-13307379

@mariadalfonso @steggema @simoneg90 please test