### PR TITLE
Fix dr03 tau MVA

### DIFF
--- a/PhysicsTools/Heppy/src/PATTauDiscriminationByMVAIsolationRun2FWlite.cc
+++ b/PhysicsTools/Heppy/src/PATTauDiscriminationByMVAIsolationRun2FWlite.cc
@@ -39,7 +39,7 @@ heppy::PATTauDiscriminationByMVAIsolationRun2FWlite::PATTauDiscriminationByMVAIs
     if (mvaName.find("dR0p3") != std::string::npos) {
         chargedIsoPtSums_ = "chargedIsoPtSumdR03";
         neutralIsoPtSums_ = "neutralIsoPtSumdR03";
-        puCorrPtSums_ = "puCorrPtSumdR03";
+        puCorrPtSums_ = "puCorrPtSum";
         footprintCorrection_ = "footprintCorrectiondR03";
         photonPtSumOutsideSignalCone_ = "photonPtSumOutsideSignalConedR03";
     }


### PR DESCRIPTION
Fix regression from https://github.com/CERN-PH-CMG/cmg-cmssw/pull/737/files#diff-db9724459059ef09a84499d3a628e9d8 :  the `puCorrPtSumdR03` does not exist n 2017 MiniAOD v2., only `puCorrPtSum` is available.

Verified that with this change I get the right MVA output as in NanoAODv4 (`CMSSW_10_2_9`, era `Run2_2017,run2_nanoAOD_94XMiniAODv2`)

@GaelTouquet @steggema @peruzzim 