### PR TITLE
Forward port 80X heppy PRs 703, 704, 705 to 92X

### DIFF
--- a/PhysicsTools/Heppy/python/analyzers/core/JSONAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/core/JSONAnalyzer.py
@@ -37,6 +37,12 @@ class JSONAnalyzer( Analyzer ):
         else:
             self.lumiList = None
         
+        if hasattr(self.cfg_comp, 'additionaljson'):
+            self.additionalLumiList = LumiList(os.path.expandvars(self.cfg_comp.additionaljson))
+            self.twojson = True
+        else: 
+            self.twojson = False
+        
         self.useLumiBlocks = self.cfg_ana.useLumiBlocks if (hasattr(self.cfg_ana,'useLumiBlocks')) else False
 
         self.rltInfo = RLTInfo()
@@ -47,6 +53,8 @@ class JSONAnalyzer( Analyzer ):
         self.count = self.counters.counter('JSON')
         self.count.register('All Events')
         self.count.register('Passed Events')
+        if self.twojson:
+            self.count.register('Additional JSON Passed Events')
 
         if self.useLumiBlocks and not self.cfg_comp.isMC and not self.lumiList is None:
             lumis = Lumis(self.cfg_comp.files)
@@ -79,6 +87,12 @@ class JSONAnalyzer( Analyzer ):
             self.count.inc('Passed Events')
             if not self.useLumiBlocks:
                 self.rltInfo.add('dummy', run, lumi)
+            if self.twojson:
+                if self.additionalLumiList.contains(run,lumi):
+                    event.passSecondJSON = True
+                    self.count.inc('Additional JSON Passed Events')
+                else:
+                    event.passSecondJSON = False
             return True
         else:
             return False

--- a/PhysicsTools/Heppy/python/analyzers/objects/METAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/METAnalyzer.py
@@ -66,9 +66,37 @@ class METAnalyzer( Analyzer ):
         chargedchs = []
         chargedPVLoose = []
         chargedPVTight = []
-        dochs=getattr(self.cfg_ana,"includeTkMetCHS",True)       
-        dotight=getattr(self.cfg_ana,"includeTkMetPVTight",True)       
-        doloose=getattr(self.cfg_ana,"includeTkMetPVLoose",True)       
+        chargedNoPV = []
+        chargedPVUsedInFit = []
+        chargedUsedInFitTight = []
+        chargedUsedInFitLoose = []
+        chargedCompatibilityDz = []
+        chargedCompatibilityBTag = []
+        chargedNotReconstructedPrimary = []
+        chargedOtherDeltaZ = []
+        dochs=getattr(self.cfg_ana,"includeTkMetCHS",True)
+        dotight=getattr(self.cfg_ana,"includeTkMetPVTight",True)
+        doloose=getattr(self.cfg_ana,"includeTkMetPVLoose",True)
+        doPVUsedInFit=getattr(self.cfg_ana,"includeTkMetPVUsedInFit",True)
+        doNoPV=getattr(self.cfg_ana,"includeTkMetNoPV",True)
+        doUsedInFitTight=getattr(self.cfg_ana,"includeTkMetUsedInFitTight",True)
+        doUsedInFitLoose=getattr(self.cfg_ana,"includeTkMetUsedInFitLoose",True)
+        doCompatibilityDz=getattr(self.cfg_ana,"includeTkMetCompatibilityDz",True)
+        doCompatibilityBTag=getattr(self.cfg_ana,"includeTkMetCompatibilityBTag",True)
+        doNotReconstructedPrimary=getattr(self.cfg_ana,"includeTkMetNotReconstructedPrimary",True)
+        doOtherDeltaZ=getattr(self.cfg_ana,"includeTkMetOtherDeltaZ",True)
+        doPuppichs=getattr(self.cfg_ana,"includeTkMetPuppiCHS",True)
+        doPuppitight=getattr(self.cfg_ana,"includeTkMetPuppiPVTight",True)
+        doPuppiloose=getattr(self.cfg_ana,"includeTkMetPuppiPVLoose",True)
+        doPuppiPVUsedInFit=getattr(self.cfg_ana,"includeTkMetPuppiPVUsedInFit",True)
+        doPuppiNoPV=getattr(self.cfg_ana,"includeTkMetPuppiNoPV",True)
+        doPuppiUsedInFitTight=getattr(self.cfg_ana,"includeTkMetPuppiUsedInFitTight",True)
+        doPuppiUsedInFitLoose=getattr(self.cfg_ana,"includeTkMetPuppiUsedInFitLoose",True)
+        doPuppiCompatibilityDz=getattr(self.cfg_ana,"includeTkMetPuppiCompatibilityDz",True)
+        doPuppiCompatibilityBTag=getattr(self.cfg_ana,"includeTkMetPuppiCompatibilityBTag",True)
+        doPuppiNotReconstructedPrimary=getattr(self.cfg_ana,"includeTkMetPuppiNotReconstructedPrimary",True)
+        doPuppiOtherDeltaZ=getattr(self.cfg_ana,"includeTkMetPuppiOtherDeltaZ",True)
+
         pfcands = self.handles['cmgCand'].product()
 
         for pfcand in pfcands:
