### PR TITLE
Heppy: Fall17 electron ID and other minor additions for 94X

### DIFF
--- a/PhysicsTools/Heppy/python/analyzers/objects/LeptonAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/LeptonAnalyzer.py
@@ -413,6 +413,18 @@ class LeptonAnalyzer( Analyzer ):
               else:              ele.EffectiveArea03 = 0.2393
               # warning: EAs not computed for cone DR=0.4 yet. Do not correct
               ele.EffectiveArea04 = 0.0
+          elif self.eleEffectiveArea == "Fall17":
+              SCEta = abs(ele.superCluster().eta())
+              ## from RecoEgamma/ElectronIdentification/data/Fall17/effAreaElectrons_cone03_pfNeuHadronsAndPhotons_92X.txt
+              if   SCEta < 1.000: ele.EffectiveArea03 = 0.1566
+              elif SCEta < 1.479: ele.EffectiveArea03 = 0.1626
+              elif SCEta < 2.000: ele.EffectiveArea03 = 0.1073
+              elif SCEta < 2.200: ele.EffectiveArea03 = 0.0854
+              elif SCEta < 2.300: ele.EffectiveArea03 = 0.1051
+              elif SCEta < 2.400: ele.EffectiveArea03 = 0.1204
+              else:               ele.EffectiveArea03 = 0.1524
+              # warning: EAs not computed for cone DR=0.4 yet. Do not correct
+              ele.EffectiveArea04 = 0.0
           else: raise RuntimeError,  "Unsupported value for ele_effectiveAreas: can only use Data2012 (rho: ?), Phys14_v1 and Spring15_v1 (rho: fixedGridRhoFastjetAll)"
 
         # Electron scale calibrations

--- a/PhysicsTools/Heppy/python/analyzers/objects/LeptonAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/LeptonAnalyzer.py
@@ -310,7 +310,7 @@ class LeptonAnalyzer( Analyzer ):
               elif aeta < 2.000: mu.EffectiveArea03 = 0.0363
               elif aeta < 2.200: mu.EffectiveArea03 = 0.0119
               else:              mu.EffectiveArea03 = 0.0064
-              mu.EffectiveArea04 = 0 # not computed
+              mu.EffectiveArea04 = mu.EffectiveArea03*16./9. # not computed, scaled from dR=0.3
           else: raise RuntimeError,  "Unsupported value for mu_effectiveAreas: can only use Data2012 (rho: ?) and Phys14_25ns_v1 or Spring15_25ns_v1 (rho: fixedGridRhoFastjetAll)"
         # Attach the vertex to them, for dxy/dz calculation
         goodVertices = getattr(event, self.vertexChoice)
@@ -431,8 +431,8 @@ class LeptonAnalyzer( Analyzer ):
               elif SCEta < 2.300: ele.EffectiveArea03 = 0.1051
               elif SCEta < 2.400: ele.EffectiveArea03 = 0.1204
               else:               ele.EffectiveArea03 = 0.1524
-              # warning: EAs not computed for cone DR=0.4 yet. Do not correct
-              ele.EffectiveArea04 = 0.0
+              # warning: EAs not computed for cone DR=0.4, use the values for DR=0.3 scaled by 16/9 instead
+              ele.EffectiveArea04 = ele.EffectiveArea03*16./9.
           else: raise RuntimeError,  "Unsupported value for ele_effectiveAreas: can only use Data2012 (rho: ?), Phys14_v1 and Spring15_v1 (rho: fixedGridRhoFastjetAll)"
 
         # Electron scale calibrations

--- a/PhysicsTools/Heppy/python/analyzers/objects/LeptonAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/LeptonAnalyzer.py
@@ -303,6 +303,14 @@ class LeptonAnalyzer( Analyzer ):
               elif aeta < 2.200: mu.EffectiveArea03 = 0.0433
               else:              mu.EffectiveArea03 = 0.0577
               mu.EffectiveArea04 = 0 # not computed
+          elif self.muEffectiveArea == "Fall17":
+              aeta = abs(mu.eta())
+              if   aeta < 0.800: mu.EffectiveArea03 = 0.0566
+              elif aeta < 1.300: mu.EffectiveArea03 = 0.0562
+              elif aeta < 2.000: mu.EffectiveArea03 = 0.0363
+              elif aeta < 2.200: mu.EffectiveArea03 = 0.0119
+              else:              mu.EffectiveArea03 = 0.0064
+              mu.EffectiveArea04 = 0 # not computed
           else: raise RuntimeError,  "Unsupported value for mu_effectiveAreas: can only use Data2012 (rho: ?) and Phys14_25ns_v1 or Spring15_25ns_v1 (rho: fixedGridRhoFastjetAll)"
         # Attach the vertex to them, for dxy/dz calculation
         goodVertices = getattr(event, self.vertexChoice)

