### PR TITLE
Support for bulk submission for run_condor_simple.sh

### DIFF
--- a/PhysicsTools/HeppyCore/scripts/heppy_batch.py
+++ b/PhysicsTools/HeppyCore/scripts/heppy_batch.py
@@ -332,6 +332,7 @@ class MyBatchManager( BatchManager ):
        scriptFile = open(scriptFileName,'w')
        storeDir = self.remoteOutputDir_.replace('/castor/cern.ch/cms','')
        mode = self.RunningMode(options.batch)
+       self.mode = mode
        if mode in ('LXPLUS-LSF', 'LXPLUS-CONDOR-SIMPLE', 'LXPLUS-CONDOR-TRANSFER'):
            scriptFile.write( batchScriptCERN( mode, jobDir, storeDir ) )
        elif mode == 'PSI':

--- a/PhysicsTools/HeppyCore/scripts/heppy_batch.py
+++ b/PhysicsTools/HeppyCore/scripts/heppy_batch.py
@@ -103,12 +103,14 @@ pushd $CMSSW_BASE/src
 eval $(scram runtime -sh)
 popd
 echo
+mkdir job
+cd job
 echo '==== copying job dir to worker ===='
 echo
 cp -rvf $LS_SUBCWD/* .
 """
        dirCopy = """
-cp -r Loop/* $LS_SUBCWD
+cp -rv Loop/* $LS_SUBCWD
 if [ $? -ne 0 ]; then
    echo 'ERROR: problem copying job directory back'
 else

--- a/PhysicsTools/HeppyCore/scripts/run_condor.sh
+++ b/PhysicsTools/HeppyCore/scripts/run_condor.sh
@@ -50,7 +50,7 @@ transfer_input_files=${transfer_input_files},chunk.tar.gz
 cat > ./job_desc.cfg <<EOF
 Universe = vanilla
 Executable = ${scriptName}
-use_x509userproxy = $ENV(X509_USER_PROXY)
+use_x509userproxy = \$ENV(X509_USER_PROXY)
 Log        = condor_job_\$(ProcId).log
 Output     = condor_job_\$(ProcId).out
 Error      = condor_job_\$(ProcId).error

--- a/PhysicsTools/HeppyCore/scripts/run_condor_simple.sh
+++ b/PhysicsTools/HeppyCore/scripts/run_condor_simple.sh
@@ -5,6 +5,11 @@ if [[ "$1" == "--help" || "$1" == "-h"  || "$1" == "-?" ]]; then
     exit 1;
 fi
 
+bulk=""
+if [[ "$1" == "--bulk" ]]; then
+    bulk=$2; shift; shift;
+fi
+
 flavour=""
 if [[ "$1" == "-f" && "$2" != "" ]]; then
     flavour=$2;
@@ -21,25 +26,37 @@ if [[ "$1" == "-t" && "$2" != "" ]]; then
 fi
 
 here=$(pwd)
+if [[ "$bulk" != "" ]]; then
+    jobdesc="jobs_desc_${bulk}.cfg"
+    prefix="\$(Chunk)/";
+    here="$here/\$(Chunk)"
+else
+    jobdesc="job_desc.cfg"
+    prefix=""
+fi;
 
 scriptName=${1:-./batchScript.sh}
 
-cat > ./job_desc.cfg <<EOF
+cat > $jobdesc <<EOF
 Universe = vanilla
-Executable = ${scriptName}
-use_x509userproxy = $ENV(X509_USER_PROXY)
-Log        = condor_job_\$(ProcId).log
-Output     = condor_job_\$(ProcId).out
-Error      = condor_job_\$(ProcId).error
+Executable = ${prefix}${scriptName}
+use_x509userproxy = \$ENV(X509_USER_PROXY)
+Log        = ${prefix}condor_job_\$(ProcId).log
+Output     = ${prefix}condor_job_\$(ProcId).out
+Error      = ${prefix}condor_job_\$(ProcId).error
 getenv      = True
 environment = "LS_SUBCWD=${here}"
 request_memory = 2000
 EOF
 
-[[ "${flavour}" != "" ]] && echo "+JobFlavour = \"${flavour}\"" >> ./job_desc.cfg
-[[ "${maxruntime}" != "" ]] && echo "+MaxRuntime = ${maxruntime}" >> ./job_desc.cfg
+[[ "${flavour}" != "" ]] && echo "+JobFlavour = \"${flavour}\"" >> $jobdesc
+[[ "${maxruntime}" != "" ]] && echo "+MaxRuntime = ${maxruntime}" >> $jobdesc
 
-echo "queue 1" >> ./job_desc.cfg
+if [[ "$bulk" != "" ]]; then
+    echo "queue Chunk matching dirs ${bulk}_Chunk*" >> $jobdesc
+else
+    echo "queue 1" >> $jobdesc
+fi;
 
 # Submit job
-/usr/bin/condor_submit job_desc.cfg
+/usr/bin/condor_submit $jobdesc


### PR DESCRIPTION
When running heppy_batch.py using `run_condor_simple.sh` at CERN, and passing the option `-B` (or `--bullk`,  all the chunks of each sample are submitted in one go. This should speed up a lot the submission of big productions that currently are quite slow.

I tested that it works, also for a mix of split and unsplit samples, and that it doesn't break existing submissions, and tested by @peruzzim on a large production.