@@ -85,23 +113,70 @@ class METAnalyzer( Analyzer ):
                 if dochs and  pvflag>0:
                     chargedchs.append(pxy)
 
-                if doloose and pvflag>1:
+                ##CHS=loose
+                if doloose and pvflag>=1:
                     chargedPVLoose.append(pxy)
 
-                if dotight and pvflag>2:
+                if dotight and pvflag>=2:
                     chargedPVTight.append(pxy)
+
+                if doNoPV and pvflag >= 0:
+                    chargedNoPV.append(pxy)
+
+                if doPVUsedInFit and pvflag== 3:
+                    chargedPVUsedInFit.append(pxy)
+
+                #adding pvAssociationQuality stuff
+                pvAssflag = pfcand.pvAssociationQuality()
+
+                if doUsedInFitTight and pvAssflag == 7 :
+                    chargedUsedInFitTight.append(pxy)
+
+                if doUsedInFitLoose and pvAssflag == 6 :
+                    chargedUsedInFitLoose.append(pxy)
+
+                if doCompatibilityDz and pvAssflag == 5 :
+                    chargedCompatibilityDz.append(pxy)
+
+                if doCompatibilityBTag and pvAssflag == 4 :
+                    chargedCompatibilityBTag.append(pxy)
+
+                if doNotReconstructedPrimary and pvAssflag == 0:
+                    chargedNotReconstructedPrimary.append(pxy)
+
+                if doOtherDeltaZ and pvAssflag == 1 :
+                    chargedOtherDeltaZ.append(pxy)
+
 
         def sumXY(pxys):
             px, py = sum(x[0] for x in pxys), sum(x[1] for x in pxys)
             return ROOT.reco.Particle.LorentzVector(-px, -py, 0, hypot(px,py))
+
         setattr(event, "tkMet"+self.cfg_ana.collectionPostFix, sumXY(charged))
         setattr(event, "tkMetPVchs"+self.cfg_ana.collectionPostFix, sumXY(chargedchs))
         setattr(event, "tkMetPVLoose"+self.cfg_ana.collectionPostFix, sumXY(chargedPVLoose))
         setattr(event, "tkMetPVTight"+self.cfg_ana.collectionPostFix, sumXY(chargedPVTight))
+        setattr(event, "tkMetPVUsedInFit"+self.cfg_ana.collectionPostFix, sumXY(chargedPVUsedInFit))
+        setattr(event, "tkMetNoPV"+self.cfg_ana.collectionPostFix, sumXY(chargedNoPV))
+        setattr(event, "tkMetUsedInFitTight"+self.cfg_ana.collectionPostFix, sumXY(chargedUsedInFitTight))
+        setattr(event, "tkMetUsedInFitLoose"+self.cfg_ana.collectionPostFix, sumXY(chargedUsedInFitLoose))
+        setattr(event, "tkMetCompatibilityDz"+self.cfg_ana.collectionPostFix, sumXY(chargedCompatibilityDz))
+        setattr(event, "tkMetCompatibilityBTag"+self.cfg_ana.collectionPostFix, sumXY(chargedCompatibilityBTag))
+        setattr(event, "tkMetNotReconstructedPrimary"+self.cfg_ana.collectionPostFix, sumXY(chargedNotReconstructedPrimary))
+        setattr(event, "tkMetOtherDeltaZ"+self.cfg_ana.collectionPostFix, sumXY(chargedOtherDeltaZ))
         getattr(event,"tkMet"+self.cfg_ana.collectionPostFix).sumEt = sum([hypot(x[0],x[1]) for x in charged])
         getattr(event,"tkMetPVchs"+self.cfg_ana.collectionPostFix).sumEt = sum([hypot(x[0],x[1]) for x in chargedchs])
         getattr(event,"tkMetPVLoose"+self.cfg_ana.collectionPostFix).sumEt = sum([hypot(x[0],x[1]) for x in chargedPVLoose])
         getattr(event,"tkMetPVTight"+self.cfg_ana.collectionPostFix).sumEt = sum([hypot(x[0],x[1]) for x in chargedPVTight])
