### PR TITLE
2017 pileup reweighting

### DIFF
--- a/PhysicsTools/Heppy/python/analyzers/core/PileUpAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/core/PileUpAnalyzer.py
@@ -97,20 +97,12 @@ class PileUpAnalyzer( Analyzer ):
             else:
                 self.datafile.cd()
                 self.mchist = self.datahist.Clone('pileup_MC')
-                self.mchist.Clear()
+                self.mchist.Reset()
                 self.currentFile = event.input.events.object().getTFile().GetName()
-                print 'PileupAnalyzer: Obtaining input pileup histogram'
-                event.input.events.object().getTFile().Get("Events").Draw("slimmedAddPileupInfo.getTrueNumInteractions()>>pileup_MC(100, 0, 100)", "slimmedAddPileupInfo.getBunchCrossing()==0")
+                event.input.events.object().getTFile().Get("Events").Draw("slimmedAddPileupInfo.getTrueNumInteractions()>>pileup_MC", "slimmedAddPileupInfo.getBunchCrossing()==0")
                 self.mchist = gPad.GetPrimitive("pileup_MC").Clone() # It's the only method that I get to work
                 self.mchist.Scale( 1 / self.mchist.Integral(0, self.mchist.GetNbinsX() + 1) )
 
-                # import pdb; pdb.set_trace()
-                if self.mchist.GetNbinsX() != self.datahist.GetNbinsX():
-                    raise ValueError('data and mc histograms must have the same number of bins')
-                if self.mchist.GetXaxis().GetXmin() != self.datahist.GetXaxis().GetXmin():
-                    raise ValueError('data and mc histograms must have the same xmin')
-                if self.mchist.GetXaxis().GetXmax() != self.datahist.GetXaxis().GetXmax():
-                    raise ValueError('data and mc histograms must have the same xmax')
 
     def declareHandles(self):
         super(PileUpAnalyzer, self).declareHandles()

--- a/PhysicsTools/Heppy/python/analyzers/core/PileUpAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/core/PileUpAnalyzer.py
@@ -1,4 +1,4 @@
-import os 
+import os
 from PhysicsTools.Heppy.analyzers.core.VertexHistograms import VertexHistograms
 from PhysicsTools.Heppy.analyzers.core.Analyzer import Analyzer
 from PhysicsTools.Heppy.analyzers.core.AutoHandle import AutoHandle
@@ -6,31 +6,31 @@ from PhysicsTools.HeppyCore.statistics.average import Average
 from PhysicsTools.Heppy.physicsutils.PileUpSummaryInfo import PileUpSummaryInfo
 import PhysicsTools.HeppyCore.framework.config as cfg
 
