### PR TITLE
fix regular expression and get pfn in createEOSDir

### DIFF
--- a/PhysicsTools/HeppyCore/python/utils/eostools.py
+++ b/PhysicsTools/HeppyCore/python/utils/eostools.py
@@ -12,7 +12,7 @@ import subprocess
 
 def splitPFN(pfn):
     """Split the PFN in to { <protocol>, <host>, <path>, <opaque> }"""
-    groups = re.match("^(\w\+)://([^/]+)/(/[^?]+)(\?.*)?", pfn)
+    groups = re.match("^(\w+)://([^/]+)/(/[^?]+)(\?.*)?", pfn)
     if not groups: raise RuntimeError, "Malformed pfn: '%s'" % pfn
     return (groups.group(1), groups.group(2), groups.group(3), groups.group(4))
 
@@ -190,10 +190,10 @@ def createEOSDir( path ):
     ???Will, I'm quite worried by the fact that if this path already exists, and is
     a file, everything will 'work'. But then we have a file, and not a directory,
     while we expect a dir..."""
-    lfn = eosToLFN(path)
-    if not isEOSFile(lfn):
+    pfn = lfnToPFN(path)
+    if not isEOSFile(pfn):
     # if not isDirectory(lfn):
-        runEOSCommand(lfn,'mkdir','-p')
+        runEOSCommand(pfn,'mkdir','-p')
     if isDirectory(path):
         return path
     else:


### PR DESCRIPTION
Tested that it works when writing to eos and to local path using:
```
heppy_batch.py -r /store/cmst3/group/exovv/clange/HeppyProduction/test_20170620 -o test_20170620 runVV_cfg.py -b 'bsub -q 1nd -u clange -o std_output.txt -J test_20170620  < batchScript.sh'
```
and
```
heppy test runVV_cfg.py -N 100
```

This might not be the final solution to all problems since `lfnToPFN` can also prepend `file:` to the path, which does not make sense in several cases (see https://github.com/clelange/cmg-cmssw/blob/dd0229459675018f8a70d097030fb9416f486fd1/PhysicsTools/HeppyCore/python/utils/eostools.py#L88-L93), but it should cover the majority of use cases.