+        getattr(event,"tkMetPVUsedInFit"+self.cfg_ana.collectionPostFix).sumEt = sum([hypot(x[0],x[1]) for x in chargedPVUsedInFit])
+        getattr(event,"tkMetNoPV"+self.cfg_ana.collectionPostFix).sumEt = sum([hypot(x[0],x[1]) for x in chargedNoPV])
+        getattr(event,"tkMetUsedInFitTight"+self.cfg_ana.collectionPostFix).sumEt = sum([hypot(x[0],x[1]) for x in chargedUsedInFitTight])
+        getattr(event,"tkMetUsedInFitLoose"+self.cfg_ana.collectionPostFix).sumEt = sum([hypot(x[0],x[1]) for x in chargedUsedInFitLoose])
+        getattr(event,"tkMetCompatibilityDz"+self.cfg_ana.collectionPostFix).sumEt = sum([hypot(x[0],x[1]) for x in chargedCompatibilityDz])
+        getattr(event,"tkMetCompatibilityBTag"+self.cfg_ana.collectionPostFix).sumEt = sum([hypot(x[0],x[1]) for x in chargedCompatibilityBTag])
+        getattr(event,"tkMetNotReconstructedPrimary"+self.cfg_ana.collectionPostFix).sumEt = sum([hypot(x[0],x[1]) for x in chargedNotReconstructedPrimary])
+        getattr(event,"tkMetOtherDeltaZ"+self.cfg_ana.collectionPostFix).sumEt = sum([hypot(x[0],x[1]) for x in chargedOtherDeltaZ])
+
 
         if  hasattr(event,'zll_p4'):
             self.adduParaPerp(getattr(event,"tkMet"+self.cfg_ana.collectionPostFix), event.zll_p4,"_zll")
