### PR TITLE
Enabling  heppy on Fermilab Condor cluster

### DIFF
--- a/PhysicsTools/Heppy/python/physicsobjects/Lepton.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Lepton.py
@@ -129,4 +129,4 @@ class Lepton( PhysicsObject):
 
     def __str__(self):
         ptc = super(Lepton, self).__str__()
-        return '{ptc}, iso={iso:5.2f}'.format(ptc=ptc, iso=self.relIso())
+        return ptc

--- a/PhysicsTools/HeppyCore/python/utils/batchmanager.py
+++ b/PhysicsTools/HeppyCore/python/utils/batchmanager.py
@@ -291,6 +291,7 @@ class BatchManager:
         hostName = os.environ['HOSTNAME']
 
         onLxplus = hostName.startswith('lxplus')
+        onLPC    = hostName.startswith('cmslpc')
         onPSI    = hostName.startswith('t3ui')
         onNAF =  hostName.startswith('naf')
 
@@ -305,12 +306,21 @@ class BatchManager:
                 return 'LXPLUS-LSF'
 
         elif batchCmd == "run_condor.sh":
-            if not onLxplus:
+            if not (onLxplus):
                 err = 'Cannot run %s on %s' % (batchCmd, hostName)
                 raise ValueError( err )
             else:
                 print 'running on CONDOR (using condor file transfer): %s from %s' % (batchCmd, hostName)
                 return 'LXPLUS-CONDOR-TRANSFER'
+
+        elif batchCmd == "run_condor_lpc.sh":
+            if not (onLPC):
+                err = 'Cannot run %s on %s' % (batchCmd, hostName)
+                raise ValueError( err )
+            else:
+                print 'running on CONDOR (using condor file transfer): %s from %s' % (batchCmd, hostName)
+                return 'LXPLUS-CONDOR-TRANSFER'
+
 
         elif batchCmd == "run_condor_simple.sh":
             if not onLxplus:

--- a/PhysicsTools/HeppyCore/scripts/run_condor_lpc.sh
+++ b/PhysicsTools/HeppyCore/scripts/run_condor_lpc.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+if [[ "$1" == "--help" || "$1" == "-h"  || "$1" == "-?" ]]; then
+    echo "usage: $0 [ -f flavour | -t max_runtime_in_minutes ] script.sh "
+    exit 1;
+fi
+
+flavour=""
+if [[ "$1" == "-f" && "$2" != "" ]]; then
+    flavour=$2;
+    shift; shift
+fi
+maxruntime="-t" # time in minutes
+if [[ "$1" == "-t" && "$2" != "" ]]; then
+    if [[ "${flavour}" != "" ]] ; then 
+        echo "Can't set both flavour and maxruntime"; 
+        exit 1; 
+    fi;
+    maxruntime=$(( $2 * 60 ));
+    shift; shift
+fi
+
+updir=$(dirname $(pwd))
+
+scriptName=${1:-./batchScript.sh}
+
+if [ ! -f ${updir}/src.tar.gz ]; then
+    tmp_in_dir=`mktemp -d 2>/dev/null || mktemp -d -t 'tmp'`
+    pushd $CMSSW_BASE
+    tar --exclude=.git -czf ${tmp_in_dir}/src.tar.gz src lib bin python
+    mv ${tmp_in_dir}/src.tar.gz ${updir}
+    rmdir ${tmp_in_dir}
+    popd
+fi
+transfer_input_files=${updir}/src.tar.gz
+
+if [ -d ${HOME}/.cmgdataset ]; then
+    if [ ! -f ${updir}/cmgdataset.tar.gz ]; then
+        pushd $HOME
+        tar -czf ${updir}/cmgdataset.tar.gz .cmgdataset
+        popd
+    fi
+    transfer_input_files=${transfer_input_files},${updir}/cmgdataset.tar.gz
+fi
+
+tar -czf chunk.tar.gz *
+transfer_input_files=${transfer_input_files},chunk.tar.gz
+
+
+cat > ./job_desc.cfg <<EOF
+Universe = vanilla
+Executable = ${scriptName}
+x509userproxy = \$ENV(X509_USER_PROXY)
+Log        = condor_job_\$(ProcId).log
+Output     = condor_job_\$(ProcId).out
+Error      = condor_job_\$(ProcId).error
+should_transfer_files   = YES 
+when_to_transfer_output = ON_EXIT
+transfer_input_files = ${transfer_input_files}
+request_memory = 2000
+EOF
+
+[[ "${flavour}" != "" ]] && echo "+JobFlavour = \"${flavour}\"" >> ./job_desc.cfg
+[[ "${maxruntime}" != "" ]] && echo "+MaxRuntime = ${maxruntime}" >> ./job_desc.cfg
+
+echo "queue 1" >> ./job_desc.cfg
+
+# Submit job
+/usr/bin/condor_submit job_desc.cfg


### PR DESCRIPTION
The FNAL LPC condor has slightly different  setup than the CERN one .
This PR makes possible to run heppy with file transfer at the LPC .
It is fully transparent to everything else.

As I was testing it , the remote version crashed due to a mistake on the Lepton class.
what is interesting is that locally, python does not crash the job for this.
  
The printout was printing relIso() but in the current version relIso needs 2 arguments so I just
removed the printout 

 