### PR TITLE
Condor submission (updated)

### DIFF
--- a/PhysicsTools/HeppyCore/python/utils/batchmanager.py
+++ b/PhysicsTools/HeppyCore/python/utils/batchmanager.py
@@ -279,6 +279,14 @@ class BatchManager:
                 print 'running on CONDOR : %s from %s' % (batchCmd, hostName)
                 return 'LXPLUS'
 
+        elif batchCmd == "run_condor_simple.sh":
+            if not onLxplus:
+                err = 'Cannot run %s on %s' % (batchCmd, hostName)
+                raise ValueError( err )
+            else:
+                print 'running on CONDOR (simplified version) : %s from %s' % (batchCmd, hostName)
+                return 'LXPLUS-SIMPLE'
+
         elif batchCmd == "qsub":
             if onPSI:
                 print 'running on SGE : %s from %s' % (batchCmd, hostName)

--- a/PhysicsTools/HeppyCore/python/utils/batchmanager.py
+++ b/PhysicsTools/HeppyCore/python/utils/batchmanager.py
@@ -43,9 +43,17 @@ class BatchManager:
                                 dest="negate", default=False,
                                 help="create jobs, but does not submit the jobs.")
         self.parser_.add_option("-b", "--batch", dest="batch",
-                                help="batch command. default is: 'run_condor.sh'. You can also use 'nohup < ./batchScript.sh &' to run locally.",
-                                default='run_condor.sh batchScript.sh')
-                                #default="bsub -q 8nh < ./batchScript.sh")
+                                help="""batch command to submit job. 
+                                    ==> LSF submission to a queue, e.g. 8nh:
+                                          'bsub -q 8nh < ./batchScript.sh'
+                                    ==> HTCondor submission using AFS to transfer files
+                                    ==> with max 240 minutes of wall clock runtime:
+                                          'run_condor_simple.sh -t 240 ./batchScript.sh' 
+                                    ==> Same but with HTCondor internal file transfer:
+                                          'run_condor.sh -t 240 ./batchScript.sh' 
+
+                                    The default is '%default'.""",
+                                default="bsub -q 8nh < ./batchScript.sh")
         self.parser_.add_option( "--option",
                                 dest="extraOptions",
                                 type="string",

--- a/PhysicsTools/HeppyCore/python/utils/batchmanager.py
+++ b/PhysicsTools/HeppyCore/python/utils/batchmanager.py
@@ -276,16 +276,16 @@ class BatchManager:
                 err = 'Cannot run %s on %s' % (batchCmd, hostName)
                 raise ValueError( err )
             else:
-                print 'running on CONDOR : %s from %s' % (batchCmd, hostName)
-                return 'LXPLUS'
+                print 'running on CONDOR (using condor file transfer): %s from %s' % (batchCmd, hostName)
+                return 'LXPLUS-CONDOR-TRANSFER'
 
         elif batchCmd == "run_condor_simple.sh":
             if not onLxplus:
                 err = 'Cannot run %s on %s' % (batchCmd, hostName)
                 raise ValueError( err )
             else:
-                print 'running on CONDOR (simplified version) : %s from %s' % (batchCmd, hostName)
-                return 'LXPLUS-SIMPLE'
+                print 'running on CONDOR (simple shared-filesystem version) : %s from %s' % (batchCmd, hostName)
+                return 'LXPLUS-CONDOR-SIMPLE'
 
         elif batchCmd == "qsub":
             if onPSI:

--- a/PhysicsTools/HeppyCore/python/utils/batchmanager.py
+++ b/PhysicsTools/HeppyCore/python/utils/batchmanager.py
@@ -43,8 +43,9 @@ class BatchManager:
                                 dest="negate", default=False,
                                 help="create jobs, but does not submit the jobs.")
         self.parser_.add_option("-b", "--batch", dest="batch",
-                                help="batch command. default is: 'bsub -q 8nh < batchScript.sh'. You can also use 'nohup < ./batchScript.sh &' to run locally.",
-                                default="bsub -q 8nh < ./batchScript.sh")
+                                help="batch command. default is: 'run_condor.sh'. You can also use 'nohup < ./batchScript.sh &' to run locally.",
+                                default='run_condor.sh batchScript.sh')
+                                #default="bsub -q 8nh < ./batchScript.sh")
         self.parser_.add_option( "--option",
                                 dest="extraOptions",
                                 type="string",
@@ -242,13 +243,14 @@ class BatchManager:
 
     def RunningMode(self, batch):
 
-        '''Return "LXPUS", "PSI", "NAF", "LOCAL", or None,
+        '''Return "LXPLUS", "PSI", "NAF", "LOCAL", or None,
 
-        "LXPLUS" : batch command is bsub, and logged on lxplus
-        "PSI"    : batch command is qsub, and logged to t3uiXX
-        "NAF"    : batch command is qsub, and logged on naf
-        "IC"     : batch command is qsub, and logged on hep.ph.ic.ac.uk
-        "LOCAL"  : batch command is nohup.
+        "LXPLUS-LSF" : batch command is bsub, and logged on lxplus
+        "LXPLUS"     : batch command is condor, and logged on lxplus
+        "PSI"        : batch command is qsub, and logged to t3uiXX
+        "NAF"        : batch command is qsub, and logged on naf
+        "IC"         : batch command is qsub, and logged on hep.ph.ic.ac.uk
+        "LOCAL"      : batch command is nohup.
 
         In all other cases, a CmsBatchException is raised
         '''
@@ -267,6 +269,14 @@ class BatchManager:
                 raise ValueError( err )
             else:
                 print 'running on LSF : %s from %s' % (batchCmd, hostName)
+                return 'LXPLUS-LSF'
+
+        elif batchCmd == "run_condor.sh":
+            if not onLxplus:
+                err = 'Cannot run %s on %s' % (batchCmd, hostName)
+                raise ValueError( err )
+            else:
+                print 'running on CONDOR : %s from %s' % (batchCmd, hostName)
                 return 'LXPLUS'
 
         elif batchCmd == "qsub":
@@ -286,6 +296,7 @@ class BatchManager:
         elif batchCmd == 'nohup' or batchCmd == './batchScript.sh':
             print 'running locally : %s on %s' % (batchCmd, hostName)
             return 'LOCAL'
+
         else:
             err = 'unknown batch command: X%sX' % batchCmd
             raise ValueError( err )

--- a/PhysicsTools/HeppyCore/scripts/heppy_batch.py
+++ b/PhysicsTools/HeppyCore/scripts/heppy_batch.py
@@ -85,7 +85,6 @@ cd cmssw
 tar xzf ../src.tar.gz
 cd src
 eval `scramv1 runtime -sh`
-scram b
 cd $_CONDOR_JOB_IWD
 mkdir -p chunk
 cd chunk

--- a/PhysicsTools/HeppyCore/scripts/heppy_batch.py
+++ b/PhysicsTools/HeppyCore/scripts/heppy_batch.py
@@ -74,6 +74,35 @@ exit $?
    return script
 
 def batchScriptCERN( jobDir, remoteDir=''):
+   script = """#!/bin/bash  
+if [ -f cmgdataset.tar.gz ]; then
+  tar xzf cmgdataset.tar.gz
+fi
+source /cvmfs/cms.cern.ch/cmsset_default.sh
+export SCRAM_ARCH={scram_arch}
+scramv1 project -n cmssw CMSSW {cmssw_version}
+cd cmssw
+tar xzf ../src.tar.gz
+cd src
+eval `scramv1 runtime -sh`
+scram b
+cd $_CONDOR_JOB_IWD
+mkdir -p chunk
+cd chunk
+tar xzf ../chunk.tar.gz
+export HOSTNAME
+export HOME=$_CONDOR_JOB_IWD
+export USER=""
+python $CMSSW_BASE/src/PhysicsTools/HeppyCore/python/framework/looper.py pycfg.py config.pck
+cd Loop
+tar -czf out.tar.gz *
+mv out.tar.gz $_CONDOR_JOB_IWD
+""".format(scram_arch = os.environ['SCRAM_ARCH'],
+           cmssw_version = os.environ['CMSSW_VERSION']
+           )
+   return script
+
+def batchScriptCERNLSF( jobDir, remoteDir=''):
    '''prepare the LSF version of the batch script, to run on LSF'''
    
    dirCopy = """echo 'sending the logs back'  # will send also root files if copy failed
@@ -305,8 +334,10 @@ class MyBatchManager( BatchManager ):
        scriptFile = open(scriptFileName,'w')
        storeDir = self.remoteOutputDir_.replace('/castor/cern.ch/cms','')
        mode = self.RunningMode(options.batch)
-       if mode == 'LXPLUS':
-           scriptFile.write( batchScriptCERN( jobDir, storeDir ) ) 
+       if mode == 'LXPLUS-LSF':
+           scriptFile.write( batchScriptCERNLSF( jobDir, storeDir ) )
+       elif mode == 'LXPLUS':
+           scriptFile.write( batchScriptCERN( jobDir, storeDir ) )
        elif mode == 'PSI':
            scriptFile.write( batchScriptPSI ( value, jobDir, storeDir ) ) # storeDir not implemented at the moment
        elif mode == 'LOCAL':

--- a/PhysicsTools/HeppyCore/scripts/heppy_batch.py
+++ b/PhysicsTools/HeppyCore/scripts/heppy_batch.py
@@ -336,7 +336,7 @@ class MyBatchManager( BatchManager ):
        scriptFile = open(scriptFileName,'w')
        storeDir = self.remoteOutputDir_.replace('/castor/cern.ch/cms','')
        mode = self.RunningMode(options.batch)
-       if mode in ('LXPLUS-LSF', 'LXPLUS-SIMPLE', 'LXPLUS-CONDOR-TRANSFER'):
+       if mode in ('LXPLUS-LSF', 'LXPLUS-CONDOR-SIMPLE', 'LXPLUS-CONDOR-TRANSFER'):
            scriptFile.write( batchScriptCERN( mode, jobDir, storeDir ) )
        elif mode == 'PSI':
            scriptFile.write( batchScriptPSI ( value, jobDir, storeDir ) ) # storeDir not implemented at the moment
@@ -348,6 +348,7 @@ class MyBatchManager( BatchManager ):
            scriptFile.write( batchScriptPADOVA( value, jobDir) )        
        elif mode == 'IC':
            scriptFile.write( batchScriptIC(jobDir) )
+       else: raise RuntimeError("Unsupported mode %s" % mode)
        scriptFile.close()
        os.system('chmod +x %s' % scriptFileName)
        

--- a/PhysicsTools/HeppyCore/scripts/heppy_batch.py
+++ b/PhysicsTools/HeppyCore/scripts/heppy_batch.py
@@ -178,10 +178,6 @@ echo '==== environment (after) ===='
 echo
 env | sort
 echo
-echo '==== copying job dir to worker ===='
-echo
-cp -rvf $LS_SUBCWD/* .
-echo
 echo '==== running ===='
 python $CMSSW_BASE/src/PhysicsTools/HeppyCore/python/framework/looper.py pycfg.py config.pck --options=options.json
 echo

--- a/PhysicsTools/HeppyCore/scripts/heppy_untarcfg.py
+++ b/PhysicsTools/HeppyCore/scripts/heppy_untarcfg.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+import tarfile
+import os
+import subprocess
+import fnmatch
+
+tarsuffix = 'out.tar.gz'
+
+##_______________________________________________________________||
+def _UnTar(tars,dry_run):
+
+    try:
+        for i in tars:
+            cwd = os.getcwd()
+            directory = os.path.dirname(i)
+            os.chdir(directory)
+            if os.path.isfile('treeProducerSusyAlphaT/tree.root'):
+                continue
+            else:
+                tar = tarfile.open(tarsuffix)
+                if dry_run:
+                    for tarinfo in tar:
+                        print "Extracting" , tarinfo.name, "from", tarsuffix
+                        sys.exit(1)
+                tar.extractall()
+                tar.close()
+                os.chdir(cwd)
+                print 'Extracted in %s directory'  %directory
+    except TypeError:
+        print 'Unable to extract tar'
+
+##_______________________________________________________________||
+def _ListTars(direc,dry_run):
+    
+    try:
+        tarfiles = [os.path.join(dirpath, f)
+            for dirpath, dirnames, files in os.walk(direc)
+                for f in fnmatch.filter(files,tarsuffix)]        
+        if len(tarfiles) == 0:
+            print 'No list formed'
+            sys.exit(1)
+    except ValueError:
+        print 'Could not form list'
+
+    _UnTar(tarfiles,dry_run)
+
+##_______________________________________________________________||
+if __name__ == '__main__':
+
+    import os
+    import sys
+    from optparse import OptionParser
+    
+    parser = OptionParser()
+    parser.add_option("--dry_run",action="store_true", default=False, help="Do not run any commands; only print them")
+
+    (options,args) = parser.parse_args()
+
+    if len(args)>1:
+        print 'Please only provide 1 argument'
+        sys.exit(1)
+    elif len(args) == 0:
+        print 'Please provide the path'
+        sys.exit(1)
+    else:
+        iDir = args[0]
+        if iDir == '.':
+            iDir = os.getcwd()
+        _ListTars(iDir,options.dry_run)

--- a/PhysicsTools/HeppyCore/scripts/heppy_untarcfg.py
+++ b/PhysicsTools/HeppyCore/scripts/heppy_untarcfg.py
@@ -14,18 +14,15 @@ def _UnTar(tars,dry_run):
             cwd = os.getcwd()
             directory = os.path.dirname(i)
             os.chdir(directory)
-            if os.path.isfile('treeProducerSusyAlphaT/tree.root'):
-                continue
-            else:
-                tar = tarfile.open(tarsuffix)
-                if dry_run:
-                    for tarinfo in tar:
-                        print "Extracting" , tarinfo.name, "from", tarsuffix
-                        sys.exit(1)
-                tar.extractall()
-                tar.close()
-                os.chdir(cwd)
-                print 'Extracted in %s directory'  %directory
+            tar = tarfile.open(tarsuffix)
+            if dry_run:
+                for tarinfo in tar:
+                    print "Extracting" , tarinfo.name, "from", tarsuffix
+                    sys.exit(1)
+            tar.extractall()
+            tar.close()
+            os.chdir(cwd)
+            print 'Extracted in %s directory'  %directory
     except TypeError:
         print 'Unable to extract tar'
 

--- a/PhysicsTools/HeppyCore/scripts/run_condor.sh
+++ b/PhysicsTools/HeppyCore/scripts/run_condor.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+updir=$(dirname $(pwd))
+
+if [ ! -f ${updir}/src.tar.gz ]; then
+    tmp_in_dir=`mktemp -d 2>/dev/null || mktemp -d -t 'tmp'`
+    pushd $CMSSW_BASE
+    tar --exclude=.git -czf ${tmp_in_dir}/src.tar.gz src
+    mv ${tmp_in_dir}/src.tar.gz ${updir}
+    rmdir ${tmp_in_dir}
+    popd
+fi
+transfer_input_files=${updir}/src.tar.gz
+
+if [ -d ${HOME}/.cmgdataset ]; then
+    if [ ! -f ${updir}/cmgdataset.tar.gz ]; then
+        pushd $HOME
+        tar -czf ${updir}/cmgdataset.tar.gz .cmgdataset
+        popd
+    fi
+    transfer_input_files=${transfer_input_files},${updir}/cmgdataset.tar.gz
+fi
+
+tar -czf chunk.tar.gz *
+transfer_input_files=${transfer_input_files},chunk.tar.gz
+
+scriptName=${1:-./batchScript.sh}
+echo "Summin"
+echo $X509_USER_PROXY
+
+cat > ./job_desc.cfg <<EOF
+Universe = vanilla
+Executable = ${scriptName}
+use_x509userproxy = true
+Log        = condor_job_\$(Process).log
+Output     = condor_job_\$(Process).out
+Error      = condor_job_\$(Process).error
+should_transfer_files   = YES 
+when_to_transfer_output = ON_EXIT
+transfer_input_files=${transfer_input_files}
+request_memory = 2000
+queue 1
+EOF
+
+# Submit job
+/usr/bin/condor_submit job_desc.cfg

--- a/PhysicsTools/HeppyCore/scripts/run_condor.sh
+++ b/PhysicsTools/HeppyCore/scripts/run_condor.sh
@@ -1,6 +1,28 @@
 #!/bin/bash
 
+if [[ "$1" == "--help" || "$1" == "-h"  || "$1" == "-?" ]] then
+    echo "usage: $0 [ -f flavour | -t max_runtime_in_minutes ] script.sh "
+    exit 1;
+fi
+
+flavour=""
+if [[ "$1" == "-f" && "$2" != "" ]] then
+    flavour=$2;
+    shift; shift
+fi
+maxruntime="-t" # time in minutes
+if [[ "$1" == "-t" && "$2" != "" ]] then
+    if [[ "${flavour}" != "" ]] ; then 
+        echo "Can't set both flavour and maxruntime"; 
+        exit 1; 
+    fi;
+    maxruntime=$$(( $2 * 60 ));
+    shift; shift
+fi
+
 updir=$(dirname $(pwd))
+
+scriptName=${1:-./batchScript.sh}
 
 if [ ! -f ${updir}/src.tar.gz ]; then
     tmp_in_dir=`mktemp -d 2>/dev/null || mktemp -d -t 'tmp'`
@@ -24,7 +46,6 @@ fi
 tar -czf chunk.tar.gz *
 transfer_input_files=${transfer_input_files},chunk.tar.gz
 
-scriptName=${1:-./batchScript.sh}
 
 cat > ./job_desc.cfg <<EOF
 Universe = vanilla
@@ -37,8 +58,12 @@ should_transfer_files   = YES
 when_to_transfer_output = ON_EXIT
 transfer_input_files = ${transfer_input_files}
 request_memory = 2000
-queue 1
 EOF
+
+[[ "${flavour}" != "" ]] && echo "+JobFlavour = \"${flavour}\"" >> ./job_desc.cfg
+[[ "${maxruntime}" != "" ]] && echo "+MaxRuntime = \"${maxruntime}\"" >> ./job_desc.cfg
+
+echo "queue 1" >> ./job_desc.cfg
 
 # Submit job
 /usr/bin/condor_submit job_desc.cfg

--- a/PhysicsTools/HeppyCore/scripts/run_condor.sh
+++ b/PhysicsTools/HeppyCore/scripts/run_condor.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
 
-if [[ "$1" == "--help" || "$1" == "-h"  || "$1" == "-?" ]] then
+if [[ "$1" == "--help" || "$1" == "-h"  || "$1" == "-?" ]]; then
     echo "usage: $0 [ -f flavour | -t max_runtime_in_minutes ] script.sh "
     exit 1;
 fi
 
 flavour=""
-if [[ "$1" == "-f" && "$2" != "" ]] then
+if [[ "$1" == "-f" && "$2" != "" ]]; then
     flavour=$2;
     shift; shift
 fi
 maxruntime="-t" # time in minutes
-if [[ "$1" == "-t" && "$2" != "" ]] then
+if [[ "$1" == "-t" && "$2" != "" ]]; then
     if [[ "${flavour}" != "" ]] ; then 
         echo "Can't set both flavour and maxruntime"; 
         exit 1; 
     fi;
-    maxruntime=$$(( $2 * 60 ));
+    maxruntime=$(( $2 * 60 ));
     shift; shift
 fi
 
@@ -61,7 +61,7 @@ request_memory = 2000
 EOF
 
 [[ "${flavour}" != "" ]] && echo "+JobFlavour = \"${flavour}\"" >> ./job_desc.cfg
-[[ "${maxruntime}" != "" ]] && echo "+MaxRuntime = \"${maxruntime}\"" >> ./job_desc.cfg
+[[ "${maxruntime}" != "" ]] && echo "+MaxRuntime = ${maxruntime}" >> ./job_desc.cfg
 
 echo "queue 1" >> ./job_desc.cfg
 

--- a/PhysicsTools/HeppyCore/scripts/run_condor.sh
+++ b/PhysicsTools/HeppyCore/scripts/run_condor.sh
@@ -25,8 +25,6 @@ tar -czf chunk.tar.gz *
 transfer_input_files=${transfer_input_files},chunk.tar.gz
 
 scriptName=${1:-./batchScript.sh}
-echo "Summin"
-echo $X509_USER_PROXY
 
 cat > ./job_desc.cfg <<EOF
 Universe = vanilla

--- a/PhysicsTools/HeppyCore/scripts/run_condor.sh
+++ b/PhysicsTools/HeppyCore/scripts/run_condor.sh
@@ -5,7 +5,7 @@ updir=$(dirname $(pwd))
 if [ ! -f ${updir}/src.tar.gz ]; then
     tmp_in_dir=`mktemp -d 2>/dev/null || mktemp -d -t 'tmp'`
     pushd $CMSSW_BASE
-    tar --exclude=.git -czf ${tmp_in_dir}/src.tar.gz src
+    tar --exclude=.git -czf ${tmp_in_dir}/src.tar.gz src lib bin python
     mv ${tmp_in_dir}/src.tar.gz ${updir}
     rmdir ${tmp_in_dir}
     popd

--- a/PhysicsTools/HeppyCore/scripts/run_condor.sh
+++ b/PhysicsTools/HeppyCore/scripts/run_condor.sh
@@ -30,12 +30,12 @@ cat > ./job_desc.cfg <<EOF
 Universe = vanilla
 Executable = ${scriptName}
 use_x509userproxy = true
-Log        = condor_job_\$(Process).log
-Output     = condor_job_\$(Process).out
-Error      = condor_job_\$(Process).error
+Log        = condor_job_\$(ProcId).log
+Output     = condor_job_\$(ProcId).out
+Error      = condor_job_\$(ProcId).error
 should_transfer_files   = YES 
 when_to_transfer_output = ON_EXIT
-transfer_input_files=${transfer_input_files}
+transfer_input_files = ${transfer_input_files}
 request_memory = 2000
 queue 1
 EOF

--- a/PhysicsTools/HeppyCore/scripts/run_condor_simple.sh
+++ b/PhysicsTools/HeppyCore/scripts/run_condor_simple.sh
@@ -1,22 +1,45 @@
 #!/bin/bash
 
+if [[ "$1" == "--help" || "$1" == "-h"  || "$1" == "-?" ]] then
+    echo "usage: $0 [ -f flavour | -t max_runtime_in_minutes ] script.sh "
+    exit 1;
+fi
+
+flavour=""
+if [[ "$1" == "-f" && "$2" != "" ]] then
+    flavour=$2;
+    shift; shift
+fi
+maxruntime="-t" # time in minutes
+if [[ "$1" == "-t" && "$2" != "" ]] then
+    if [[ "${flavour}" != "" ]] ; then 
+        echo "Can't set both flavour and maxruntime"; 
+        exit 1; 
+    fi;
+    maxruntime=$$(( $2 * 60 ));
+    shift; shift
+fi
+
 here=$(pwd)
 
 scriptName=${1:-./batchScript.sh}
 
 cat > ./job_desc.cfg <<EOF
-Universe          = vanilla
-Executable        = ${scriptName}
-Log               = condor_job_\$(ProcId).log
-Output            = condor_job_\$(ProcId).out
-Error             = condor_job_\$(ProcId).error
-getenv            = True
-environment       = "LS_SUBCWD=${here}"
+Universe = vanilla
+Executable = ${scriptName}
 use_x509userproxy = true
-request_memory    = 2000
-+JobFlavour       = "espresso"
-queue 1
+Log        = condor_job_\$(ProcId).log
+Output     = condor_job_\$(ProcId).out
+Error      = condor_job_\$(ProcId).error
+getenv      = True
+environment = "LS_SUBCWD=${here}"
+request_memory = 2000
 EOF
+
+[[ "${flavour}" != "" ]] && echo "+JobFlavour = \"${flavour}\"" >> ./job_desc.cfg
+[[ "${maxruntime}" != "" ]] && echo "+MaxRuntime = \"${maxruntime}\"" >> ./job_desc.cfg
+
+echo "queue 1" >> ./job_desc.cfg
 
 # Submit job
 /usr/bin/condor_submit job_desc.cfg

--- a/PhysicsTools/HeppyCore/scripts/run_condor_simple.sh
+++ b/PhysicsTools/HeppyCore/scripts/run_condor_simple.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
 
-if [[ "$1" == "--help" || "$1" == "-h"  || "$1" == "-?" ]] then
+if [[ "$1" == "--help" || "$1" == "-h"  || "$1" == "-?" ]]; then
     echo "usage: $0 [ -f flavour | -t max_runtime_in_minutes ] script.sh "
     exit 1;
 fi
 
 flavour=""
-if [[ "$1" == "-f" && "$2" != "" ]] then
+if [[ "$1" == "-f" && "$2" != "" ]]; then
     flavour=$2;
     shift; shift
 fi
 maxruntime="-t" # time in minutes
-if [[ "$1" == "-t" && "$2" != "" ]] then
-    if [[ "${flavour}" != "" ]] ; then 
+if [[ "$1" == "-t" && "$2" != "" ]]; then
+    if [[ "${flavour}" != "" ]]; then 
         echo "Can't set both flavour and maxruntime"; 
         exit 1; 
     fi;
-    maxruntime=$$(( $2 * 60 ));
+    maxruntime=$(( $2 * 60 ));
     shift; shift
 fi
 
@@ -37,7 +37,7 @@ request_memory = 2000
 EOF
 
 [[ "${flavour}" != "" ]] && echo "+JobFlavour = \"${flavour}\"" >> ./job_desc.cfg
-[[ "${maxruntime}" != "" ]] && echo "+MaxRuntime = \"${maxruntime}\"" >> ./job_desc.cfg
+[[ "${maxruntime}" != "" ]] && echo "+MaxRuntime = ${maxruntime}" >> ./job_desc.cfg
 
 echo "queue 1" >> ./job_desc.cfg
 

--- a/PhysicsTools/HeppyCore/scripts/run_condor_simple.sh
+++ b/PhysicsTools/HeppyCore/scripts/run_condor_simple.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+here=$(pwd)
+
+scriptName=${1:-./batchScript.sh}
+
+cat > ./job_desc.cfg <<EOF
+Universe          = vanilla
+Executable        = ${scriptName}
+Log               = condor_job_\$(ProcId).log
+Output            = condor_job_\$(ProcId).out
+Error             = condor_job_\$(ProcId).error
+getenv            = True
+environment       = "LS_SUBCWD=${here}"
+use_x509userproxy = true
+request_memory    = 2000
++JobFlavour       = "espresso"
+queue 1
+EOF
+
+# Submit job
+/usr/bin/condor_submit job_desc.cfg


### PR DESCRIPTION
Starting from #713 by @shane-breeze and changing some things:
 * when using the HTCondor transfer, ship also the lib, bin and python directory to avoid compiling on the worker node
 * implement also HTCondor submission using the AFS shared filesystem
 * allow specifying the max job duration (cern condor default is 20 mins, which is usually too short)
 * allow remote stage out of trees to EOS also from HTCondor jobs 

This PR keeps LSF as default, but all three submission modes are possible. E.g. for a job of about 4 hours wall clock time:
 * To run on LSF, do <br>`heppy_batch.py  ....  -b 'bsub -q 8nh < batchScript.sh'`
 * To run on Condor using AFS<br> `heppy_batch.py  ....  -b 'run_condor_simple.sh -t 240 < batchScript.sh'`
 * To run on Condor using Condor transfer<br> `heppy_batch.py  ....  -b 'run_condor.sh -t 240 < batchScript.sh'`

Note that when using Condor transfer one must run `heppy_untarcfg.py .` in the output directory after the jobs are complete, while when using AFS it behaves like LSF so it needs no untarring.