-from ROOT import TFile, TH1F, gROOT, gPad
+from ROOT import TFile, TH1F, gPad
 
 class PileUpAnalyzer( Analyzer ):
     '''Computes pile-up weights for MC from the pile up histograms for MC and data.
     These histograms should be set on the components as
     puFileData, puFileMC attributes, as is done here:
-    
+
     http://cmssw.cvs.cern.ch/cgi-bin/cmssw.cgi/UserCode/CMG/CMGTools/H2TauTau/Colin/test_tauMu_2012_cfg.py?view=markup
 
     THESE HISTOGRAMS MUST BE CONSISTENT, SEE
     https://twiki.cern.ch/twiki/bin/view/CMS/CMGToolsPileUpReweighting#Generating_pile_up_distributions
 
     If the component is not MC, or if the puFileData and puFileMC are not
-    set for the component, the reweighting is not done. 
-    
+    set for the component, the reweighting is not done.
+
     The analyzer sets event.vertexWeight.
     This weight is multiplied to the global event weight, event.eventWeight.
     When using this analyzer, make sure that the VertexAnalyzer is disabled,
     as you would be reweighting the MC PU distribution twice!
-    
+
     Additionally, this analyzer writes in the output an histogram containing the unweighting MC
-    pile-up distribution, to be used in input of the weighting for a later pass. 
-    
-    Example of use: 
-    
+    pile-up distribution, to be used in input of the weighting for a later pass.
+
+    Example of use:
+
     puAna = cfg.Analyzer(
       "PileUpAnalyzer",
       # build unweighted pu distribution using number of pile up interactions if False
@@ -60,9 +60,9 @@ class PileUpAnalyzer( Analyzer ):
         if self.cfg_comp.isEmbed :
           self.cfg_comp.puFileMC   = None
           self.cfg_comp.puFileData = None
-        
-        if not self.autoPU:
-            self.setupInputs()
+
+        self.setupInputs()
+
 
     def setupInputs(self, event=None):
         if self.cfg_comp.isMC or self.cfg_comp.isEmbed:
@@ -74,22 +74,36 @@ class PileUpAnalyzer( Analyzer ):
                 self.datahist = self.datafile.Get('pileup')
                 self.datahist.Scale( 1 / self.datahist.Integral() )
 
-                if self.autoPU:
-                    gROOT.cd()
-                    self.mchist = self.datahist.Clone('pileup_MC')
-                    self.mchist.Clear()
-                    self.currentFile = event.input.events.object().getTFile().GetName()
-                    print 'PileupAnalyzer: Obtaining input pileup histogram'
-                    event.input.events.object().getTFile().Get("Events").Draw("slimmedAddPileupInfo.getTrueNumInteractions()>>pileup_MC(100, 0, 100)", "slimmedAddPileupInfo.getBunchCrossing()==0")
-                    self.mchist = gPad.GetPrimitive("pileup_MC").Clone() # It's the only method that I get to work
-                else:
+                if not self.autoPU:
                     assert( os.path.isfile(os.path.expandvars(self.cfg_comp.puFileMC)) )
 
                     self.mcfile = TFile( self.cfg_comp.puFileMC )
                     self.mchist = self.mcfile.Get('pileup')
-                
+                    self.mchist.Scale( 1 / self.mchist.Integral(0, self.mchist.GetNbinsX() + 1) )
+
+                    # import pdb; pdb.set_trace()
+                    if self.mchist.GetNbinsX() != self.datahist.GetNbinsX():
+                        raise ValueError('data and mc histograms must have the same number of bins')
+                    if self.mchist.GetXaxis().GetXmin() != self.datahist.GetXaxis().GetXmin():
+                        raise ValueError('data and mc histograms must have the same xmin')
+                    if self.mchist.GetXaxis().GetXmax() != self.datahist.GetXaxis().GetXmax():
+                        raise ValueError('data and mc histograms must have the same xmax')
+
+
+    def setupEventInputs(self, event=None):
+        if self.cfg_comp.isMC or self.cfg_comp.isEmbed:
+            if not hasattr(self.cfg_comp,"puFileMC") or (self.cfg_comp.puFileMC is None and self.cfg_comp.puFileData is None):
+                self.enable = False
+            else:
+                self.datafile.cd()
+                self.mchist = self.datahist.Clone('pileup_MC')
+                self.mchist.Clear()
+                self.currentFile = event.input.events.object().getTFile().GetName()
+                print 'PileupAnalyzer: Obtaining input pileup histogram'
+                event.input.events.object().getTFile().Get("Events").Draw("slimmedAddPileupInfo.getTrueNumInteractions()>>pileup_MC(100, 0, 100)", "slimmedAddPileupInfo.getBunchCrossing()==0")
+                self.mchist = gPad.GetPrimitive("pileup_MC").Clone() # It's the only method that I get to work
                 self.mchist.Scale( 1 / self.mchist.Integral(0, self.mchist.GetNbinsX() + 1) )
-                
+
                 # import pdb; pdb.set_trace()
                 if self.mchist.GetNbinsX() != self.datahist.GetNbinsX():
                     raise ValueError('data and mc histograms must have the same number of bins')
@@ -104,12 +118,12 @@ class PileUpAnalyzer( Analyzer ):
             'slimmedAddPileupInfo',
             'std::vector<PileupSummaryInfo>',
             fallbackLabel="addPileupInfo"
-            ) 
+            )
 
         if self.allVertices == '_AUTO_':
-            self.handles['vertices'] =  AutoHandle( "offlineSlimmedPrimaryVertices", 'std::vector<reco::Vertex>', fallbackLabel="offlinePrimaryVertices" ) 
+            self.handles['vertices'] =  AutoHandle( "offlineSlimmedPrimaryVertices", 'std::vector<reco::Vertex>', fallbackLabel="offlinePrimaryVertices" )
         else:
-            self.handles['vertices'] =  AutoHandle( self.allVertices, 'std::vector<reco::Vertex>' ) 
+            self.handles['vertices'] =  AutoHandle( self.allVertices, 'std::vector<reco::Vertex>' )
 
     def beginLoop(self, setup):
         super(PileUpAnalyzer,self).beginLoop(setup)
@@ -120,7 +134,7 @@ class PileUpAnalyzer( Analyzer ):
         self.readCollections( event.input )
 
         if self.autoPU and self.currentFile != event.input.events.object().getTFile().GetName():
-            self.setupInputs(event)
+            self.setupEventInputs(event)
 
         ## if component is embed return (has no trigger obj)
         if self.cfg_comp.isEmbed :
@@ -150,7 +164,7 @@ class PileUpAnalyzer( Analyzer ):
                     for ptHat_zPosition in ptHat_zPositions:
                         event.pileUpVertex_z.append(ptHat_zPosition[1])
                         event.pileUpVertex_ptHat.append(ptHat_zPosition[0])
-            
+
             if event.nPU is None:
                 raise ValueError('nPU cannot be None! means that no pu info has been found for bunch crossing 0.')
         elif self.cfg_comp.isEmbed:
@@ -171,11 +185,11 @@ class PileUpAnalyzer( Analyzer ):
                     event.puWeight = data/mc
                 else:
                     event.puWeight = 1
-                
+
         event.eventWeight *= event.puWeight
         self.averages['puWeight'].add( event.puWeight )
         return True
-        
+
     def write(self, setup):
         super(PileUpAnalyzer, self).write(setup)
         if self.cfg_comp.isMC and self.doHists:
@@ -188,4 +202,3 @@ setattr(PileUpAnalyzer,"defaultConfig", cfg.Analyzer(
     makeHists=False
 )
 )
-


### PR DESCRIPTION
This implements a per-file PU reweighting and mitigates the PU bug in the Fall2017 production.
Enable by setting `autoPU = True`.