### PR TITLE
JetID 2017

### DIFF
--- a/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
@@ -402,8 +402,8 @@ class JetAnalyzer( Analyzer ):
         
 
     def testJetID(self, jet):
-        jet.puJetIdPassed = jet.puJetId() 
-        jet.pfJetIdPassed = jet.jetID('POG_PFID_Loose') 
+        jet.puJetIdPassed = jet.puJetId()
+        jet.pfJetIdPassed = jet.jetID('POG_PFID_Tight')
         if self.cfg_ana.relaxJetId:
             return True
         else:

--- a/PhysicsTools/Heppy/python/analyzers/objects/autophobj.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/autophobj.py
@@ -216,6 +216,17 @@ jetTypeExtra = NTupleObjectType("jetExtra",  baseObjectTypes = [ jetType ], vari
     NTupleVariable("partonMotherId", lambda x : getattr(x,'partonMotherId', 0), int,     mcOnly=True, help="parton flavour (manually matching to status 23 particles)"),
     NTupleVariable("nLeptons",   lambda x : len(x.leptons) if  hasattr(x,'leptons') else  0 , float, mcOnly=False,help="Number of associated leptons"),
 ])
+jetTypeID = NTupleObjectType("jetID", baseObjectTypes=[jetType], variables=[
+    NTupleVariable("rawEnergy", lambda x: x.rawEnergy(), float, mcOnly=False, help="energy before JECs"),
+    NTupleVariable("chf", lambda x: x.chargedHadronEnergy()/x.rawEnergy(), float, mcOnly=False, help="charged hadron fraction"),
+    NTupleVariable("nhf", lambda x: x.neutralHadronEnergy()/x.rawEnergy(), float, mcOnly=False, help="neutral hadron fraction"),
+    NTupleVariable("phf", lambda x: x.neutralEmEnergy()/x.rawEnergy(), float, mcOnly=False, help="neutral EM fraction"),
+    NTupleVariable("muf", lambda x: x.muonEnergy()/x.rawEnergy(), float, mcOnly=False, help="muon fraction"),
+    NTupleVariable("elf", lambda x: x.chargedEmEnergy()/x.rawEnergy(), float, mcOnly=False, help="charged EM fraction"),
+    NTupleVariable("chm", lambda x: x.chargedHadronMultiplicity(), int, mcOnly=False, help="charged hadron multiplicity"),
+    NTupleVariable("npr", lambda x: x.chargedMultiplicity() + x.neutralMultiplicity(), int, mcOnly=False, help="number of constituents"),
+    NTupleVariable("npn", lambda x: x.neutralMultiplicity(), int, mcOnly=False, help="neutral hadron multiplicity"),
+])
 
       
 ##------------------------------------------  

--- a/PhysicsTools/Heppy/python/physicsobjects/Jet.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Jet.py
@@ -119,13 +119,17 @@ class Jet(PhysicsObject):
             if   self.jetID("PAG_monoID_Loose") and self.jetID("POG_PFID_Tight") : return 4;
             if   self.jetID("POG_PFID_Tight")  : return 3;
             #elif self.jetID("POG_PFID_Medium") : return 2;  commented this line because this working point doesn't exist anymore (as 12/05/15)
-            elif self.jetID("POG_PFID_Loose")  : return 1;
+            # elif self.jetID("POG_PFID_Loose")  : return 1;
             else                               : return 0;
         
         # jetID from here: https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetID#Recommendations_for_13_TeV_data
-        if name == "POG_PFID_Loose":    return ((eta<2.7 and ((npr>1 and phf<0.99 and nhf<0.99) and (eta>2.4 or (elf<0.99 and chf>0 and chm>0)))) or ((eta>2.7 and eta<3.0) and (nhf<0.98 and phf>0.01 and npn>2)) or (eta>3.0 and (phf<0.90 and npn>10)))
-        if name == "POG_PFID_Tight":    return ((eta<2.7 and ((npr>1 and phf<0.90 and nhf<0.90) and (eta>2.4 or (elf<0.99 and chf>0 and chm>0)))) or ((eta>2.7 and eta<3.0) and (nhf<0.98 and  phf>0.01 and npn>2)) or (eta>3.0 and (phf<0.90 and npn>10)))
-        if name == "POG_PFID_TightLepVeto": return ((eta<2.7 and ((npr>1 and phf<0.90 and nhf<0.90 and muf<0.8) and (eta>2.4 or (elf<0.90 and chf>0 and chm>0)))))
+        if name == "POG_PFID_Loose2016":    return ((eta<2.7 and ((npr>1 and phf<0.99 and nhf<0.99) and (eta>2.4 or (elf<0.99 and chf>0 and chm>0)))) or ((eta>2.7 and eta<3.0) and (nhf<0.98 and phf>0.01 and npn>2)) or (eta>3.0 and (phf<0.90 and npn>10)))
+        if name == "POG_PFID_Tight2016":    return ((eta<2.7 and ((npr>1 and phf<0.90 and nhf<0.90) and (eta>2.4 or (elf<0.99 and chf>0 and chm>0)))) or ((eta>2.7 and eta<3.0) and (nhf<0.98 and  phf>0.01 and npn>2)) or (eta>3.0 and (phf<0.90 and npn>10)))
+        if name == "POG_PFID_TightLepVeto2016": return ((eta<2.7 and ((npr>1 and phf<0.90 and nhf<0.90 and muf<0.8) and (eta>2.4 or (elf<0.90 and chf>0 and chm>0)))))
+        # 2017 jetID from https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetID13TeVRun2017#Preliminary_Recommendations_for
+        if name == "POG_PFID_Tight":    return ((eta<2.7 and ((npr>1 and phf<0.90 and nhf<0.90) and (eta>2.4 or (chf>0 and chm>0)))) or ((eta>2.7 and eta<3.0) and (phf<0.99 and phf>0.02 and npn>2)) or (eta>3.0 and (phf<0.90 and nhf>0.02 and npn>10)))
+        if name == "POG_PFID_TightLepVeto": return ((eta<2.7 and ((npr>1 and phf<0.90 and nhf<0.90 and muf<0.8) and (eta>2.4 or (elf<0.80 and chf>0 and chm>0)))))
+        #
         if name == "VBFHBB_PFID_Loose":  return (npr>1 and phf<0.99 and nhf<0.99);
         if name == "VBFHBB_PFID_Medium": return (npr>1 and phf<0.99 and nhf<0.99) and ((eta<=2.4 and nhf<0.9 and phf<0.9 and elf<0.99 and muf<0.99 and chf>0 and chm>0) or eta>2.4);
         if name == "VBFHBB_PFID_Tight":  return (npr>1 and phf<0.99 and nhf<0.99) and ((eta<=2.4 and nhf<0.9 and phf<0.9 and elf<0.70 and muf<0.70 and chf>0 and chm>0) or eta>2.4);


### PR DESCRIPTION
Updating PF Jet ID based on https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetID13TeVRun2017#Preliminary_Recommendations_for

This removes `POG_PFID_Loose` (which is renamed to `POG_PFID_Loose2016`), since Loose ID is not recommended anymore.

In addition, added a new jet type for jet ID studies.