--- a/PhysicsTools/Heppy/python/analyzers/objects/autophobj.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/autophobj.py
@@ -195,6 +195,7 @@ jetType = NTupleObjectType("jet",  baseObjectTypes = [ fourVectorType ], variabl
     NTupleVariable("btagCSV",   lambda x : x.btag('pfCombinedInclusiveSecondaryVertexV2BJetTags'), help="CSV-IVF v2 discriminator"),
 #    NTupleVariable("btagCMVA",  lambda x : x.btag('pfCombinedMVABJetTags'), help="CMVA discriminator"),
     NTupleVariable("btagCMVA",  lambda x : x.btag('pfCombinedMVAV2BJetTags'), help="CMVA discriminator"),
+    NTupleVariable("btagDeepCSV", lambda x : (lambda y: -99 if isnan(y) else y)(x.btag('pfDeepCSVJetTags:probb')+x.btag('pfDeepCSVJetTags:probbb')), help="DeepCSV discriminator, BvsAll = b+bb"),
     NTupleVariable("rawPt",  lambda x : x.pt() * x.rawFactor(), help="p_{T} before JEC"),
     NTupleVariable("mcPt",   lambda x : x.mcJet.pt() if getattr(x,"mcJet",None) else 0., mcOnly=True, help="p_{T} of associated gen jet"),
     NTupleVariable("mcFlavour", lambda x : x.partonFlavour(), int,     mcOnly=True, help="parton flavour (physics definition, i.e. including b's from shower)"),

--- a/PhysicsTools/Heppy/python/analyzers/objects/autophobj.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/autophobj.py
@@ -214,6 +214,7 @@ jetTypeExtra = NTupleObjectType("jetExtra",  baseObjectTypes = [ jetType ], vari
     NTupleVariable("qgl",   lambda x :x.qgl() , float, mcOnly=False,help="QG Likelihood"),
     NTupleVariable("ptd",   lambda x : getattr(x.computeQGvars(),'ptd', 0), float, mcOnly=False,help="QG input variable: ptD"),
     NTupleVariable("axis2",   lambda x : getattr(x.computeQGvars(),'axis2', 0) , float, mcOnly=False,help="QG input variable: axis2"),
+    NTupleVariable("axis1",   lambda x : getattr(x.computeQGvars(),'axis1', 0) , float, mcOnly=False,help="QG input variable: axis1"),
     NTupleVariable("mult",   lambda x : getattr(x.computeQGvars(),'mult', 0) , int, mcOnly=False,help="QG input variable: total multiplicity"),
     NTupleVariable("partonId", lambda x : getattr(x,'partonId', 0), int,     mcOnly=True, help="parton flavour (manually matching to status 23 particles)"),
     NTupleVariable("partonMotherId", lambda x : getattr(x,'partonMotherId', 0), int,     mcOnly=True, help="parton flavour (manually matching to status 23 particles)"),

--- a/PhysicsTools/Heppy/python/physicsobjects/Electron.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Electron.py
@@ -45,6 +45,12 @@ class Electron( Lepton ):
         elif id == "MVA_ID_NonTrig_Spring16_VLoose":   return self.mvaIDRun2("Spring16","VLoose")
         elif id == "MVA_ID_NonTrig_Spring16_VLooseIdEmu":   return self.mvaIDRun2("Spring16","VLooseIdEmu")
         elif id == "MVA_ID_NonTrig_Spring16_Tight":    return self.mvaIDRun2("Spring16","Tight")
+        elif id == "MVA_ID_nonIso_Fall17_Loose":       return self.mvaIDRun2("Fall17noIso","Loose")
+        elif id == "MVA_ID_nonIso_Fall17_wp90":        return self.mvaIDRun2("Fall17noIso","wp90")
+        elif id == "MVA_ID_nonIso_Fall17_wp80":        return self.mvaIDRun2("Fall17noIso","wp80")
+        elif id == "MVA_ID_Iso_Fall17_Loose":       return self.mvaIDRun2("Fall17Iso","Loose")
+        elif id == "MVA_ID_Iso_Fall17_wp90":        return self.mvaIDRun2("Fall17Iso","wp90")
+        elif id == "MVA_ID_Iso_Fall17_wp80":        return self.mvaIDRun2("Fall17Iso","wp80")
         elif id.startswith("POG_Cuts_ID_"):
                 return self.cutBasedId(id.replace("POG_Cuts_ID_","POG_"))
         for ID in self.electronIDs():
@@ -230,7 +236,7 @@ class Electron( Lepton ):
                 self._mvaRun2[name] =  self.physObj.userFloat("ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values")
                 return self._mvaRun2[name]
             if name not in ElectronMVAID_ByName: raise RuntimeError, "Unknown electron run2 mva id %s (known ones are: %s)\n" % (name, ElectronMVAID_ByName.keys())
-            if name in ("Spring16HZZ","Spring16GP"):
+            if name in ("Spring16HZZ","Spring16GP","Fall17noIso","Fall17Iso"):
                 if self.event == None: raise RuntimeError, "You need to set electron.event before calling any new MVA"
                 self._mvaRun2[name] = ElectronMVAID_ByName[name](self.physObj, self.event, self.associatedVertex, self.rho, debug)
             else:
@@ -391,6 +397,133 @@ class Electron( Lepton ):
                     c = (a-b)/10
                     cut = min(a,max(b,a-c*(self.pt()-15))) # warning: the _high WP must be looser than the _low one
                     return (val>cut)
+
+            elif name == "Fall17noIso":
+                if wp == 'Loose':
+                    if self.pt() <= 10:
+                        if   eta < 0.8  : return self.mvaRun2(name) > -0.13285867293779202
+                        elif eta < 1.479: return self.mvaRun2(name) > -0.31765300958836074
+                        else            : return self.mvaRun2(name) > -0.0799205914718861
+                    else:
+                        if   eta < 0.8  : return self.mvaRun2(name) > -0.856871961305474
+                        elif eta < 1.479: return self.mvaRun2(name) > -0.8107642141584835
+                        else            : return self.mvaRun2(name) > -0.7179265933023059
+                elif wp == 'wp90':
+                    if self.pt()<=10 and eta<0.8:
+                        c = 0.9165112826974601
+                        tau = 2.7381703555094217
+                        A = 1.03549199648109
+                    elif self.pt()>10 and eta<0.8:
+                        c = 0.9616542816132922
+                        tau = 8.757943837889817
+                        A = 3.1390200321591206
+                    elif self.pt()<=10 and eta<1.479:
+                        c = 0.8655738322220173
+                        tau = 2.4027944652597073
+                        A = 0.7975615613282494
+                    elif self.pt()>10 and eta<1.479:
+                        c = 0.9319258011430132
+                        tau = 8.846057432565809
+                        A = 3.5985063793347787
+                    elif self.pt()<=10:
+                        c = -3016.035055227131
+                        tau = -52140.61856333602
+                        A = -3016.3029387236506
+                    elif self.pt()>10:
+                        c = 0.8899260780999244
+                        tau = 10.124234115859881
+                        A = 4.352791250718547
+                    return self.mvaRun2(name) > c-A*exp(-self.pt()/tau)
+                elif wp == 'wp80':
+                    if self.pt()<=10 and eta<0.8:
+                        c = 0.9530240956555949
+                        tau = 2.7591425841003647
+                        A = 0.4669644718545271
+                    elif self.pt()>10 and eta<0.8:
+                        c = 0.9825268564943458
+                        tau = 8.702601455860762
+                        A = 1.1974861596609097
+                    elif self.pt()<=10 and eta<1.479:
+                        c = 0.9336564763961019
+                        tau = 2.709276284272272
+                        A = 0.33512286599215946
+                    elif self.pt()>10 and eta<1.479:
+                        c = 0.9727509457929913
+                        tau = 8.179525631018565
+                        A = 1.7111755094657688
+                    elif self.pt()<=10:
+                        c = 0.9313133688365339
+                        tau = 1.5821934800715558
+                        A = 3.8889462619659265
+                    elif self.pt()>10:
+                        c = 0.9562619539540145
+                        tau = 8.109845366281608
+                        A = 3.013927699126942
+                    return self.mvaRun2(name) > c-A*exp(-self.pt()/tau)
+
+            elif name == "Fall17Iso":
+                if wp == 'Loose':
+                    if self.pt() <= 10:
+                        if   eta < 0.8  : return self.mvaRun2(name) > -0.09564086146419018
+                        elif eta < 1.479: return self.mvaRun2(name) > -0.28229916981926795
+                        else            : return self.mvaRun2(name) > -0.05466682296962322
+                    else:
+                        if   eta < 0.8  : return self.mvaRun2(name) > -0.833466688584422
+                        elif eta < 1.479: return self.mvaRun2(name) > -0.7677000247570116
+                        else            : return self.mvaRun2(name) > -0.6917305995653829
+                elif wp == 'wp90':
+                    if self.pt()<=10 and eta<0.8:
+                        c = 0.9387070396095831
+                        tau = 2.6525585228167636
+                        A = 0.8222647164151365
+                    elif self.pt()>10 and eta<0.8:
+                        c = 0.9717674837607253
+                        tau = 8.912850985100356
+                        A = 1.9712414940437244
+                    elif self.pt()<=10 and eta<1.479:
+                        c = 0.8948802925677235
+                        tau = 2.7645670358783523
+                        A = 0.4123381218697539
+                    elif self.pt()>10 and eta<1.479:
+                        c = 0.9458745023265976
+                        tau = 8.83104420392795
+                        A = 2.40849932040698
+                    elif self.pt()<=10:
+                        c = -1830.8583661119892
+                        tau = -36578.11055382301
+                        A = -1831.2083578116517
+                    elif self.pt()>10:
+                        c = 0.8979112012086751
+                        tau = 9.814082144168015
+                        A = 4.171581694893849
+                    return self.mvaRun2(name) > c-A*exp(-self.pt()/tau)
+                elif wp == 'wp80':
+                    if self.pt()<=10 and eta<0.8:
+                        c = 0.9725509559754997
+                        tau = 2.976593261509491
+                        A = 0.2653858736397496
+                    elif self.pt()>10 and eta<0.8:
+                        c = 0.9896562087723659
+                        tau = 10.342490511998674
+                        A = 0.40204156417414094
+                    elif self.pt()<=10 and eta<1.479:
+                        c = 0.9508038141601247
+                        tau = 2.6633500558725713
+                        A = 0.2355820499260076
+                    elif self.pt()>10 and eta<1.479:
+                        c = 0.9819232656533827
+                        tau = 9.05548836482051
+                        A = 0.772674931169389
+                    elif self.pt()<=10:
+                        c = 0.9365037167596238
+                        tau = 1.5765442323949856
+                        A = 3.067015289215309
+                    elif self.pt()>10:
+                        c = 0.9625098201744635
+                        tau = 8.42589315557279
+                        A = 2.2916152615134173
+                    return self.mvaRun2(name) > c-A*exp(-self.pt()/tau)
+
             else: raise RuntimeError, "Ele MVA ID type not found"
 
     def dEtaInSeed(self):

--- a/PhysicsTools/Heppy/python/physicsobjects/Jet.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Jet.py
@@ -314,6 +314,9 @@ class Jet(PhysicsObject):
 
        if a+b-delta > 0: jet.axis2 = -math.log(math.sqrt(0.5*(a+b-delta)))
        else: jet.axis2 = -1.                                              
+       if a+b+delta > 0: jet.axis1 = -math.log(math.sqrt(0.5*(a+b+delta)))
+       else: jet.axis1 = -1.
+
        return jet	
    
 

--- a/PhysicsTools/Heppy/python/physicsutils/ElectronMVAID.py
+++ b/PhysicsTools/Heppy/python/physicsutils/ElectronMVAID.py
@@ -39,6 +39,24 @@ class ElectronMVAID_Spring16:
             self._init = True
         return self.estimator.mvaValue(ele,event)
 
+class ElectronMVAID_Fall17:
+    def __init__(self,name,tag,flavor,*xmls):
+        self.name = name
+        self.tag = tag
+        self.flavor = flavor
+        self.sxmls = ROOT.vector(ROOT.string)()
+        for x in xmls: self.sxmls.push_back(x)
+        self._init = False
+    def __call__(self,ele,event,vtx,rho,debug=False):
+        if not self._init:
+            ROOT.gSystem.Load("libRecoEgammaElectronIdentification")
+            if self.flavor=='noIso': self.estimator = ROOT.ElectronMVAEstimatorRun2Fall17(self.tag,self.name,False)
+            elif self.flavor=='Iso': self.estimator = ROOT.ElectronMVAEstimatorRun2Fall17(self.tag,self.name,True)
+            else: raise RuntimeError, 'Undefined flavor of ElectronMVAID_Fall17'
+            self.estimator.init(self.sxmls)
+            self._init = True
+        return self.estimator.mvaValue(ele,event)
+
 
 
 ElectronMVAID_Trig = ElectronMVAID("BDT", "Trig", 
@@ -109,6 +127,22 @@ ElectronMVAID_Spring16GP = ElectronMVAID_Spring16("ElectronMVAEstimatorRun2Sprin
     "RecoEgamma/ElectronIdentification/data/Spring16_GeneralPurpose_V1/electronID_mva_Spring16_GeneralPurpose_V1_EB2_10.weights.xml",
     "RecoEgamma/ElectronIdentification/data/Spring16_GeneralPurpose_V1/electronID_mva_Spring16_GeneralPurpose_V1_EE_10.weights.xml",
 )
+ElectronMVAID_Fall17noIso = ElectronMVAID_Fall17("ElectronMVAEstimatorRun2Fall17","V1","noIso",
+    "RecoEgamma/ElectronIdentification/data/Fall17/EIDmva_EB1_5_2017_puinfo_BDT.weights.xml",
+    "RecoEgamma/ElectronIdentification/data/Fall17/EIDmva_EB2_5_2017_puinfo_BDT.weights.xml",
+    "RecoEgamma/ElectronIdentification/data/Fall17/EIDmva_EE_5_2017_puinfo_BDT.weights.xml",
+    "RecoEgamma/ElectronIdentification/data/Fall17/EIDmva_EB1_10_2017_puinfo_BDT.weights.xml",
+    "RecoEgamma/ElectronIdentification/data/Fall17/EIDmva_EB2_10_2017_puinfo_BDT.weights.xml",
+    "RecoEgamma/ElectronIdentification/data/Fall17/EIDmva_EE_10_2017_puinfo_BDT.weights.xml"
+)
+ElectronMVAID_Fall17Iso = ElectronMVAID_Fall17("ElectronMVAEstimatorRun2Fall17","V1","Iso",
+    "RecoEgamma/ElectronIdentification/data/Fall17/EIDmva_EB1_5_2017_puinfo_iso_BDT.weights.xml",
+    "RecoEgamma/ElectronIdentification/data/Fall17/EIDmva_EB2_5_2017_puinfo_iso_BDT.weights.xml",
+    "RecoEgamma/ElectronIdentification/data/Fall17/EIDmva_EE_5_2017_puinfo_iso_BDT.weights.xml",
+    "RecoEgamma/ElectronIdentification/data/Fall17/EIDmva_EB1_10_2017_puinfo_iso_BDT.weights.xml",
+    "RecoEgamma/ElectronIdentification/data/Fall17/EIDmva_EB2_10_2017_puinfo_iso_BDT.weights.xml",
+    "RecoEgamma/ElectronIdentification/data/Fall17/EIDmva_EE_10_2017_puinfo_iso_BDT.weights.xml"
+)
 
 ElectronMVAID_ByName = {
     'Trig':ElectronMVAID_Trig,
@@ -121,4 +155,6 @@ ElectronMVAID_ByName = {
     'NonTrigPhys14':ElectronMVAID_NonTrigPhys14,
     'Spring16HZZ':ElectronMVAID_Spring16HZZ,
     'Spring16GP':ElectronMVAID_Spring16GP,
+    'Fall17noIso':ElectronMVAID_Fall17noIso,
+    'Fall17Iso':ElectronMVAID_Fall17Iso,
 }

--- a/PhysicsTools/HeppyCore/scripts/run_condor.sh
+++ b/PhysicsTools/HeppyCore/scripts/run_condor.sh
@@ -50,7 +50,7 @@ transfer_input_files=${transfer_input_files},chunk.tar.gz
 cat > ./job_desc.cfg <<EOF
 Universe = vanilla
 Executable = ${scriptName}
-use_x509userproxy = true
+use_x509userproxy = $ENV(X509_USER_PROXY)
 Log        = condor_job_\$(ProcId).log
 Output     = condor_job_\$(ProcId).out
 Error      = condor_job_\$(ProcId).error

--- a/PhysicsTools/HeppyCore/scripts/run_condor_simple.sh
+++ b/PhysicsTools/HeppyCore/scripts/run_condor_simple.sh
@@ -27,7 +27,7 @@ scriptName=${1:-./batchScript.sh}
 cat > ./job_desc.cfg <<EOF
 Universe = vanilla
 Executable = ${scriptName}
-use_x509userproxy = true
+use_x509userproxy = $ENV(X509_USER_PROXY)
 Log        = condor_job_\$(ProcId).log
 Output     = condor_job_\$(ProcId).out
 Error      = condor_job_\$(ProcId).error


### PR DESCRIPTION
- support Fall17 electron MVA ID (requires separate modifications to RecoEgamma/ to be called)
- added Fall17 effective areas for muons and electrons (but default EA choice not switched)
- added deepCSV BvsAll discriminator to jets
- added jet axis1 variable
- correctly passing certificate environment to condor jobs