### PR TITLE
Lepton isolation update 2

### DIFF
--- a/PhysicsTools/Heppy/python/analyzers/objects/LeptonAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/LeptonAnalyzer.py
@@ -587,7 +587,7 @@ class LeptonAnalyzer( Analyzer ):
         mu.absIsoAn04 = mu.absIsoAnCharged + mu.absIsoAnNeutral
         mu.relIsoAn04 = mu.absIsoAn04/mu.pt()
 
-    def attachIsoAnnealusMiniIso(self, mu):  # annulus isolation with miniIsoR (outer cone based on 0.4, inner on 0.2) and delta beta PU correction
+    def attachIsoAnnealusMiniIso(self, mu):  # annulus isolation with miniIso (outer cone based on 0.4, inner on 0.2) and delta beta PU correction
         mu.miniIsoRin  = 10.0/min(max(mu.pt(), 50),200)
         mu.miniIsoRout = 20.0/min(max(mu.pt(), 50),200)
         mu.absIsoAnCharged = self.IsolationComputer.chargedAbsIso      (mu.physObj, mu.miniIsoRout, mu.miniIsoRin, 0.0, self.IsolationComputer.selfVetoNone)
@@ -802,7 +802,7 @@ setattr(LeptonAnalyzer,"defaultConfig",cfg.Analyzer(
                                      # Choose None to just use the individual object's PU correction
     miniIsolationVetoLeptons = None, # use 'inclusive' to veto inclusive leptons and their footprint in all isolation cones
     doDirectionalIsolation = [], # calculate directional isolation with leptons (works only with doMiniIsolation, pass list of cone sizes)
-    doFixedConeIsoWithMiniIsoVeto = False, # calculate fixed cone isolations with the same vetoes used for miniIsoR,
+    doFixedConeIsoWithMiniIsoVeto = False, # calculate fixed cone isolations with the same vetoes used for miniIso,
     # Activity Annulus
     doIsoAnnulus = False, # off by default since it requires access to all PFCandidates 
     # do MC matching 

--- a/PhysicsTools/Heppy/python/analyzers/objects/LeptonAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/LeptonAnalyzer.py
@@ -452,11 +452,11 @@ class LeptonAnalyzer( Analyzer ):
         # Compute relIso with R=0.3 and R=0.4 cones
         for ele in allelectrons:
             if self.cfg_ana.ele_isoCorr=="rhoArea" :
-                 ele.absIso03 = (ele.chargedHadronIsoR(0.3) + max(ele.neutralHadronIsoR(0.3)+ele.photonIsoR(0.3)-ele.rho*ele.EffectiveArea03,0))
-                 ele.absIso04 = (ele.chargedHadronIsoR(0.4) + max(ele.neutralHadronIsoR(0.4)+ele.photonIsoR(0.4)-ele.rho*ele.EffectiveArea04,0))
+                 ele.absIso03 = (ele.chargedHadronIso(0.3) + max(ele.neutralHadronIso(0.3)+ele.photonIso(0.3)-ele.rho*ele.EffectiveArea03,0))
+                 ele.absIso04 = (ele.chargedHadronIso(0.4) + max(ele.neutralHadronIso(0.4)+ele.photonIso(0.4)-ele.rho*ele.EffectiveArea04,0))
             elif self.cfg_ana.ele_isoCorr=="deltaBeta" :
-                 ele.absIso03 = (ele.chargedHadronIsoR(0.3) + max( ele.neutralHadronIsoR(0.3)+ele.photonIsoR(0.3) - ele.puChargedHadronIsoR(0.3)/2, 0.0))
-                 ele.absIso04 = (ele.chargedHadronIsoR(0.4) + max( ele.neutralHadronIsoR(0.4)+ele.photonIsoR(0.4) - ele.puChargedHadronIsoR(0.4)/2, 0.0))
+                 ele.absIso03 = (ele.chargedHadronIso(0.3) + max( ele.neutralHadronIso(0.3)+ele.photonIso(0.3) - ele.puChargedHadronIso(0.3)/2, 0.0))
+                 ele.absIso04 = (ele.chargedHadronIso(0.4) + max( ele.neutralHadronIso(0.4)+ele.photonIso(0.4) - ele.puChargedHadronIso(0.4)/2, 0.0))
             else :
                  raise RuntimeError("Unsupported ele_isoCorr name '" + str(self.cfg_ana.ele_isoCorr) +  "'! For now only 'rhoArea' and 'deltaBeta' are supported.")
             ele.relIso03 = ele.absIso03/ele.pt()
@@ -587,7 +587,7 @@ class LeptonAnalyzer( Analyzer ):
         mu.absIsoAn04 = mu.absIsoAnCharged + mu.absIsoAnNeutral
         mu.relIsoAn04 = mu.absIsoAn04/mu.pt()
 
-    def attachIsoAnnealusMiniIso(self, mu):  # annulus isolation with miniIso (outer cone based on 0.4, inner on 0.2) and delta beta PU correction
+    def attachIsoAnnealusMiniIso(self, mu):  # annulus isolation with miniIsoR (outer cone based on 0.4, inner on 0.2) and delta beta PU correction
         mu.miniIsoRin  = 10.0/min(max(mu.pt(), 50),200)
         mu.miniIsoRout = 20.0/min(max(mu.pt(), 50),200)
         mu.absIsoAnCharged = self.IsolationComputer.chargedAbsIso      (mu.physObj, mu.miniIsoRout, mu.miniIsoRin, 0.0, self.IsolationComputer.selfVetoNone)
@@ -802,7 +802,7 @@ setattr(LeptonAnalyzer,"defaultConfig",cfg.Analyzer(
                                      # Choose None to just use the individual object's PU correction
     miniIsolationVetoLeptons = None, # use 'inclusive' to veto inclusive leptons and their footprint in all isolation cones
     doDirectionalIsolation = [], # calculate directional isolation with leptons (works only with doMiniIsolation, pass list of cone sizes)
-    doFixedConeIsoWithMiniIsoVeto = False, # calculate fixed cone isolations with the same vetoes used for miniIso,
+    doFixedConeIsoWithMiniIsoVeto = False, # calculate fixed cone isolations with the same vetoes used for miniIsoR,
     # Activity Annulus
     doIsoAnnulus = False, # off by default since it requires access to all PFCandidates 
     # do MC matching 

--- a/PhysicsTools/Heppy/python/analyzers/objects/autophobj.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/autophobj.py
@@ -86,8 +86,8 @@ leptonTypeExtra = NTupleObjectType("leptonExtra", baseObjectTypes = [ leptonType
     # Loose id 
     NTupleVariable("looseIdOnly",   lambda x : x.looseIdOnly, int, help="Loose ID as per LeptonAnalyzer (only what configured in the id part, not also dxy/dz/iso cuts of the lepton analyzer)"),
     # Extra isolation variables
-    NTupleVariable("chargedHadRelIso03",  lambda x : x.chargedHadronIsoR(0.3)/x.pt(), help="PF Rel Iso, R=0.3, charged hadrons only"),
-    NTupleVariable("chargedHadRelIso04",  lambda x : x.chargedHadronIsoR(0.4)/x.pt(), help="PF Rel Iso, R=0.4, charged hadrons only"),
+    NTupleVariable("chargedHadRelIso03",  lambda x : x.chargedHadronIso(0.3)/x.pt(), help="PF Rel Iso, R=0.3, charged hadrons only"),
+    NTupleVariable("chargedHadRelIso04",  lambda x : x.chargedHadronIso(0.4)/x.pt(), help="PF Rel Iso, R=0.4, charged hadrons only"),
     # Extra muon ID working points
     NTupleVariable("softMuonId", lambda x : x.muonID("POG_ID_Soft") if abs(x.pdgId())==13 else 1, int, help="Muon POG Soft id"),
     NTupleVariable("pfMuonId",   lambda x : x.muonID("POG_ID_Loose") if abs(x.pdgId())==13 else 1, int, help="Muon POG Loose id"),

--- a/PhysicsTools/Heppy/python/physicsobjects/Electron.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Electron.py
@@ -5,26 +5,6 @@ import ROOT
 import sys
 from math import exp
 
-effective_areas = dict(
-    ea03 = [
-        (1.000, 0.1440),
-        (1.479, 0.1562),
-        (2.000, 0.1032),
-        (2.200, 0.0859),
-        (2.300, 0.1116),
-        (2.400, 0.1321),
-        (2.500, 0.1654)        
-        ]
-)
-
-def get_effective_area(eta, area):
-    eta = abs(eta)
-    ea_defs = effective_areas[area]
-    for etamax, ea in ea_defs: 
-        if eta < etamax:
-            return ea 
-    return ea_defs[-1][1]
-
 class Electron( Lepton ):
 
     def __init__(self, *args, **kwargs):
@@ -43,8 +23,6 @@ class Electron( Lepton ):
         self._mvaTrigV0     = {True:None, False:None}
         self._mvaTrigNoIPV0 = {True:None, False:None}
         self._mvaRun2 = {}
-        self.effarea_03 = get_effective_area(self.physObj.superCluster().eta(),
-                                             'ea03')
 
     def electronID( self, id, vertex=None, rho=None ):
         if id is None or id == "": return True

--- a/PhysicsTools/Heppy/python/physicsobjects/Electron.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Electron.py
@@ -593,21 +593,21 @@ class Electron( Lepton ):
         '''
         Calculate Isolation, subtract FSR, apply specific PU corrections" 
         '''
-        photonIso = self.photonIsoR(R)
+        photonIso = self.photonIso(R)
         if hasattr(self,'fsrPhotons'):
             for gamma in self.fsrPhotons:
                 dr = deltaR(gamma.eta(), gamma.phi(), self.physObj.eta(), self.physObj.phi())
                 if (self.isEB() or dr > 0.08) and dr < R:
                     photonIso = max(photonIso-gamma.pt(),0.0)                
         if puCorr == "deltaBeta":
-            offset = dBetaFactor * self.puChargedHadronIsoR(R)
+            offset = dBetaFactor * self.puChargedHadronIso(R)
         elif puCorr == "rhoArea":
             offset = self.rho*getattr(self,"EffectiveArea"+(str(R).replace(".","")))
         elif puCorr in ["none","None",None]:
             offset = 0
         else:
              raise RuntimeError("Unsupported PU correction scheme %s" % puCorr)
-        return self.chargedHadronIsoR(R)+max(0.,photonIso+self.neutralHadronIsoR(R)-offset)            
+        return self.chargedHadronIso(R)+max(0.,photonIso+self.neutralHadronIso(R)-offset)            
 
 
     def dxy(self, vertex=None):

--- a/PhysicsTools/Heppy/python/physicsobjects/Electron.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Electron.py
@@ -5,6 +5,25 @@ import ROOT
 import sys
 from math import exp
 
+effective_areas = dict(
+    ea03 = [
+        (1.000, 0.1440),
+        (1.479, 0.1562),
+        (2.000, 0.1032),
+        (2.200, 0.0859),
+        (2.300, 0.1116),
+        (2.400, 0.1321),
+        (2.500, 0.1654)        
+        ]
+)
+
+def get_effective_area(eta, area):
+    eta = abs(eta)
+    ea_defs = effective_areas[area]
+    for etamax, ea in ea_defs: 
+        if eta < etamax:
+            return ea 
+    return ea_defs[-1][1]
 
 class Electron( Lepton ):
 
@@ -24,6 +43,8 @@ class Electron( Lepton ):
         self._mvaTrigV0     = {True:None, False:None}
         self._mvaTrigNoIPV0 = {True:None, False:None}
         self._mvaRun2 = {}
+        self.effarea_03 = get_effective_area(self.physObj.superCluster().eta(),
+                                             'ea03')
 
     def electronID( self, id, vertex=None, rho=None ):
         if id is None or id == "": return True
@@ -565,29 +586,26 @@ class Electron( Lepton ):
         else: isoValue = -999
         return max(0, isoValue - self.rhoHLT*hltEA)
 
-    def chargedHadronIsoR(self,R=0.4):
+    def chargedHadronIso(self,R=0.4):
         if   R == 0.3: return self.physObj.pfIsolationVariables().sumChargedHadronPt
         elif R == 0.4: return self.physObj.chargedHadronIso()
         raise RuntimeError("Electron chargedHadronIso missing for R=%s" % R)
 
-    def neutralHadronIsoR(self,R=0.4):
+    def neutralHadronIso(self,R=0.4):
         if   R == 0.3: return self.physObj.pfIsolationVariables().sumNeutralHadronEt
         elif R == 0.4: return self.physObj.neutralHadronIso()
         raise RuntimeError("Electron neutralHadronIso missing for R=%s" % R)
 
-    def photonIsoR(self,R=0.4):
+    def photonIso(self,R=0.4):
         if   R == 0.3: return self.physObj.pfIsolationVariables().sumPhotonEt
         elif R == 0.4: return self.physObj.photonIso()
         raise RuntimeError("Electron photonIso missing for R=%s" % R)
 
-    def chargedAllIsoR(self,R=0.4):
+    def chargedAllIso(self,R=0.4):
         if   R == 0.3: return self.physObj.pfIsolationVariables().sumChargedParticlePt
         raise RuntimeError("Electron chargedAllIso missing for R=%s" % R)
 
-    def chargedAllIso(self):
-        raise RuntimeError("Electron chargedAllIso missing")
-
-    def puChargedHadronIsoR(self,R=0.4):
+    def puChargedHadronIso(self,R=0.4):
         if   R == 0.3: return self.physObj.pfIsolationVariables().sumPUPt
         elif R == 0.4: return self.physObj.puChargedHadronIso()
         raise RuntimeError("Electron chargedHadronIso missing for R=%s" % R)

--- a/PhysicsTools/Heppy/python/physicsobjects/Lepton.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Lepton.py
@@ -115,22 +115,6 @@ class Lepton( PhysicsObject):
         '''
         return self.relIso(0.4, 'EA', area_cone_size=area_cone_size)
     
-    def absIsoR(self, R=0.4, dbeta_factor=0, all_charged=False):
-        '''Calculate absolute isolation in given cone 
-        with optional delta-beta subtraction.
-        for backward compatibility, should be removed. 
-        '''
-        return self.absIso(R, 'dbeta', dbeta_factor=dbeta_factor,
-                           all_charged = all_charged) 
-    
-    def relIsoR(self, R=0.4, dBetaFactor=0, all_charged=False):
-        '''Calculate relative isolation in given cone 
-        with optional delta-beta subtraction.
-        for backward compatibility, should be removed. 
-        '''
-        return self.relIso(R, 'dbeta', dbeta_factor=dbeta_factor,
-                           all_charged = all_charged) 
-
     def lostInner(self):
         if hasattr(self.innerTrack(),"trackerExpectedHitsInner") :
 		return self.innerTrack().trackerExpectedHitsInner().numberOfLostHits()

--- a/PhysicsTools/Heppy/python/physicsobjects/Lepton.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Lepton.py
@@ -15,7 +15,7 @@ class Lepton( PhysicsObject):
         return abs(db/edb) if edb > 0 else 999.
 
     def absIso(self, cone_size, iso_type, dbeta_factor=None, 
-               area_cone_size=None, area_table=None, all_charged = False):
+               area_table=None, all_charged = False):
         iso_ch = None
         if all_charged:
             iso_ch = self.chargedAllIso(cone_size)
@@ -27,14 +27,13 @@ class Lepton( PhysicsObject):
         if iso_type == 'EA':
             if dbeta_factor:  
                 raise ValueError('using EA iso, do not specify dbeta_factor')
-            if area_cone_size is None: 
-                raise ValueError('using EA iso, provide area_cone_size, e.g. "03"')
             else:
+                area_cone_size = str(cone_size).replace('.','')
                 area = self.effective_area(area_cone_size, area_table)
             corr_neutral = self.rho * area
         elif iso_type == 'dbeta': 
-            if area_cone_size or area_table: 
-                raise ValueError('using delta beta iso, do not specify area_cone_size or area table')
+            if area_table: 
+                raise ValueError('using delta beta iso, do not specify area table')
             if dbeta_factor is None: 
                 raise ValueError('using delta beta iso, provide dbeta_factor')
             iso_photon = self.photonIso(cone_size)
@@ -43,19 +42,17 @@ class Lepton( PhysicsObject):
             iso_puch =  self.puChargedHadronIso(cone_size)
             corr_neutral = dbeta_factor * iso_puch
         elif iso_type == 'raw':
-            if area_cone_size or area_table or dbeta_factor: 
-                raise ValueError('using raw iso, do not specify area_cone_size, area table, or dbeta factor')
+            if area_table or dbeta_factor: 
+                raise ValueError('using raw iso, do not specify area table, or dbeta factor')
             corr_neutral = 0.
         else: 
             raise ValueError('unknown isolation type: '+iso_type)
         return iso_ch + max(0., iso_photon + iso_nh - corr_neutral)     
 
-
-    def relIso(self, cone_size, iso_type, dbeta_factor=None, 
-               area_cone_size=None, area_table=None, all_charged = False):
+    def relIso(self, cone_size, iso_type, dbeta_factor=None,
+               area_table=None, all_charged = False):
         return self.absIso(cone_size, iso_type, 
                            dbeta_factor=dbeta_factor, 
-                           area_cone_size=area_cone_size, 
                            area_table=area_table, 
                            all_charged=all_charged) / self.pt()
 

--- a/PhysicsTools/Heppy/python/physicsobjects/Lepton.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Lepton.py
@@ -5,39 +5,77 @@ class Lepton( PhysicsObject):
     def ip3D(self):
         '''3D impact parameter value.'''
         return abs(self.dB(self.PV3D))
-
+ 
     def sip3D(self):
         '''3D impact parameter significance.'''
         db, edb = self.dB(self.PV3D), self.edB(self.PV3D)
         return abs(db/edb) if edb > 0 else 999.
 
+    def absIso(self, cone_size, iso_type, dbeta_factor=None, area=None, 
+               all_charged = False):
+        iso_ch = None
+        if all_charged:
+            iso_ch = self.chargedAllIso(cone_size)
+        else:
+            iso_ch = self.chargedHadronIso(cone_size)
+        iso_photon = self.photonIso(cone_size)
+        iso_nh = self.neutralHadronIso(cone_size)
+        corr_neutral = None
+        if iso_type == 'EA':
+            if dbeta_factor:  
+                raise ValueError('using EA iso, do not specify dbeta_factor')
+            if area is None: 
+                raise ValueError('using EA iso, provide area, e.g. "03"')
+            elif area != '03':
+                raise ValueError('the only EA iso to be supported is "03"')
+            corr_neutral = self.rho * getattr(self, '_'.join(["effarea", area]))
+        elif iso_type == 'dbeta': 
+            if area: 
+                raise ValueError('using delta beta iso, do not specify area')
+            if dbeta_factor is None: 
+                raise ValueError('using delta beta iso, provide dbeta_factor')
+            iso_photon = self.photonIso(cone_size)
+            iso_ch = self.chargedHadronIso(cone_size)
+            iso_nh = self.neutralHadronIso(cone_size)
+            iso_puch =  self.puChargedHadronIso(cone_size)
+            corr_neutral = dbeta_factor * iso_puch
+        elif iso_type == 'raw':
+            corr_neutral = 0.
+        else: 
+            raise ValueError('unknown isolation type: '+iso_type)
+        return iso_ch + max(0., iso_photon + iso_nh - corr_neutral)     
+
+    def relIso(self, cone_size, iso_type, dbeta_factor=None, area=None, 
+               all_charged = False):
+        return self.absIso(cone_size, iso_type, dbeta_factor, area, all_charged) / self.pt()
+
     def absIsoFromEA(self, area='04'):
-        '''Calculate Isolation using the effective area approach.'''
-        photonIso = self.photonIso()
-        offset = self.rho*getattr(self,"EffectiveArea"+area)
-        return self.chargedHadronIso()+max(0.,photonIso+self.neutralHadronIso()-offset)            
-
+        '''Calculate absolute isolation using the effective area approach, 
+        for backward compatibility, should be removed. 
+        '''
+        return self.absIso(0.4, 'EA', area=area)
+    
     def relIsoFromEA(self, area='04'):
-        return self.absIsoFromEA(area)/self.pt() if self.pt()>0 else -999
-
-    def relIso(self, dBetaFactor=0, allCharged=0):
-        '''Relative isolation with default cone size of 0.4.'''
-        rel = self.absIsoR(dBetaFactor=dBetaFactor, allCharged=allCharged)/self.pt() if self.pt()>0 else -999
-        return rel
-
-    def absIsoR(self, R=0.4, dBetaFactor=0, allCharged=False):
-        '''Isolation in given cone with optional delta-beta subtraction.'''
-        if dBetaFactor>0 and self.puChargedHadronIsoR(R)<0:
-            raise ValueError('If you want to use dbeta corrections, you must make sure that the pu charged hadron iso is available. This should never happen') 
-        neutralIso = self.neutralHadronIsoR(R) + self.photonIsoR(R)
-        corNeutralIso = neutralIso - dBetaFactor * self.puChargedHadronIsoR(R)
-        charged = self.chargedHadronIsoR(R)
-        if allCharged:
-            charged = self.chargedAllIsoR(R)
-        return charged + max(corNeutralIso, 0.)
-
-    def relIsoR(self, R=0.4, dBetaFactor=0, allCharged=False):
-        return self.absIsoR(R, dBetaFactor, allCharged)/self.pt() if self.pt()>0 else -999
+        '''Calculate relative isolation using the effective area approach, 
+        for backward compatibility, should be removed. 
+        '''
+        return self.relIso(0.4, 'EA', area=area)
+    
+    def absIsoR(self, R=0.4, dbeta_factor=0, all_charged=False):
+        '''Calculate absolute isolation in given cone 
+        with optional delta-beta subtraction.
+        for backward compatibility, should be removed. 
+        '''
+        return self.absIso(R, 'dbeta', dbeta_factor=dbeta_factor,
+                           all_charged = all_charged) 
+    
+    def relIsoR(self, R=0.4, dBetaFactor=0, all_charged=False):
+        '''Calculate relative isolation in given cone 
+        with optional delta-beta subtraction.
+        for backward compatibility, should be removed. 
+        '''
+        return self.relIso(R, 'dbeta', dbeta_factor=dbeta_factor,
+                           all_charged = all_charged) 
 
     def lostInner(self):
         if hasattr(self.innerTrack(),"trackerExpectedHitsInner") :

--- a/PhysicsTools/Heppy/python/physicsobjects/Lepton.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Lepton.py
@@ -1,7 +1,10 @@
 from PhysicsTools.Heppy.physicsobjects.PhysicsObject import *
+from PhysicsTools.Heppy.physicsutils.EffectiveAreas import is_ea_table
+
 import ROOT
 
 class Lepton( PhysicsObject):
+
     def ip3D(self):
         '''3D impact parameter value.'''
         return abs(self.dB(self.PV3D))
@@ -11,8 +14,8 @@ class Lepton( PhysicsObject):
         db, edb = self.dB(self.PV3D), self.edB(self.PV3D)
         return abs(db/edb) if edb > 0 else 999.
 
-    def absIso(self, cone_size, iso_type, dbeta_factor=None, area=None, 
-               all_charged = False):
+    def absIso(self, cone_size, iso_type, dbeta_factor=None, 
+               area_cone_size=None, area_table=None, all_charged = False):
         iso_ch = None
         if all_charged:
             iso_ch = self.chargedAllIso(cone_size)
@@ -24,14 +27,14 @@ class Lepton( PhysicsObject):
         if iso_type == 'EA':
             if dbeta_factor:  
                 raise ValueError('using EA iso, do not specify dbeta_factor')
-            if area is None: 
-                raise ValueError('using EA iso, provide area, e.g. "03"')
-            elif area != '03':
-                raise ValueError('the only EA iso to be supported is "03"')
-            corr_neutral = self.rho * getattr(self, '_'.join(["effarea", area]))
+            if area_cone_size is None: 
+                raise ValueError('using EA iso, provide area_cone_size, e.g. "03"')
+            else:
+                area = effective_area(area_cone_size, area_table)
+            corr_neutral = self.rho * area
         elif iso_type == 'dbeta': 
-            if area: 
-                raise ValueError('using delta beta iso, do not specify area')
+            if area_cone_size or area_table: 
+                raise ValueError('using delta beta iso, do not specify area_cone_size or area table')
             if dbeta_factor is None: 
                 raise ValueError('using delta beta iso, provide dbeta_factor')
             iso_photon = self.photonIso(cone_size)
@@ -45,21 +48,41 @@ class Lepton( PhysicsObject):
             raise ValueError('unknown isolation type: '+iso_type)
         return iso_ch + max(0., iso_photon + iso_nh - corr_neutral)     
 
-    def relIso(self, cone_size, iso_type, dbeta_factor=None, area=None, 
-               all_charged = False):
-        return self.absIso(cone_size, iso_type, dbeta_factor, area, all_charged) / self.pt()
 
-    def absIsoFromEA(self, area='04'):
+    def relIso(self, cone_size, iso_type, dbeta_factor=None, 
+               area_cone_size=None, area_table=None,
+               all_charged = False):
+        return self.absIso(cone_size, iso_type, 
+                           dbeta_factor, 
+                           area_cone_size, area_table, 
+                           all_charged) / self.pt()
+
+    def effective_area(area_cone_size, area_table):
+        if area_table and not is_ea_table(area_table):
+            raise ValueError('area_table is not an area table')
+        if area_table is None: 
+            # area table not provided by the user as argument to the isolation method.
+            # try to find it in the object or its class
+            ea_attr_name = ''.join(['EffectiveArea',area_cone_size])
+            area_table = getattr(self, ea_attr_name, None)
+            if area_table is None: 
+                area_table = getattr(self.__class__, ea_attr_name, None)
+                if area_table is None: 
+                    raise ValueError('{} not found. It should be added to the lepton object as an attribute or a class attribute.')
+        return effective_area(self, area_cone_size, area_table)
+
+
+    def absIsoFromEA(self, area_cone_size='04'):
         '''Calculate absolute isolation using the effective area approach, 
         for backward compatibility, should be removed. 
         '''
-        return self.absIso(0.4, 'EA', area=area)
+        return self.absIso(0.4, 'EA', area_cone_size=area_cone_size)
     
-    def relIsoFromEA(self, area='04'):
+    def relIsoFromEA(self, area_cone_size='04'):
         '''Calculate relative isolation using the effective area approach, 
         for backward compatibility, should be removed. 
         '''
-        return self.relIso(0.4, 'EA', area=area)
+        return self.relIso(0.4, 'EA', area_cone_size=area_cone_size)
     
     def absIsoR(self, R=0.4, dbeta_factor=0, all_charged=False):
         '''Calculate absolute isolation in given cone 

--- a/PhysicsTools/Heppy/python/physicsobjects/Muon.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Muon.py
@@ -146,21 +146,21 @@ class Muon( Lepton ):
         '''
         Calculate Isolation, subtract FSR, apply specific PU corrections" 
         '''
-        photonIso = self.photonIsoR(R)
+        photonIso = self.photonIso(R)
         if hasattr(self,'fsrPhotons'):
             for gamma in self.fsrPhotons:
                 dr = deltaR(gamma.eta(), gamma.phi(), self.physObj.eta(), self.physObj.phi())
                 if dr > 0.01 and dr < R:
                     photonIso = max(photonIso-gamma.pt(),0.0)                
         if puCorr == "deltaBeta":
-            offset = dBetaFactor * self.puChargedHadronIsoR(R)
+            offset = dBetaFactor * self.puChargedHadronIso(R)
         elif puCorr == "rhoArea":
             offset = self.rho*getattr(self,"EffectiveArea"+(str(R).replace(".","")))
         elif puCorr in ["none","None",None]:
             offset = 0
         else:
              raise RuntimeError("Unsupported PU correction scheme %s" % puCorr)
-        return self.chargedHadronIsoR(R)+max(0.,photonIso+self.neutralHadronIsoR(R)-offset)            
+        return self.chargedHadronIso(R)+max(0.,photonIso+self.neutralHadronIso(R)-offset)            
 
     def ptErr(self):
         if "_ptErr" in self.__dict__: return self.__dict__['_ptErr']

--- a/PhysicsTools/Heppy/python/physicsobjects/Muon.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Muon.py
@@ -116,30 +116,27 @@ class Muon( Lepton ):
         '''returns the uncertainty on dxz (from gsf track)'''
         return getattr(self,self._trackForDxyDz)().dzError()
 
-    def chargedHadronIsoR(self,R=0.4):
+    def chargedHadronIso(self,R=0.4):
         if   R == 0.3: return self.physObj.pfIsolationR03().sumChargedHadronPt 
         elif R == 0.4: return self.physObj.pfIsolationR04().sumChargedHadronPt 
         raise RuntimeError("Muon chargedHadronIso missing for R=%s" % R)
 
-    def neutralHadronIsoR(self,R=0.4):
+    def neutralHadronIso(self,R=0.4):
         if   R == 0.3: return self.physObj.pfIsolationR03().sumNeutralHadronEt 
         elif R == 0.4: return self.physObj.pfIsolationR04().sumNeutralHadronEt 
         raise RuntimeError("Muon neutralHadronIso missing for R=%s" % R)
 
-    def photonIsoR(self,R=0.4):
+    def photonIso(self,R=0.4):
         if   R == 0.3: return self.physObj.pfIsolationR03().sumPhotonEt 
         elif R == 0.4: return self.physObj.pfIsolationR04().sumPhotonEt 
         raise RuntimeError("Muon photonIso missing for R=%s" % R)
 
-    def chargedAllIsoR(self,R=0.4):
+    def chargedAllIso(self,R=0.4):
         if   R == 0.3: return self.physObj.pfIsolationR03().sumChargedParticlePt 
         elif R == 0.4: return self.physObj.pfIsolationR04().sumChargedParticlePt 
         raise RuntimeError("Muon chargedAllIso missing for R=%s" % R)
 
-    def chargedAllIso(self):
-        return self.chargedAllIsoR()
-
-    def puChargedHadronIsoR(self,R=0.4):
+    def puChargedHadronIso(self,R=0.4):
         if   R == 0.3: return self.physObj.pfIsolationR03().sumPUPt 
         elif R == 0.4: return self.physObj.pfIsolationR04().sumPUPt 
         raise RuntimeError("Muon chargedHadronIso missing for R=%s" % R)

--- a/PhysicsTools/Heppy/python/physicsobjects/Tau.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Tau.py
@@ -17,10 +17,6 @@ class Tau(Lepton):
         '''Just making the tau behave as a lepton, with dummy parameters.'''
         return -1
 
-    def relIsoR(self, R=0.3, dBetaFactor=0, allCharged=0):
-        '''Just making the tau behave as a lepton, with dummy parameters.'''
-        return -1
-
     def mvaId(self):
         '''For a transparent treatment of electrons, muons and taus. Returns -99'''
         return -99

--- a/PhysicsTools/Heppy/python/physicsutils/EffectiveAreas.py
+++ b/PhysicsTools/Heppy/python/physicsutils/EffectiveAreas.py
@@ -6,6 +6,7 @@
 # else proceed to next pair
 # eta should be either the eta of the supercluster or the eta of the electron,
 # which is specified below
+scaling_03_04 = 16./9.
 
 areas = dict(
     Data2012 = {
@@ -84,8 +85,6 @@ areas = dict(
                        'eta' : lambda x: x.superCluster().eta()
                        }
         },
-
-    scaling_03_04 = 16./9.
     Fall17 = {
         # https://github.com/cms-sw/cmssw/blob/CMSSW_9_4_X/RecoEgamma/ElectronIdentification/data/Fall17/effAreaElectrons_cone03_pfNeuHadronsAndPhotons_92X.txt
         'electron' : { '03' : 
@@ -103,7 +102,7 @@ areas = dict(
                          (2.200, 0.0854 * scaling_03_04),
                          (2.300, 0.1051 * scaling_03_04),
                          (2.400, 0.1204 * scaling_03_04),
-                         (2.500, 0.1524 * scaling_03_04) ]
+                         (2.500, 0.1524 * scaling_03_04) ],
                        'eta' : lambda x: x.superCluster().eta()
                        }
         },

--- a/PhysicsTools/Heppy/python/physicsutils/EffectiveAreas.py
+++ b/PhysicsTools/Heppy/python/physicsutils/EffectiveAreas.py
@@ -9,6 +9,8 @@
 
 areas = dict(
     Data2012 = {
+        # the value corresponding to the electron key is called an 
+        # "area table" in what follows
         'electron' : { '03' : 
                        [ (1.000, 0.13),
                          (1.479, 0.14),
@@ -83,16 +85,25 @@ areas = dict(
                        }
         },
 
-    
+    scaling_03_04 = 16./9.
     Fall17 = {
+        # https://github.com/cms-sw/cmssw/blob/CMSSW_9_4_X/RecoEgamma/ElectronIdentification/data/Fall17/effAreaElectrons_cone03_pfNeuHadronsAndPhotons_92X.txt
         'electron' : { '03' : 
-                       [ (1.000, 0.1440),
-                         (1.479, 0.1562),
-                         (2.000, 0.1032),
-                         (2.200, 0.0859),
-                         (2.300, 0.1116),
-                         (2.400, 0.1321),
-                         (2.500, 0.1654) ],
+                       [ (1.000, 0.1566),
+                         (1.479, 0.1626),
+                         (2.000, 0.1073),
+                         (2.200, 0.0854),
+                         (2.300, 0.1051),
+                         (2.400, 0.1204),
+                         (2.500, 0.1524) ],
+                       '04' :  # warning: EAs not computed for cone DR=0.4, use the values for DR=0.3 scaled by 16/9 instead
+                       [ (1.000, 0.1566 * scaling_03_04),
+                         (1.479, 0.1626 * scaling_03_04),
+                         (2.000, 0.1073 * scaling_03_04),
+                         (2.200, 0.0854 * scaling_03_04),
+                         (2.300, 0.1051 * scaling_03_04),
+                         (2.400, 0.1204 * scaling_03_04),
+                         (2.500, 0.1524 * scaling_03_04) ]
                        'eta' : lambda x: x.superCluster().eta()
                        }
         },
@@ -127,3 +138,18 @@ def effective_area(lepton, cone_size, table):
         if eta < etamax: 
             return ea
     return table[cone_size][-1][1] # out of range, take last value
+
+def is_ea_table(candidate): 
+    '''return True if candidate is an area table'''
+    if not hasattr(candidate, '__iter__'):
+        return False
+    if not 'eta' in candidate: 
+        return False
+    for key, val in candidate.iteritems():
+        if key == 'eta': 
+            continue
+        else: 
+            for ea in val:
+                if len(ea) != 2: 
+                    return False
+    return True

--- a/PhysicsTools/Heppy/python/physicsutils/EffectiveAreas.py
+++ b/PhysicsTools/Heppy/python/physicsutils/EffectiveAreas.py
@@ -1,0 +1,129 @@
+### effective area tables and tools
+
+# Tables --------------------------------------
+# in the form (etamax, value)
+# if eta < etamax, apply this value
+# else proceed to next pair
+# eta should be either the eta of the supercluster or the eta of the electron,
+# which is specified below
+
+areas = dict(
+    Data2012 = {
+        'electron' : { '03' : 
+                       [ (1.000, 0.13),
+                         (1.479, 0.14),
+                         (2.000, 0.07),
+                         (2.200, 0.09),
+                         (2.300, 0.11),
+                         (2.400, 0.11),
+                         (2.500, 0.14) ],
+                       '04' : 
+                       [ (1.000, 0.208),
+                         (1.479, 0.209),
+                         (2.000, 0.115),
+                         (2.200, 0.143),
+                         (2.300, 0.183),
+                         (2.400, 0.194),
+                         (2.500, 0.261) ],
+                       'eta' : lambda x: x.superCluster().eta()
+                       }
+        },
+
+    Phys14_25ns_v1 = { 
+        'electron' : { '03' : 
+                       [ (0.800, 0.1013),
+                         (1.300, 0.0988),
+                         (2.000, 0.0572),
+                         (2.200, 0.0842), 
+                         (2.500, 0.1530) ],
+                       '04' : 
+                       [ (0.800, 0.1830),
+                         (1.300, 0.1734),
+                         (2.000, 0.1077),
+                         (2.200, 0.1565),
+                         (2.500, 0.2680) ],
+                       'eta' : lambda x : x.eta()
+                       }
+        },
+
+    Spring15_50ns_v1 = { 
+        'electron' : { '03' :
+                           [ (0.800, 0.0973),
+                             (1.300, 0.0954),
+                             (2.000, 0.0632),
+                             (2.200, 0.0727),
+                             (2.500, 0.1337) ],
+                       'eta' : lambda x: x.superCluster().eta()
+                       }
+        },
+
+    Spring15_25ns_v1 = {
+        'electron' : { '03' : 
+                       [ (1.000, 0.1752),
+                         (1.479, 0.1862),
+                         (2.000, 0.1411),
+                         (2.200, 0.1534),
+                         (2.300, 0.1903),
+                         (2.400, 0.2243),
+                         (2.500, 0.2687) ],
+                       'eta' : lambda x: x.superCluster().eta()
+                       }
+        },
+
+    Spring16_25ns_v1 = {
+        'electron' : { '03' :
+                           [ (1.000, 0.1703),
+                             (1.479, 0.1715),
+                             (2.000, 0.1213),
+                             (2.200, 0.1230),
+                             (2.300, 0.1635),
+                             (2.400, 0.1937),
+                             (2.500, 0.2393) ],
+                       'eta' : lambda x: x.superCluster().eta()
+                       }
+        },
+
+    
+    Fall17 = {
+        'electron' : { '03' : 
+                       [ (1.000, 0.1440),
+                         (1.479, 0.1562),
+                         (2.000, 0.1032),
+                         (2.200, 0.0859),
+                         (2.300, 0.1116),
+                         (2.400, 0.1321),
+                         (2.500, 0.1654) ],
+                       'eta' : lambda x: x.superCluster().eta()
+                       }
+        },
+    )
+
+
+def effective_area_table(lepton, era):
+    '''return effective area descriptor
+    lepton = 'electron' or 'muon',
+    era = see EffectiveAreas.py.
+    '''
+    leptype = None
+    if abs(lepton.pdgid())==11:
+        leptype = 'electron'
+    elif abs(lepton.pdgid())==13:
+        leptype = 'muon'
+    else:
+        raise ValueError( 
+            'no effective areas for lepton with pdgid {}'.format(lepton.pdgid())
+            )
+    return areas[era][leptype]
+
+
+def effective_area(lepton, cone_size, table):
+    '''return effective area value.
+    lepton: the lepton physics object, an electron or a muon;
+    cone_size: e.g. '03' for a cone size of 0.3; 
+    table: use the effective_area_table function to get it.'''
+    eta_func = table['eta']
+    eta = abs(eta_func(lepton))
+    for etamax, ea in table[cone_size]:
+        if eta < etamax: 
+            return ea
+    return table[cone_size][-1][1] # out of range, take last value

--- a/PhysicsTools/Heppy/python/physicsutils/test_EffectiveAreas.py
+++ b/PhysicsTools/Heppy/python/physicsutils/test_EffectiveAreas.py
@@ -1,0 +1,71 @@
+import unittest
+import pprint 
+
+from EffectiveAreas import * 
+
+class FakeSuperCluster(object): 
+    def __init__(self, eta):
+        self._eta = eta
+    def eta(self):
+        return self._eta
+
+class FakeLepton(object):
+    def __init__(self, pdgid, eta, sceta=None):
+        self._pdgid = pdgid
+        self._eta = eta
+        if sceta: 
+            self._sc = FakeSuperCluster(sceta)
+    def eta(self):
+        return self._eta
+    def pdgid(self):
+        return self._pdgid
+    def superCluster(self):
+        return self._sc  
+
+class TestEffectiveAreas(unittest.TestCase):
+
+    def test_1_fall17(self):
+        '''test access to fall 17 eas'''
+        ele = FakeLepton(11, 0.9, 1.1)
+        ea_table = effective_area_table(ele, 'Fall17')
+        ea = effective_area(ele, '03', ea_table)
+        self.assertEqual(ea, 0.1562)
+        # test out of range: 
+        ele = FakeLepton(11, 99, 99)
+        ea = effective_area(ele, '03', ea_table)
+        self.assertEqual(ea, 0.1654)
+        # test negative eta
+        ele = FakeLepton(11, -0.9, -1.1)
+        ea = effective_area(ele, '03', ea_table)
+        self.assertEqual(ea, 0.1562)
+
+    def test_2_Phys14_25ns_v1(self):
+        '''test access to Phys14_25ns_v1 
+        (ele.eta() instead of supercluster eta)
+        '''
+        ele = FakeLepton(11, 0.81, 0.79)
+        ea_table = effective_area_table(ele, 'Phys14_25ns_v1')
+        ea = effective_area(ele, '03', ea_table)
+        self.assertEqual(ea, 0.0988)
+
+    def test_table_integrity(self):
+        for era, value in areas.iteritems(): 
+            for leptype, table in value.iteritems(): 
+                # check lepton type
+                self.assertIn(leptype, ['electron','muon'])
+                # check presence of eta function
+                self.assertIn('eta', table) 
+                self.assertTrue( hasattr(table['eta'], '__call__'))
+                del table['eta']
+                # now only the tables for each cone size are left
+                for cone, eas in table.iteritems():
+                    cone_size = int(cone)
+                    for ea in eas: 
+                        self.assertTrue(len(ea)==2)
+                    
+        
+        
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/PhysicsTools/Heppy/python/physicsutils/test_EffectiveAreas.py
+++ b/PhysicsTools/Heppy/python/physicsutils/test_EffectiveAreas.py
@@ -26,18 +26,20 @@ class TestEffectiveAreas(unittest.TestCase):
 
     def test_1_fall17(self):
         '''test access to fall 17 eas'''
+        scd_value = 0.1626
+        last_value = 0.1524
         ele = FakeLepton(11, 0.9, 1.1)
         ea_table = effective_area_table(ele, 'Fall17')
         ea = effective_area(ele, '03', ea_table)
-        self.assertEqual(ea, 0.1562)
+        self.assertEqual(ea, scd_value)
         # test out of range: 
         ele = FakeLepton(11, 99, 99)
         ea = effective_area(ele, '03', ea_table)
-        self.assertEqual(ea, 0.1654)
+        self.assertEqual(ea, last_value)
         # test negative eta
         ele = FakeLepton(11, -0.9, -1.1)
         ea = effective_area(ele, '03', ea_table)
-        self.assertEqual(ea, 0.1562)
+        self.assertEqual(ea, scd_value)
 
     def test_2_Phys14_25ns_v1(self):
         '''test access to Phys14_25ns_v1 

--- a/PhysicsTools/Heppy/python/physicsutils/test_EffectiveAreas.py
+++ b/PhysicsTools/Heppy/python/physicsutils/test_EffectiveAreas.py
@@ -63,7 +63,9 @@ class TestEffectiveAreas(unittest.TestCase):
                     for ea in eas: 
                         self.assertTrue(len(ea)==2)
                     
-        
+    def test_is_ea_table(self):
+        self.assertTrue( is_ea_table(areas['Fall17']['electron']) ) 
+        self.assertFalse( is_ea_table('03')) 
         
 
 


### PR DESCRIPTION
Hello, in this pull request, I'm taking over from Gael Touquet for PR #738, which can be closed. 

@gpetruc thank you again for your comments. As you requested, the effective areas can now be provided: 
1. to the isolation methods
2. to the lepton object
3. to the lepton class

The effective area is searched for in this order. 
We use solution 3 in our analysis configuration, like this: 

```python
Electron.EffectiveArea03 = areas['Fall17']['electron']
Electron.iso_htt = lambda x: x.relIso(0.3, "EA", 
                                      all_charged=False)
```

There is  a new EffectiveAreas.py module where they are defined in a global dictionary, that can be easily accessed. For now, this dictionary contains the values that are in the LeptonAnalyzer for the electron. 

I didn't want to modify the LeptonAnalyzer at this stage, but if you want, in a second pull request after this one is merged, I can:
- adapt the lepton analyzer to use the EffectiveAreas module, so that effective areas are defined at a single place. 
- add muon effective areas to EffectiveAreas 

In the next PR, I can also remove the obsolete methods in Lepton.py

Testing done: 
- The results of the isolation are synchronized in the context of our analysis. 
- There is a unittest for EffectiveAreas.  
- I performed a systematic check of the Lepton isolation interface using [this analyzer](https://github.com/cbernet/cmgtools-lite/blob/modular/H2TauTau/python/heppy/analyzers/colin/InteractiveDebug.py)

Please let me know if you have any further comments.

@GaelTouquet @lucastorterotot