@@ -292,9 +367,19 @@ setattr(METAnalyzer,"defaultConfig", cfg.Analyzer(
     old74XMiniAODs = False, # need to set to True to get proper Raw MET on plain 74X MC produced with CMSSW <= 7_4_12
     makeShiftedMETs = True,
     doTkMet = False,
+    ### more on tkMET
     includeTkMetCHS = True,
     includeTkMetPVLoose = True,
     includeTkMetPVTight = True,
+    includeTkMetNoPV = False,
+    includeTkMetPVUsedInFit = False,
+    includeTkMetUsedInFitTight = False,
+    includeTkMetUsedInFitLoose = False,
+    includeTkMetCompatibilityDz = False,
+    includeTkMetCompatibilityBTag = False,
+    includeTkMetNotReconstructedPrimary = False,
+    includeTkMetOtherDeltaZ = False,
+    ###
     doMetNoPU = False, # Not existing in MiniAOD at the moment
     doMetNoMu = False,  
     doMetNoEle = False,  

--- a/PhysicsTools/Heppy/python/analyzers/objects/METAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/METAnalyzer.py
@@ -111,12 +111,6 @@ class METAnalyzer( Analyzer ):
         chargedPVTight = []
         chargedNoPV = []
         chargedPVUsedInFit = []
-        chargedUsedInFitTight = []
-        chargedUsedInFitLoose = []
-        chargedCompatibilityDz = []
-        chargedCompatibilityBTag = []
-        chargedNotReconstructedPrimary = []
-        chargedOtherDeltaZ = []
         dochs=getattr(self.cfg_ana,"includeTkMetCHS",False)
         dotight=getattr(self.cfg_ana,"includeTkMetPVTight",False)
         doloose=getattr(self.cfg_ana,"includeTkMetPVLoose",False)
@@ -163,24 +157,12 @@ class METAnalyzer( Analyzer ):
         setattr(event, "tkMetPVTight"+self.cfg_ana.collectionPostFix, sumXY(chargedPVTight))
         setattr(event, "tkMetPVUsedInFit"+self.cfg_ana.collectionPostFix, sumXY(chargedPVUsedInFit))
         setattr(event, "tkMetNoPV"+self.cfg_ana.collectionPostFix, sumXY(chargedNoPV))
-        setattr(event, "tkMetUsedInFitTight"+self.cfg_ana.collectionPostFix, sumXY(chargedUsedInFitTight))
-        setattr(event, "tkMetUsedInFitLoose"+self.cfg_ana.collectionPostFix, sumXY(chargedUsedInFitLoose))
-        setattr(event, "tkMetCompatibilityDz"+self.cfg_ana.collectionPostFix, sumXY(chargedCompatibilityDz))
-        setattr(event, "tkMetCompatibilityBTag"+self.cfg_ana.collectionPostFix, sumXY(chargedCompatibilityBTag))
-        setattr(event, "tkMetNotReconstructedPrimary"+self.cfg_ana.collectionPostFix, sumXY(chargedNotReconstructedPrimary))
-        setattr(event, "tkMetOtherDeltaZ"+self.cfg_ana.collectionPostFix, sumXY(chargedOtherDeltaZ))
         getattr(event,"tkMet"+self.cfg_ana.collectionPostFix).sumEt = sum([hypot(x[0],x[1]) for x in charged])
         getattr(event,"tkMetPVchs"+self.cfg_ana.collectionPostFix).sumEt = sum([hypot(x[0],x[1]) for x in chargedchs])
         getattr(event,"tkMetPVLoose"+self.cfg_ana.collectionPostFix).sumEt = sum([hypot(x[0],x[1]) for x in chargedPVLoose])
         getattr(event,"tkMetPVTight"+self.cfg_ana.collectionPostFix).sumEt = sum([hypot(x[0],x[1]) for x in chargedPVTight])
         getattr(event,"tkMetPVUsedInFit"+self.cfg_ana.collectionPostFix).sumEt = sum([hypot(x[0],x[1]) for x in chargedPVUsedInFit])
         getattr(event,"tkMetNoPV"+self.cfg_ana.collectionPostFix).sumEt = sum([hypot(x[0],x[1]) for x in chargedNoPV])
-        getattr(event,"tkMetUsedInFitTight"+self.cfg_ana.collectionPostFix).sumEt = sum([hypot(x[0],x[1]) for x in chargedUsedInFitTight])
-        getattr(event,"tkMetUsedInFitLoose"+self.cfg_ana.collectionPostFix).sumEt = sum([hypot(x[0],x[1]) for x in chargedUsedInFitLoose])
-        getattr(event,"tkMetCompatibilityDz"+self.cfg_ana.collectionPostFix).sumEt = sum([hypot(x[0],x[1]) for x in chargedCompatibilityDz])
-        getattr(event,"tkMetCompatibilityBTag"+self.cfg_ana.collectionPostFix).sumEt = sum([hypot(x[0],x[1]) for x in chargedCompatibilityBTag])
-        getattr(event,"tkMetNotReconstructedPrimary"+self.cfg_ana.collectionPostFix).sumEt = sum([hypot(x[0],x[1]) for x in chargedNotReconstructedPrimary])
-        getattr(event,"tkMetOtherDeltaZ"+self.cfg_ana.collectionPostFix).sumEt = sum([hypot(x[0],x[1]) for x in chargedOtherDeltaZ])
 
 
         if  hasattr(event,'zll_p4'):

--- a/PhysicsTools/Heppy/python/analyzers/objects/autophobj.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/autophobj.py
@@ -53,6 +53,8 @@ leptonType = NTupleObjectType("lepton", baseObjectTypes = [ particleType ], vari
     NTupleVariable("eleCutIdCSA14_25ns_v1",     lambda x : (1*x.electronID("POG_Cuts_ID_CSA14_25ns_v1_Veto") + 1*x.electronID("POG_Cuts_ID_CSA14_25ns_v1_Loose") + 1*x.electronID("POG_Cuts_ID_CSA14_25ns_v1_Medium") + 1*x.electronID("POG_Cuts_ID_CSA14_25ns_v1_Tight")) if abs(x.pdgId()) == 11 else -1, int, help="Electron cut-based id (POG CSA14_25ns_v1): 0=none, 1=veto, 2=loose, 3=medium, 4=tight"),
     NTupleVariable("eleCutIdCSA14_50ns_v1",     lambda x : (1*x.electronID("POG_Cuts_ID_CSA14_50ns_v1_Veto") + 1*x.electronID("POG_Cuts_ID_CSA14_50ns_v1_Loose") + 1*x.electronID("POG_Cuts_ID_CSA14_50ns_v1_Medium") + 1*x.electronID("POG_Cuts_ID_CSA14_50ns_v1_Tight")) if abs(x.pdgId()) == 11 else -1, int, help="Electron cut-based id (POG CSA14_50ns_v1): 0=none, 1=veto, 2=loose, 3=medium, 4=tight"),
     NTupleVariable("eleCutIdSpring15_25ns_v1",     lambda x : (1*x.electronID("cutBasedElectronID-Spring15-25ns-V1-standalone-veto") + 1*x.electronID("cutBasedElectronID-Spring15-25ns-V1-standalone-loose") + 1*x.electronID("cutBasedElectronID-Spring15-25ns-V1-standalone-medium") + 1*x.electronID("cutBasedElectronID-Spring15-25ns-V1-standalone-tight")) if abs(x.pdgId()) == 11 and x.isElectronIDAvailable("cutBasedElectronID-Spring15-25ns-V1-standalone-veto") else -1, int, help="Electron cut-based id (POG Spring15_25ns_v1): 0=none, 1=veto, 2=loose, 3=medium, 4=tight"),
+    # more on electron
+    NTupleVariable("hasGainSwitchFlag",   lambda x : x.userInt("hasGainSwitchFlag") if abs(x.pdgId()) == 11 else -1, int, help="photon has gain switched"),
     # Impact parameter
     NTupleVariable("dxy",   lambda x : x.dxy(), help="d_{xy} with respect to PV, in cm (with sign)"),
     NTupleVariable("dz",    lambda x : x.dz() , help="d_{z} with respect to PV, in cm (with sign)"),
@@ -180,6 +182,7 @@ photonType = NTupleObjectType("gamma", baseObjectTypes = [ particleType ], varia
     NTupleVariable("relIso", lambda x : x.ftprRelIso03 if hasattr(x,'ftprRelIso03') else x.relIso, float, help="relativeIsolation for photons with footprint removal and pile-up correction"),
     NTupleVariable("mcMatchId",  lambda x : getattr(x, 'mcMatchId', -99), int, mcOnly=True, help="Match to source from hard scatter (pdgId of heaviest particle in chain, 25 for H, 6 for t, 23/24 for W/Z), zero if non-prompt or fake"),
     NTupleVariable("mcPt",   lambda x : x.mcGamma.pt() if getattr(x,"mcGamma",None) else 0., mcOnly=True, help="p_{T} of associated gen photon"),
+    NTupleVariable("hasGainSwitchFlag", lambda x: x.userInt("hasGainSwitchFlag"), int, help="photon has gain switched"),
 ])
 
 ##------------------------------------------  

--- a/PhysicsTools/Heppy/python/analyzers/objects/autophobj.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/autophobj.py
@@ -54,7 +54,7 @@ leptonType = NTupleObjectType("lepton", baseObjectTypes = [ particleType ], vari
     NTupleVariable("eleCutIdCSA14_50ns_v1",     lambda x : (1*x.electronID("POG_Cuts_ID_CSA14_50ns_v1_Veto") + 1*x.electronID("POG_Cuts_ID_CSA14_50ns_v1_Loose") + 1*x.electronID("POG_Cuts_ID_CSA14_50ns_v1_Medium") + 1*x.electronID("POG_Cuts_ID_CSA14_50ns_v1_Tight")) if abs(x.pdgId()) == 11 else -1, int, help="Electron cut-based id (POG CSA14_50ns_v1): 0=none, 1=veto, 2=loose, 3=medium, 4=tight"),
     NTupleVariable("eleCutIdSpring15_25ns_v1",     lambda x : (1*x.electronID("cutBasedElectronID-Spring15-25ns-V1-standalone-veto") + 1*x.electronID("cutBasedElectronID-Spring15-25ns-V1-standalone-loose") + 1*x.electronID("cutBasedElectronID-Spring15-25ns-V1-standalone-medium") + 1*x.electronID("cutBasedElectronID-Spring15-25ns-V1-standalone-tight")) if abs(x.pdgId()) == 11 and x.isElectronIDAvailable("cutBasedElectronID-Spring15-25ns-V1-standalone-veto") else -1, int, help="Electron cut-based id (POG Spring15_25ns_v1): 0=none, 1=veto, 2=loose, 3=medium, 4=tight"),
     # more on electron
-    NTupleVariable("hasGainSwitchFlag",   lambda x : x.userInt("hasGainSwitchFlag") if abs(x.pdgId()) == 11 else -1, int, help="photon has gain switched"),
+    NTupleVariable("hasGainSwitchFlag",   lambda x : x.userInt("hasGainSwitchFlag") if hasattr(x,'hasGainSwitchFlag') and abs(x.pdgId()) == 11 else -1, int, help="photon has gain switched"),
     # Impact parameter
     NTupleVariable("dxy",   lambda x : x.dxy(), help="d_{xy} with respect to PV, in cm (with sign)"),
     NTupleVariable("dz",    lambda x : x.dz() , help="d_{z} with respect to PV, in cm (with sign)"),
@@ -182,7 +182,7 @@ photonType = NTupleObjectType("gamma", baseObjectTypes = [ particleType ], varia
     NTupleVariable("relIso", lambda x : x.ftprRelIso03 if hasattr(x,'ftprRelIso03') else x.relIso, float, help="relativeIsolation for photons with footprint removal and pile-up correction"),
     NTupleVariable("mcMatchId",  lambda x : getattr(x, 'mcMatchId', -99), int, mcOnly=True, help="Match to source from hard scatter (pdgId of heaviest particle in chain, 25 for H, 6 for t, 23/24 for W/Z), zero if non-prompt or fake"),
     NTupleVariable("mcPt",   lambda x : x.mcGamma.pt() if getattr(x,"mcGamma",None) else 0., mcOnly=True, help="p_{T} of associated gen photon"),
-    NTupleVariable("hasGainSwitchFlag", lambda x: x.userInt("hasGainSwitchFlag"), int, help="photon has gain switched"),
+    NTupleVariable("hasGainSwitchFlag", lambda x: x.userInt("hasGainSwitchFlag") if hasattr(x,'hasGainSwitchFlag') else -1, int, help="photon has gain switched"),
 ])
 
 ##------------------------------------------  

--- a/PhysicsTools/Heppy/python/analyzers/objects/autophobj.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/autophobj.py
@@ -54,7 +54,7 @@ leptonType = NTupleObjectType("lepton", baseObjectTypes = [ particleType ], vari
     NTupleVariable("eleCutIdCSA14_50ns_v1",     lambda x : (1*x.electronID("POG_Cuts_ID_CSA14_50ns_v1_Veto") + 1*x.electronID("POG_Cuts_ID_CSA14_50ns_v1_Loose") + 1*x.electronID("POG_Cuts_ID_CSA14_50ns_v1_Medium") + 1*x.electronID("POG_Cuts_ID_CSA14_50ns_v1_Tight")) if abs(x.pdgId()) == 11 else -1, int, help="Electron cut-based id (POG CSA14_50ns_v1): 0=none, 1=veto, 2=loose, 3=medium, 4=tight"),
     NTupleVariable("eleCutIdSpring15_25ns_v1",     lambda x : (1*x.electronID("cutBasedElectronID-Spring15-25ns-V1-standalone-veto") + 1*x.electronID("cutBasedElectronID-Spring15-25ns-V1-standalone-loose") + 1*x.electronID("cutBasedElectronID-Spring15-25ns-V1-standalone-medium") + 1*x.electronID("cutBasedElectronID-Spring15-25ns-V1-standalone-tight")) if abs(x.pdgId()) == 11 and x.isElectronIDAvailable("cutBasedElectronID-Spring15-25ns-V1-standalone-veto") else -1, int, help="Electron cut-based id (POG Spring15_25ns_v1): 0=none, 1=veto, 2=loose, 3=medium, 4=tight"),
     # more on electron
-    NTupleVariable("hasGainSwitchFlag",   lambda x : x.userInt("hasGainSwitchFlag") if hasattr(x,'hasGainSwitchFlag') and abs(x.pdgId()) == 11 else -1, int, help="photon has gain switched"),
+    NTupleVariable("hasGainSwitchFlag",   lambda x : x.userInt("hasGainSwitchFlag") if x.hasUserInt('hasGainSwitchFlag') and abs(x.pdgId()) == 11 else -1, int, help="photon has gain switched"),
     # Impact parameter
     NTupleVariable("dxy",   lambda x : x.dxy(), help="d_{xy} with respect to PV, in cm (with sign)"),
     NTupleVariable("dz",    lambda x : x.dz() , help="d_{z} with respect to PV, in cm (with sign)"),
@@ -182,7 +182,7 @@ photonType = NTupleObjectType("gamma", baseObjectTypes = [ particleType ], varia
     NTupleVariable("relIso", lambda x : x.ftprRelIso03 if hasattr(x,'ftprRelIso03') else x.relIso, float, help="relativeIsolation for photons with footprint removal and pile-up correction"),
     NTupleVariable("mcMatchId",  lambda x : getattr(x, 'mcMatchId', -99), int, mcOnly=True, help="Match to source from hard scatter (pdgId of heaviest particle in chain, 25 for H, 6 for t, 23/24 for W/Z), zero if non-prompt or fake"),
     NTupleVariable("mcPt",   lambda x : x.mcGamma.pt() if getattr(x,"mcGamma",None) else 0., mcOnly=True, help="p_{T} of associated gen photon"),
-    NTupleVariable("hasGainSwitchFlag", lambda x: x.userInt("hasGainSwitchFlag") if hasattr(x,'hasGainSwitchFlag') else -1, int, help="photon has gain switched"),
+    NTupleVariable("hasGainSwitchFlag", lambda x: x.userInt("hasGainSwitchFlag") if x.hasUserInt('hasGainSwitchFlag') else -1, int, help="photon has gain switched"),
 ])
 
 ##------------------------------------------  

--- a/PhysicsTools/Heppy/python/physicsobjects/Electron.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Electron.py
@@ -70,8 +70,8 @@ class Electron( Lepton ):
             'dxy' : abs(self.dxy()),
             'dz' : abs(self.dz()),
             'chi2' : self.normalizedGsfChi2(),
-            'ECALPFIsoEA' : self.hltPFIso('ECALPFIsoEA')/self.pt(),
-            'HCALPFIsoEA' : self.hltPFIso('HCALPFIsoEA')/self.pt(),
+            'ECALPFIsoEA' : self.hltPFIso('ECALPFIsoEA')/self.pt() if self.rhoHLT != None in wp else None,
+            'HCALPFIsoEA' : self.hltPFIso('HCALPFIsoEA')/self.pt() if self.rhoHLT != None in wp else None,
             'trkIso' : self.dr03TkSumPt()/self.pt(),
         }
         WP = {
@@ -356,15 +356,16 @@ class Electron( Lepton ):
                 elif wp == "POG80": 
                     # for pt < 10 the performance is suboptimal, 
                     #see https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2 for updates on this category
-                    if   eta < 0.8  : return self.mvaRun2(name+'GP') > 0.941;
-                    elif eta < 1.479: return self.mvaRun2(name+'GP') > 0.899;
-                    else            : return self.mvaRun2(name+'GP') > 0.758;
+                    if   eta < 0.8  : return self.mvaRun2(name+'GP') > 0.940962684155;
+                    elif eta < 1.479: return self.mvaRun2(name+'GP') > 0.899208843708;
+                    else            : return self.mvaRun2(name+'GP') > 0.758484721184;
+
                 elif wp == "POG90":
                     # for pt < 10 the performance is suboptimal, 
                     #see https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2 for updates on this category
-                    if eta < 0.8: return self.mvaRun2(name+'GP') > 0.837
-                    elif eta < 1.479: return self.mvaRun2(name+'GP') > 0.715
-                    else: return self.mvaRun2(name+'GP') > 0.357
+                    if eta < 0.8: return self.mvaRun2(name+'GP') > 0.836695742607
+                    elif eta < 1.479: return self.mvaRun2(name+'GP') > 0.715337944031
+                    else: return self.mvaRun2(name+'GP') > 0.356799721718
                 elif wp=="VLoose":
                     smooth_cut = True
                     _vlow = [0.46,-0.03,0.06]

--- a/PhysicsTools/Heppy/python/physicsobjects/Electron.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Electron.py
@@ -70,8 +70,8 @@ class Electron( Lepton ):
             'dxy' : abs(self.dxy()),
             'dz' : abs(self.dz()),
             'chi2' : self.normalizedGsfChi2(),
-            'ECALPFIsoEA' : self.hltPFIso('ECALPFIsoEA')/self.pt() if self.rhoHLT != None in wp else None,
-            'HCALPFIsoEA' : self.hltPFIso('HCALPFIsoEA')/self.pt() if self.rhoHLT != None in wp else None,
+            'ECALPFIsoEA' : self.hltPFIso('ECALPFIsoEA')/self.pt() if "HLT" in wp else None,
+            'HCALPFIsoEA' : self.hltPFIso('HCALPFIsoEA')/self.pt() if "HLT" in wp else None,
             'trkIso' : self.dr03TkSumPt()/self.pt(),
         }
         WP = {

--- a/PhysicsTools/Heppy/python/utils/miniAodFiles.py
+++ b/PhysicsTools/Heppy/python/utils/miniAodFiles.py
@@ -53,7 +53,7 @@ def miniAodFiles():
  
     else:
         raise ValueError('no mini AOD file defined for release '+cmsswRelease())
-    eosfiles = [''.join(['root://eoscms//eos/cms', lfn]) for lfn in files]
+    eosfiles = [''.join(['root://cms-xrd-global.cern.ch/', lfn]) for lfn in files]
     return eosfiles
 
 

--- a/PhysicsTools/HeppyCore/python/utils/eostools.py
+++ b/PhysicsTools/HeppyCore/python/utils/eostools.py
@@ -48,7 +48,7 @@ def runEOSCommand(path, cmd, *args):
     tokens = splitPFN(path)
     
     #obviously, this is not nice
-    command = ['/afs/cern.ch/project/eos/installation/pro/bin/eos.select', cmd]
+    command = ['eos', cmd]
     command.extend(args)
     command.append(tokens[2])
     return _runCommand(command)

--- a/PhysicsTools/HeppyCore/scripts/heppy_batch.py
+++ b/PhysicsTools/HeppyCore/scripts/heppy_batch.py
@@ -101,16 +101,16 @@ do
    source $VO_CMS_SW_DIR/cmsset_default.sh
    for try in `seq 1 3`; do
       echo "Stageout try $try"
-      echo "/afs/cern.ch/project/eos/installation/pro/bin/eos.select mkdir {srm}"
-      /afs/cern.ch/project/eos/installation/pro/bin/eos.select mkdir {srm}
-      echo "/afs/cern.ch/project/eos/installation/pro/bin/eos.select cp `pwd`/$f {srm}/${{ff}}_{idx}.root"
-      /afs/cern.ch/project/eos/installation/pro/bin/eos.select cp `pwd`/$f {srm}/${{ff}}_{idx}.root
+      echo "eos mkdir {srm}"
+      eos mkdir {srm}
+      echo "eos cp `pwd`/$f {srm}/${{ff}}_{idx}.root"
+      eos cp `pwd`/$f {srm}/${{ff}}_{idx}.root
       if [ $? -ne 0 ]; then
          echo "ERROR: remote copy failed for file $ff"
          continue
       fi
       echo "remote copy succeeded"
-      remsize=$(/afs/cern.ch/project/eos/installation/pro/bin/eos.select find --size {srm}/${{ff}}_{idx}.root | cut -d= -f3) 
+      remsize=$(eos find --size {srm}/${{ff}}_{idx}.root | cut -d= -f3) 
       locsize=$(cat `pwd`/$f | wc -c)
       ok=$(($remsize==$locsize))
       if [ $ok -ne 1 ]; then

--- a/PhysicsTools/HeppyCore/scripts/heppy_hadd.py
+++ b/PhysicsTools/HeppyCore/scripts/heppy_hadd.py
@@ -36,17 +36,8 @@ def haddPck(file, odir, idirs):
     txtFile.write( str(sum) )
     txtFile.write( '\n' )
     txtFile.close()
-    
 
-def hadd(file, odir, idirs, appx=''):
-    if file.endswith('.pck'):
-        try:
-            haddPck( file, odir, idirs)
-        except ImportError:
-            pass
-        return
-    elif not file.endswith('.root'):
-        return
+def haddLocal(file, odir, idirs, appx):
     haddCmd = ['hadd']
     haddCmd.append( file.replace( idirs[0], odir ).replace('.root', appx+'.root') )
     for dir in idirs:
@@ -56,8 +47,8 @@ def hadd(file, odir, idirs, appx=''):
     print cmd
     if len(cmd) > MAX_ARG_STRLEN:
         print 'Command longer than maximum unix string length; dividing into 2'
-        hadd(file, odir, idirs[:len(idirs)/2], '1')
-        hadd(file.replace(idirs[0], idirs[len(idirs)/2]), odir, idirs[len(idirs)/2:], '2')
+        haddLocal(file, odir, idirs[:len(idirs)/2], '1')
+        haddLocal(file.replace(idirs[0], idirs[len(idirs)/2]), odir, idirs[len(idirs)/2:], '2')
         haddCmd = ['hadd']
         haddCmd.append( file.replace( idirs[0], odir ).replace('.root', appx+'.root') )
         haddCmd.append( file.replace( idirs[0], odir ).replace('.root', '1.root') )
@@ -67,6 +58,49 @@ def hadd(file, odir, idirs, appx=''):
         os.system(cmd)
     else:
         os.system(cmd)
+    
+def haddEos(file, odir, idirs, appx=''):
+    file = file.replace('.url', '')
+    haddCmd = ['hadd']
+    haddCmd.append( file.replace( idirs[0], odir ).replace('.root', appx+'.root') )
+    for dir in idirs:
+        with open(file.replace( idirs[0], dir ) + '.url') as ff: 
+            ifile = ff.readlines()[0].rstrip()
+        haddCmd.append(ifile)
+    cmd = ' '.join(haddCmd)
+    print '\n', cmd
+    if len(cmd) > MAX_ARG_STRLEN:
+        #import pdb ; pdb.set_trace()
+        print 'Command longer than maximum unix string length; dividing into 2'
+        haddEos(file.replace('.url', ''), odir, idirs[:len(idirs)/2], '1')
+        print 'first'#; import pdb ; pdb.set_trace()
+        haddEos(file.replace(idirs[0], idirs[len(idirs)/2]).replace('.url', ''), odir, idirs[len(idirs)/2:], '2')
+        print 'second'#; import pdb ; pdb.set_trace()
+        haddCmd = ['hadd']
+        haddCmd.append( file.replace( idirs[0], odir ).replace('.root', appx+'.root') )
+        haddCmd.append( file.replace( idirs[0], odir ).replace('.root', '1.root') )
+        haddCmd.append( file.replace( idirs[0], odir ).replace('.root', '2.root') )
+        cmd = ' '.join(haddCmd)
+        print 'Running merge cmd:', cmd
+        os.system(cmd)
+    os.system(cmd)
+  
+
+def hadd(file, odir, idirs, appx=''):
+    if file.endswith('.pck'):
+        try:
+            haddPck( file, odir, idirs)
+        except ImportError:
+            pass
+        return
+    elif file.endswith('.root.url'):
+        haddEos(file, odir, idirs, appx)
+    elif file.endswith('.root'):
+        haddLocal(file, odir, idirs, appx)
+    else:
+        return
+
+
 
 
 def haddRec(odir, idirs):


### PR DESCRIPTION
Rebase to 9_2_X everything in the 80X heppy branch between the tags heppy_80X_30Jun2017 to heppy_80X_15Dec2017
 * #705 by @jheikkil: *Use precise spring16 electron raw MVA values instead of the rounded ones*
 * #704by @mariadalfonso: *Heppy: METanalyzer, gainSwitch Heppy to port to 92X*
 * #703 by @peruzzim: *Heppy: use local EOS client instead of the AFS-based one bugfix Heppy production*